### PR TITLE
chore: add pre-commit hooks with ruff linting and formatting

### DIFF
--- a/.agents/skills/record-knowledge/SKILL.md
+++ b/.agents/skills/record-knowledge/SKILL.md
@@ -303,5 +303,5 @@ When executing this skill:
 
 ---
 
-**Skill Version:** 1.0.0  
+**Skill Version:** 1.0.0
 **Last Updated:** 2026-03-07

--- a/.github/workflows/ci-precommit.yml
+++ b/.github/workflows/ci-precommit.yml
@@ -1,0 +1,20 @@
+name: pre-commit
+
+on:
+  push:
+    branches-ignore:
+      - 'release/**'
+  pull_request:
+    paths-ignore:
+      - '*.md'
+      - 'docs/**'
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - uses: pre-commit/action@v3.0.0

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -139,7 +139,7 @@ jobs:
           echo "**Version**: ${{ steps.version.outputs.version }}" >> $GITHUB_STEP_SUMMARY
           echo "**Target**: ${{ steps.pypi_target.outputs.target }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          
+
           if [[ "${{ job.status }}" == "success" ]]; then
             echo "### ✅ Publication Successful!" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
@@ -147,13 +147,13 @@ jobs:
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "### 📥 Installation" >> $GITHUB_STEP_SUMMARY
             echo '```bash' >> $GITHUB_STEP_SUMMARY
-            
+
             if [[ "${{ steps.pypi_target.outputs.target }}" == "test" ]]; then
               echo "pip install --index-url https://test.pypi.org/simple/ agentic-beacon" >> $GITHUB_STEP_SUMMARY
             else
               echo "pip install agentic-beacon" >> $GITHUB_STEP_SUMMARY
             fi
-            
+
             echo '```' >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "### 🚀 Quick Start" >> $GITHUB_STEP_SUMMARY
@@ -203,12 +203,12 @@ jobs:
               direction: 'desc',
               per_page: 10
             });
-            
-            const releasePR = prs.data.find(pr => 
-              pr.title.includes('release agentic-beacon') && 
+
+            const releasePR = prs.data.find(pr =>
+              pr.title.includes('release agentic-beacon') &&
               pr.merged_at
             );
-            
+
             if (releasePR) {
               github.rest.issues.createComment({
                 issue_number: releasePR.number,

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,27 @@
+repos:
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v4.5.0
+  hooks:
+  - id: trailing-whitespace
+  - id: check-ast
+  - id: check-json
+  - id: check-merge-conflict
+  - id: check-yaml
+  - id: check-toml
+  - id: check-symlinks
+  - id: detect-aws-credentials
+    args: ["--allow-missing-credentials"]
+  - id: debug-statements
+  - id: end-of-file-fixer
+  - id: mixed-line-ending
+    args: ['--fix=auto']
+
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  rev: v0.9.2
+  hooks:
+    - id: ruff
+      types_or: [ python, pyi ]
+      args: [ --fix, --config=pyproject.toml ]
+    - id: ruff-format
+      types_or: [ python, pyi ]
+      args: [--config=pyproject.toml]

--- a/docs/agentic-warehouse-design.md
+++ b/docs/agentic-warehouse-design.md
@@ -259,7 +259,7 @@ Context is organized into three tiers:
 
 ### Progressive Disclosure Pattern
 
-Context files should be a **pointer system**, not an encyclopedia. 
+Context files should be a **pointer system**, not an encyclopedia.
 
 **In context files:**
 - 1-2 sentence summary of the pattern or rule

--- a/docs/boot-context-design/agents-md-architecture.md
+++ b/docs/boot-context-design/agents-md-architecture.md
@@ -56,12 +56,12 @@ AGENTS.md files serve as **boot context** - the knowledge agents see immediately
   - Git workflow patterns
   - Code review standards
   - Documentation requirements
-  
+
 - **Universal coding patterns**
   - Session handoff patterns
   - Error handling conventions
   - Logging standards
-  
+
 - **Organizational policies**
   - Security requirements
   - Compliance guidelines
@@ -85,7 +85,7 @@ AGENTS.md files serve as **boot context** - the knowledge agents see immediately
   - Import patterns
   - Naming conventions
   - Language idioms and best practices
-  
+
 - **Common language pitfalls**
   - Agent failure modes specific to this language
   - Performance anti-patterns
@@ -108,7 +108,7 @@ AGENTS.md files serve as **boot context** - the knowledge agents see immediately
   - Technology stack standards (e.g., PostgreSQL over SQLite)
   - Architectural patterns (e.g., microservices, event-driven)
   - Infrastructure patterns (e.g., containerization, CI/CD)
-  
+
 - **Tool-specific conventions**
   - Airflow DAG patterns
   - API design standards
@@ -569,9 +569,9 @@ When an agent starts a session, contexts are loaded in this order:
    ├─ global.md (always loaded)
    ├─ language context file (e.g. python.md, if declared in beacon.yaml)
    └─ domain context file (e.g. data-platform.md, if declared in beacon.yaml)
-   
+
 2. User-level preferences (~/.config/opencode/AGENTS.md)
-   
+
 3. Project-level context (<project>/AGENTS.md)
 ```
 

--- a/docs/boot-context-design/project-level-agents-design.md
+++ b/docs/boot-context-design/project-level-agents-design.md
@@ -321,10 +321,10 @@ src/
    ```bash
    # Start PostgreSQL and Redis
    docker-compose up -d postgres redis
-   
+
    # Run migrations
    alembic upgrade head
-   
+
    # Seed test data (optional)
    python scripts/seed_test_data.py
    ```
@@ -522,10 +522,10 @@ def test_get_customer_not_found():
     mock_repo = Mock()
     mock_repo.find_by_id.return_value = None
     service = CustomerService(repository=mock_repo)
-    
+
     # Act
     result = service.get_customer("nonexistent")
-    
+
     # Assert
     assert result.is_err()
     assert result.unwrap_err() == CustomerError.NOT_FOUND
@@ -543,10 +543,10 @@ def test_create_customer(db_session):
     # Arrange
     repo = CustomerRepository(session=db_session)
     customer = Customer(email="test@example.com", name="Test User")
-    
+
     # Act
     created = repo.create(customer)
-    
+
     # Assert
     assert created.id is not None
     found = repo.find_by_id(created.id)
@@ -572,19 +572,19 @@ class Settings(BaseSettings):
     # Database
     database_url: str
     database_pool_size: int = 10
-    
+
     # Redis
     redis_url: str
-    
+
     # External APIs
     salesforce_client_id: str
     salesforce_client_secret: str
     stripe_api_key: str
-    
+
     # Application
     environment: str = "development"
     log_level: str = "INFO"
-    
+
     class Config:
         env_file = ".env"
 
@@ -837,7 +837,7 @@ curl http://localhost:8000/health
 
 **Symptoms:**
 ```
-sqlalchemy.exc.OperationalError: (psycopg2.OperationalError) 
+sqlalchemy.exc.OperationalError: (psycopg2.OperationalError)
 could not connect to server: Connection refused
 ```
 
@@ -852,10 +852,10 @@ could not connect to server: Connection refused
    ```bash
    # Check current value
    echo $DATABASE_URL
-   
+
    # Should be (for local dev):
    # postgresql://cdp:cdp@localhost:5432/cdp
-   
+
    # Fix in .env file
    ```
 
@@ -869,7 +869,7 @@ could not connect to server: Connection refused
    ```bash
    # Find what's using port 5432
    lsof -i :5432
-   
+
    # Kill it or change docker-compose port
    ```
 
@@ -918,7 +918,7 @@ salesforce.exceptions.AuthenticationFailed: 401 Unauthorized
    # Check environment variables
    echo $SALESFORCE_CLIENT_ID
    echo $SALESFORCE_CLIENT_SECRET
-   
+
    # Should match Salesforce Connected App credentials
    ```
 
@@ -975,7 +975,7 @@ curl -X POST http://localhost:8000/webhooks/stripe \
    ```bash
    # Use ngrok to expose local server
    ngrok http 8000
-   
+
    # Configure webhook URL to ngrok URL
    # https://abcd1234.ngrok.io/webhooks/stripe
    ```
@@ -988,7 +988,7 @@ curl -X POST http://localhost:8000/webhooks/stripe \
    ```bash
    # Check webhook secret is correct
    echo $STRIPE_WEBHOOK_SECRET
-   
+
    # Should match Stripe dashboard → Developers → Webhooks → Signing secret
    ```
 
@@ -1217,7 +1217,7 @@ from src.models.event import Event
 
 class CustomerFactory:
     """Factory for creating test customers."""
-    
+
     @staticmethod
     def create(
         email: str = "test@example.com",
@@ -1225,7 +1225,7 @@ class CustomerFactory:
         **kwargs
     ) -> Customer:
         return Customer(email=email, name=name, **kwargs)
-    
+
     @staticmethod
     def create_batch(count: int) -> list[Customer]:
         return [
@@ -1238,7 +1238,7 @@ class CustomerFactory:
 
 class EventFactory:
     """Factory for creating test events."""
-    
+
     @staticmethod
     def create(
         customer_id: str,
@@ -1262,7 +1262,7 @@ def test_customer_segmentation(db_session):
     for customer in customers:
         db_session.add(customer)
     db_session.commit()
-    
+
     # Test segmentation logic
     segment = segment_service.create_segment(criteria={...})
     assert len(segment.customers) > 0
@@ -1283,14 +1283,14 @@ def test_get_customer_not_found():
     # Create mock repository
     mock_repo = Mock()
     mock_repo.find_by_id.return_value = None
-    
+
     # Inject mock into service
     service = CustomerService(repository=mock_repo)
-    
+
     # Test
     result = service.get_customer("nonexistent")
     assert result.is_err()
-    
+
     # Verify mock was called
     mock_repo.find_by_id.assert_called_once_with("nonexistent")
 ```
@@ -1311,15 +1311,15 @@ def test_salesforce_sync(mock_get, db_session):
         ]
     }
     mock_get.return_value.status_code = 200
-    
+
     # Test with mocked external API
     client = SalesforceClient()
     result = client.sync_customers()
-    
+
     # Verify results
     assert len(result) == 1
     assert result[0].email == "test@example.com"
-    
+
     # Verify API was called
     mock_get.assert_called_once()
 ```
@@ -1403,7 +1403,7 @@ pytest -n auto
    ```bash
    # Start test database
    docker-compose -f docker-compose.test.yml up -d
-   
+
    # Run integration tests
    pytest -m integration
    ```
@@ -1412,7 +1412,7 @@ pytest -n auto
    ```bash
    # Deploy to staging
    ./scripts/deploy-staging.sh
-   
+
    # Run E2E tests against staging
    pytest -m e2e --base-url=https://staging.api.yourcompany.com
    ```

--- a/docs/spec-driven-development.md
+++ b/docs/spec-driven-development.md
@@ -2,7 +2,7 @@
 
 A guide for using spec-driven development approaches in agentic engineering.
 
-**Last Updated:** 2026-03-06  
+**Last Updated:** 2026-03-06
 **Status:** Draft / To Be Expanded
 
 ---

--- a/docs/specs-vs-artifacts.md
+++ b/docs/specs-vs-artifacts.md
@@ -93,10 +93,10 @@ my-project/
 artifacts:
   knowledge:
     - backend/api-design-rules.md     # The "How" - rules for APIs
-  
+
   skills:
     - generate-api-client             # The "Tool" - generate client code
-  
+
   contexts:
     - specs/core-auth-api.yaml        # The shared "What" - auth API spec
 ```
@@ -172,11 +172,11 @@ artifacts:
     - backend/api-security-rules.md      # How: Handle sensitive data
     - backend/error-handling-patterns.md # How: Return error responses
     - payments/pci-compliance-rules.md   # How: PCI-DSS requirements
-  
+
   skills:
     - generate-api-tests                  # Tool: Generate test suites
     - security-audit                      # Tool: Check for vulnerabilities
-  
+
   contexts:
     - specs/stripe-api-contract.yaml     # Shared: Stripe integration spec
 ```

--- a/examples/sample-warehouse/contexts/AGENTS.global.md
+++ b/examples/sample-warehouse/contexts/AGENTS.global.md
@@ -1,6 +1,6 @@
 # Global Context
 
-**Organization:** Example Corp  
+**Organization:** Example Corp
 **Last Updated:** [Date]
 
 ---

--- a/examples/sample-warehouse/docs/contribution-guide.md
+++ b/examples/sample-warehouse/docs/contribution-guide.md
@@ -11,8 +11,8 @@
 
 ### 2. Follow Structure
 
-**Contexts:** Brief summary + pointer to knowledge  
-**Knowledge:** Detailed explanation with examples  
+**Contexts:** Brief summary + pointer to knowledge
+**Knowledge:** Detailed explanation with examples
 **Skills:** Step-by-step procedures
 
 ### 3. Test Locally

--- a/guides/beacon-yaml-reference.md
+++ b/guides/beacon-yaml-reference.md
@@ -19,10 +19,10 @@ artifacts:
   knowledge:
     - <pattern-or-path>
     - <pattern-or-path>
-  
+
   skills:
     - <pattern-or-path>
-  
+
   contexts:
     - <pattern-or-path>
 ```

--- a/guides/creating-skills.md
+++ b/guides/creating-skills.md
@@ -89,7 +89,7 @@ See `checklist.md` for a per-line item reference.
 ## Output
 A structured review with three sections:
 - **Blockers** — Must be resolved before merge
-- **Suggestions** — Recommended improvements  
+- **Suggestions** — Recommended improvements
 - **Notes** — Observations, questions, praise
 ```
 

--- a/guides/team-collaboration.md
+++ b/guides/team-collaboration.md
@@ -104,11 +104,11 @@ artifacts:
     - languages/python/pytest/**/*.md
     - best-practices/api-design.md
     - infrastructure/docker-python.md
-  
+
   skills:
     - python/code-review
     - python/generate-unit-tests
-  
+
   contexts:
     - teams/backend/AGENTS.md
     - projects/api-services/standards.md
@@ -134,9 +134,9 @@ artifacts:
   knowledge:
     - languages/python/type-hints.md
     - best-practices/code-review.md
-  
+
   skills: []
-  
+
   contexts:
     - teams/backend/AGENTS.md
 ```
@@ -149,10 +149,10 @@ artifacts:
     - languages/python/pytest/**/*.md
     - best-practices/code-review.md
     - best-practices/tdd-workflow.md
-  
+
   skills:
     - python/generate-unit-tests
-  
+
   contexts:
     - teams/backend/AGENTS.md
 ```
@@ -283,7 +283,7 @@ knowledge:
   - languages/python/pydantic-v2.md
 ```
 
-**Testing:** 
+**Testing:**
 - [ ] Used in at least one project
 - [ ] Team review completed
 - [ ] Examples validated

--- a/guides/troubleshooting.md
+++ b/guides/troubleshooting.md
@@ -189,7 +189,7 @@ cat .agentic-beacon/config.toml
 cd project-a
 abc warehouse connect --path ~/team-warehouse-a
 
-# Project B  
+# Project B
 cd project-b
 abc warehouse connect --path ~/team-warehouse-b
 ```

--- a/knowledge/decisions/follow-global-python-standards.md
+++ b/knowledge/decisions/follow-global-python-standards.md
@@ -1,7 +1,7 @@
 # Decision: Follow Global Python Standards
 
-**Date:** 2026-03-07  
-**Status:** Active  
+**Date:** 2026-03-07
+**Status:** Active
 **Context:** Agentic Beacon Framework
 
 ---

--- a/knowledge/decisions/no-temporary-docs.md
+++ b/knowledge/decisions/no-temporary-docs.md
@@ -1,7 +1,7 @@
 # Decision: No Temporary Documentation in Repository
 
-**Date:** 2026-03-07  
-**Status:** Active  
+**Date:** 2026-03-07
+**Status:** Active
 **Context:** Agentic Beacon Framework
 
 ---

--- a/knowledge/decisions/pydantic-settings-patterns.md
+++ b/knowledge/decisions/pydantic-settings-patterns.md
@@ -1,7 +1,7 @@
 # Decision: Pydantic Settings Patterns for Configuration Management
 
-**Date:** 2026-03-08  
-**Status:** Accepted  
+**Date:** 2026-03-08
+**Status:** Accepted
 **Context:** Configuration management standardization
 
 ## Decision
@@ -26,12 +26,12 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 
 class WarehouseSettings(BaseSettings):
     """Warehouse connection settings from config.toml."""
-    
+
     model_config = SettingsConfigDict(
         toml_file=".agentic-beacon/config.toml",
         extra="ignore",  # Forward compatibility
     )
-    
+
     warehouse: WarehouseConfig
 ```
 
@@ -67,20 +67,20 @@ Use Pydantic BaseModel for nested configuration sections:
 ```python
 class WarehouseConfig(BaseModel):
     """Warehouse configuration section."""
-    
+
     local_path: str = Field(..., description="Absolute path to local warehouse")
-    
+
     @field_validator("local_path")
     @classmethod
     def validate_local_path(cls, v: str) -> str:
         """Validate and normalize path."""
         if not v or not v.strip():
             raise ValueError("local_path cannot be empty")
-        
+
         path = Path(v).expanduser().resolve()
         if not path.is_absolute():
             raise ValueError("local_path must be an absolute path")
-        
+
         return str(path)
 
 class WarehouseSettings(BaseSettings):
@@ -110,19 +110,19 @@ For configurations with non-standard structures (like beacon.yaml with grouped a
 ```python
 class BeaconSettings(BaseModel):
     """Custom structure requiring manual parsing."""
-    
+
     artifacts: ArtifactsConfig
-    
+
     @classmethod
     def from_yaml(cls, path: Path) -> "BeaconSettings":
         """Manual YAML parsing with validation."""
         with open(path) as f:
             data = yaml.safe_load(f)
-        
+
         # Validate structure
         if "artifacts" not in data:
             raise ValidationError("Missing required 'artifacts' section")
-        
+
         # Use Pydantic for validation
         return cls(**data)
 ```

--- a/knowledge/decisions/settings-module-structure.md
+++ b/knowledge/decisions/settings-module-structure.md
@@ -1,7 +1,7 @@
 # Decision: Settings Module Structure and Naming Conventions
 
-**Date:** 2026-03-08  
-**Status:** Accepted  
+**Date:** 2026-03-08
+**Status:** Accepted
 **Context:** Agentic Beacon configuration management structure
 
 ## Decision
@@ -44,13 +44,13 @@ libs/beacon/src/beacon/core/
 class WarehouseSettings(BaseSettings):
     """Warehouse connection settings from config.toml."""
     warehouse: WarehouseConfig
-    
+
     @classmethod
     def from_path(cls, local_path: str) -> "WarehouseSettings":
         """Create settings from path and write to file."""
         # Validates, writes TOML, then loads via BaseSettings
         ...
-    
+
     def to_toml(self, path: Path) -> None:
         """Write settings to TOML file."""
         ...
@@ -58,12 +58,12 @@ class WarehouseSettings(BaseSettings):
 class BeaconSettings(BaseModel):
     """Beacon artifact dependencies from beacon.yaml."""
     artifacts: ArtifactsConfig
-    
+
     @classmethod
     def from_yaml(cls, path: Path) -> "BeaconSettings":
         """Load settings from YAML file."""
         ...
-    
+
     def to_yaml(self, path: Path) -> None:
         """Write settings to YAML file."""
         ...

--- a/knowledge/facts/release-workflow.md
+++ b/knowledge/facts/release-workflow.md
@@ -1,6 +1,6 @@
 # Fact: Release Workflow
 
-**Last Updated:** 2026-03-07  
+**Last Updated:** 2026-03-07
 **Context:** Agentic Beacon Framework
 
 ---

--- a/knowledge/facts/repository-structure.md
+++ b/knowledge/facts/repository-structure.md
@@ -1,6 +1,6 @@
 # Fact: Repository Structure
 
-**Last Updated:** 2026-03-07  
+**Last Updated:** 2026-03-07
 **Context:** Agentic Beacon Framework
 
 ---

--- a/knowledge/lessons/adding-cli-command.md
+++ b/knowledge/lessons/adding-cli-command.md
@@ -1,6 +1,6 @@
 # Lesson: Adding a New CLI Command
 
-**Last Updated:** 2026-03-07  
+**Last Updated:** 2026-03-07
 **Context:** Agentic Beacon Framework
 
 ---

--- a/knowledge/lessons/complete-test-resolution.md
+++ b/knowledge/lessons/complete-test-resolution.md
@@ -46,7 +46,7 @@ When implementing tasks with TDD test cases, there's a temptation to mark tasks 
    - Leave audit trail in git commit message
 
    **Path C: Skip with justification**
-   - Use `@pytest.mark.skip(reason="...")` 
+   - Use `@pytest.mark.skip(reason="...")`
    - Document in tasks.md:
      ```markdown
      - [x] Task 1.X Description

--- a/knowledge/lessons/critical-safeguards.md
+++ b/knowledge/lessons/critical-safeguards.md
@@ -1,6 +1,6 @@
 # Lesson: Critical Project Safeguards
 
-**Last Updated:** 2026-03-07  
+**Last Updated:** 2026-03-07
 **Context:** Agentic Beacon Framework
 
 ---

--- a/knowledge/lessons/updating-warehouse-structure.md
+++ b/knowledge/lessons/updating-warehouse-structure.md
@@ -1,6 +1,6 @@
 # Lesson: Updating Warehouse Structure
 
-**Last Updated:** 2026-03-07  
+**Last Updated:** 2026-03-07
 **Context:** Agentic Beacon Framework
 
 ---
@@ -36,11 +36,11 @@ If `abc init` output changes, follow this systematic update process:
    ```bash
    # Test init
    abc init test-warehouse --org "Test" --languages python
-   
+
    # Test setup
    cd test-project
    abc setup --warehouse test-warehouse --all
-   
+
    # Verify structure is correct
    ls -la .opencode/
    ```

--- a/libs/beacon/PRIVATE_DEPLOYMENT.md
+++ b/libs/beacon/PRIVATE_DEPLOYMENT.md
@@ -180,10 +180,10 @@ After testing in homelab:
 
 ## Configuration Summary
 
-**Package Name:** `beacon`  
-**Version:** `0.1.0`  
-**Python Required:** `>=3.12`  
-**License:** MIT  
+**Package Name:** `beacon`
+**Version:** `0.1.0`
+**Python Required:** `>=3.12`
+**License:** MIT
 **Repository:** https://github.com/Shadowsong27/agentic-engineering-warehouse-template
 
 **Installation:**

--- a/libs/beacon/QUICKSTART.md
+++ b/libs/beacon/QUICKSTART.md
@@ -174,6 +174,6 @@ abc delta --help
 
 ---
 
-**For deployment guide, see:** [HOMELAB_PUBLISH.md](./HOMELAB_PUBLISH.md)  
-**For complete docs, see:** [README.md](./README.md)  
+**For deployment guide, see:** [HOMELAB_PUBLISH.md](./HOMELAB_PUBLISH.md)
+**For complete docs, see:** [README.md](./README.md)
 **For project status, see:** [PROJECT_COMPLETE.md](./PROJECT_COMPLETE.md)

--- a/libs/beacon/README.md
+++ b/libs/beacon/README.md
@@ -306,7 +306,7 @@ agentic status
 
 # Output:
 # Installation: /Users/you/my-project/.opencode
-# 
+#
 # Installed Contexts
 # ┌─────────┐
 # │ Context │

--- a/libs/beacon/src/beacon/cli.py
+++ b/libs/beacon/src/beacon/cli.py
@@ -2,17 +2,16 @@
 
 import sys
 from pathlib import Path
-from typing import List, Optional
 
 import click
 from loguru import logger
 from rich.console import Console
 from rich.table import Table
 
-from .core.settings import WarehouseSettings, BeaconSettings, validate_beacon_directory
-from .core.sync import SyncEngine
 from .core.delta import DeltaComparator, DeltaStatus
 from .core.gitignore import GitignoreManager
+from .core.settings import BeaconSettings, WarehouseSettings
+from .core.sync import SyncEngine
 from .distributor import WarehouseDistributor
 from .initializer import WarehouseInitializer
 from .warehouse import WarehouseValidator
@@ -20,7 +19,7 @@ from .warehouse import WarehouseValidator
 console = Console()
 
 
-def find_warehouse_root() -> Optional[Path]:
+def find_warehouse_root() -> Path | None:
     """
     Find warehouse root by looking for warehouse markers.
 
@@ -117,10 +116,10 @@ def warehouse() -> None:
 def init(
     *,
     name: str,
-    path: Optional[Path],
-    org: Optional[str],
-    languages: Optional[str],
-    domains: Optional[str],
+    path: Path | None,
+    org: str | None,
+    languages: str | None,
+    domains: str | None,
     no_git: bool,
     no_interactive: bool,
 ) -> None:
@@ -168,8 +167,12 @@ def init(
 
     # Set defaults
     org = org or "Your Organization"
-    languages_list = [lang.strip() for lang in (languages or "").split(",") if lang.strip()]
-    domains_list = [domain.strip() for domain in (domains or "").split(",") if domain.strip()]
+    languages_list = [
+        lang.strip() for lang in (languages or "").split(",") if lang.strip()
+    ]
+    domains_list = [
+        domain.strip() for domain in (domains or "").split(",") if domain.strip()
+    ]
 
     # Create initializer and init warehouse
     try:
@@ -182,7 +185,9 @@ def init(
         )
 
         # Display results
-        console.print("\n[bold green]✓ Warehouse initialized successfully![/bold green]\n")
+        console.print(
+            "\n[bold green]✓ Warehouse initialized successfully![/bold green]\n"
+        )
         console.print(f"  [blue]Location:[/blue] {result['warehouse_path']}")
         console.print(f"  [blue]Organization:[/blue] {org}")
 
@@ -192,7 +197,7 @@ def init(
         if domains_list:
             console.print(f"  [blue]Domains:[/blue] {', '.join(domains_list)}")
 
-        if result['git_initialized']:
+        if result["git_initialized"]:
             console.print("  [blue]Git:[/blue] Initialized with initial commit")
 
         # Next steps
@@ -217,7 +222,7 @@ def init(
     type=click.Path(path_type=Path),
     help="Path to local warehouse directory",
 )
-def connect(*, path: Optional[Path]) -> None:
+def connect(*, path: Path | None) -> None:
     """
     Connect project to a local warehouse.
 
@@ -262,7 +267,9 @@ def connect(*, path: Optional[Path]) -> None:
         console.print("\n[red bold]✗ Invalid warehouse structure[/red bold]\n")
         for error in validation_result.errors:
             console.print(f"  [red]✗[/red] {error}")
-        console.print("\n[dim]See examples/sample-warehouse for a valid warehouse structure[/dim]")
+        console.print(
+            "\n[dim]See examples/sample-warehouse for a valid warehouse structure[/dim]"
+        )
         sys.exit(1)
 
     console.print("[green]✓[/green] Warehouse structure validated")
@@ -273,7 +280,7 @@ def connect(*, path: Optional[Path]) -> None:
 
     # Save connection configuration
     try:
-        settings = WarehouseSettings.from_path(warehouse_path)
+        WarehouseSettings.from_path(warehouse_path)
         console.print("[green]✓[/green] Connection saved")
 
         # Update .gitignore
@@ -282,7 +289,7 @@ def connect(*, path: Optional[Path]) -> None:
             console.print("[green]✓[/green] Updated .gitignore")
 
         # Success message
-        console.print(f"\n[bold green]✓ Connected to warehouse[/bold green]")
+        console.print("\n[bold green]✓ Connected to warehouse[/bold green]")
         console.print(f"  [blue]Location:[/blue] {warehouse_path}")
 
         # Next steps
@@ -323,7 +330,9 @@ def setup(*, manual: bool, agent_assisted: bool) -> None:
     """
     # Validate mutually exclusive flags
     if manual and agent_assisted:
-        console.print("[red]Error:[/red] --manual and --agent-assisted are mutually exclusive")
+        console.print(
+            "[red]Error:[/red] --manual and --agent-assisted are mutually exclusive"
+        )
         sys.exit(1)
 
     # Check for .agentic-beacon directory
@@ -358,9 +367,15 @@ def setup(*, manual: bool, agent_assisted: bool) -> None:
     else:
         # Interactive mode
         console.print("\n[bold]Setup Project Configuration[/bold]")
-        console.print("[dim]Choose how to configure artifacts for this project:[/dim]\n")
-        console.print("  1. [cyan]Agent-assisted[/cyan] - Install project-setup skill for AI agent")
-        console.print("  2. [green]Manual[/green] - Create empty template to edit yourself")
+        console.print(
+            "[dim]Choose how to configure artifacts for this project:[/dim]\n"
+        )
+        console.print(
+            "  1. [cyan]Agent-assisted[/cyan] - Install project-setup skill for AI agent"
+        )
+        console.print(
+            "  2. [green]Manual[/green] - Create empty template to edit yourself"
+        )
         console.print("  3. [yellow]Skip[/yellow] - Configure later\n")
 
         choice = click.prompt(
@@ -442,7 +457,9 @@ def _install_project_setup_skill(beacon_dir: Path) -> None:
         warehouse_path = Path(settings.warehouse.local_path)
 
         if not warehouse_path.exists():
-            console.print("[yellow]Warning:[/yellow] Warehouse path not found, skipping catalog generation")
+            console.print(
+                "[yellow]Warning:[/yellow] Warehouse path not found, skipping catalog generation"
+            )
             return
 
         # Generate warehouse catalog
@@ -484,7 +501,9 @@ def _generate_warehouse_catalog(warehouse_path: Path) -> str:
 
         lines.append(f"## {section_name}")
         lines.append("")
-        lines.append(f"Paths are relative to warehouse root. Use in beacon.yaml under `artifacts.{section_dir}`.")
+        lines.append(
+            f"Paths are relative to warehouse root. Use in beacon.yaml under `artifacts.{section_dir}`."
+        )
         lines.append("")
 
         # Scan for files
@@ -507,25 +526,27 @@ def _generate_warehouse_catalog(warehouse_path: Path) -> str:
 
         lines.append("")
 
-    lines.extend([
-        "## Usage",
-        "",
-        "Add paths to your `.agentic-beacon/beacon.yaml` file:",
-        "",
-        "```yaml",
-        "artifacts:",
-        "  knowledge:",
-        "    - knowledge/languages/python/**/*.md  # Glob pattern",
-        "    - knowledge/infrastructure/docker-standards.md  # Specific file",
-        "  skills:",
-        "    - skills/code-review/SKILL.md",
-        "  contexts:",
-        "    - contexts/AGENTS.md",
-        "```",
-        "",
-        "Then run `abc sync` to download the artifacts.",
-        "",
-    ])
+    lines.extend(
+        [
+            "## Usage",
+            "",
+            "Add paths to your `.agentic-beacon/beacon.yaml` file:",
+            "",
+            "```yaml",
+            "artifacts:",
+            "  knowledge:",
+            "    - knowledge/languages/python/**/*.md  # Glob pattern",
+            "    - knowledge/infrastructure/docker-standards.md  # Specific file",
+            "  skills:",
+            "    - skills/code-review/SKILL.md",
+            "  contexts:",
+            "    - contexts/AGENTS.md",
+            "```",
+            "",
+            "Then run `abc sync` to download the artifacts.",
+            "",
+        ]
+    )
 
     return "\n".join(lines)
 
@@ -555,7 +576,9 @@ def _extract_description(file_path: Path) -> str:
 @main.command()
 @click.option("--preserve", is_flag=True, help="Skip files with local modifications")
 @click.option("--prune", is_flag=True, help="Remove artifacts no longer in beacon.yaml")
-@click.option("--verbose", "verbose_flag", is_flag=True, help="Show detailed sync output")
+@click.option(
+    "--verbose", "verbose_flag", is_flag=True, help="Show detailed sync output"
+)
 def sync(*, preserve: bool, prune: bool, verbose_flag: bool) -> None:
     """
     Sync artifacts from warehouse to project.
@@ -597,9 +620,13 @@ def sync(*, preserve: bool, prune: bool, verbose_flag: bool) -> None:
 
         # Validate warehouse still exists
         if not warehouse_path.exists():
-            console.print(f"[red]Error:[/red] Warehouse path no longer exists: {warehouse_path}")
+            console.print(
+                f"[red]Error:[/red] Warehouse path no longer exists: {warehouse_path}"
+            )
             console.print("The warehouse may have been moved or deleted.")
-            console.print("Run 'abc warehouse connect --path <warehouse>' to reconnect.")
+            console.print(
+                "Run 'abc warehouse connect --path <warehouse>' to reconnect."
+            )
             sys.exit(1)
 
         # Load beacon.yaml
@@ -607,13 +634,15 @@ def sync(*, preserve: bool, prune: bool, verbose_flag: bool) -> None:
 
         # Check if there are any artifacts to sync
         total_artifacts = (
-            len(beacon_settings.artifacts.knowledge) +
-            len(beacon_settings.artifacts.skills) +
-            len(beacon_settings.artifacts.contexts)
+            len(beacon_settings.artifacts.knowledge)
+            + len(beacon_settings.artifacts.skills)
+            + len(beacon_settings.artifacts.contexts)
         )
 
         if total_artifacts == 0:
-            console.print("[yellow]No artifacts configured in beacon.yaml. Nothing to sync.[/yellow]")
+            console.print(
+                "[yellow]No artifacts configured in beacon.yaml. Nothing to sync.[/yellow]"
+            )
             sys.exit(0)
 
         # Create artifacts directory
@@ -622,8 +651,7 @@ def sync(*, preserve: bool, prune: bool, verbose_flag: bool) -> None:
 
         # Initialize sync engine
         sync_engine = SyncEngine(
-            warehouse_path=warehouse_path,
-            artifacts_path=artifacts_dir
+            warehouse_path=warehouse_path, artifacts_path=artifacts_dir
         )
 
         # Collect all artifact paths (expanding globs)
@@ -638,12 +666,18 @@ def sync(*, preserve: bool, prune: bool, verbose_flag: bool) -> None:
                     try:
                         matches = sync_engine.expand_glob(pattern)
                         if not matches:
-                            console.print(f"  [yellow]Warning:[/yellow] No files matched pattern: {pattern}")
+                            console.print(
+                                f"  [yellow]Warning:[/yellow] No files matched pattern: {pattern}"
+                            )
                         elif verbose_flag:
-                            console.print(f"  Pattern '{pattern}' matched {len(matches)} files")
+                            console.print(
+                                f"  Pattern '{pattern}' matched {len(matches)} files"
+                            )
                         artifact_paths.extend(matches)
                     except Exception as e:
-                        console.print(f"  [red]Error:[/red] Invalid glob pattern '{pattern}': {e}")
+                        console.print(
+                            f"  [red]Error:[/red] Invalid glob pattern '{pattern}': {e}"
+                        )
                         sys.exit(1)
                 else:
                     artifact_paths.append(pattern)
@@ -665,14 +699,18 @@ def sync(*, preserve: bool, prune: bool, verbose_flag: bool) -> None:
         gitignore_mgr.ensure_entries()
 
         # Display summary
-        console.print(f"\n[bold green]✓ Sync complete[/bold green]")
+        console.print("\n[bold green]✓ Sync complete[/bold green]")
         console.print(f"  [blue]Copied:[/blue] {summary.copied} files")
         console.print(f"  [blue]Unchanged:[/blue] {summary.skipped} files")
         if summary.preserved > 0:
-            console.print(f"  [yellow]Preserved:[/yellow] {summary.preserved} locally modified files")
+            console.print(
+                f"  [yellow]Preserved:[/yellow] {summary.preserved} locally modified files"
+            )
             console.print("  [dim]Use 'abc delta' to review local changes.[/dim]")
         if summary.pruned > 0:
-            console.print(f"  [yellow]Pruned:[/yellow] {summary.pruned} artifacts no longer in beacon.yaml")
+            console.print(
+                f"  [yellow]Pruned:[/yellow] {summary.pruned} artifacts no longer in beacon.yaml"
+            )
         if summary.errors > 0:
             console.print(f"  [red]Errors:[/red] {summary.errors} files")
 
@@ -685,7 +723,7 @@ def sync(*, preserve: bool, prune: bool, verbose_flag: bool) -> None:
 @main.command()
 @click.argument("file", required=False, type=str)
 @click.option("--no-color", is_flag=True, help="Disable color output in diffs")
-def delta(*, file: Optional[str], no_color: bool) -> None:
+def delta(*, file: str | None, no_color: bool) -> None:
     """
     Compare local artifacts against warehouse.
 
@@ -723,8 +761,12 @@ def delta(*, file: Optional[str], no_color: bool) -> None:
         warehouse_path = Path(warehouse_settings.warehouse.local_path)
 
         if not warehouse_path.exists():
-            console.print(f"[red]Error:[/red] Warehouse path no longer exists: {warehouse_path}")
-            console.print("Run 'abc warehouse connect --path <warehouse>' to reconnect.")
+            console.print(
+                f"[red]Error:[/red] Warehouse path no longer exists: {warehouse_path}"
+            )
+            console.print(
+                "Run 'abc warehouse connect --path <warehouse>' to reconnect."
+            )
             sys.exit(1)
 
         artifacts_dir = beacon_dir / "artifacts"
@@ -748,12 +790,16 @@ def delta(*, file: Optional[str], no_color: bool) -> None:
         sys.exit(1)
 
 
-def _show_delta_summary(comparator: DeltaComparator, beacon_settings: BeaconSettings) -> None:
+def _show_delta_summary(
+    comparator: DeltaComparator, beacon_settings: BeaconSettings
+) -> None:
     """Show summary of all artifact differences."""
     summary = comparator.compare_from_config(beacon_settings)
 
     if not summary.has_differences:
-        console.print("[green]No differences found. Local artifacts match warehouse.[/green]")
+        console.print(
+            "[green]No differences found. Local artifacts match warehouse.[/green]"
+        )
         return
 
     # Show differences
@@ -768,7 +814,7 @@ def _show_delta_summary(comparator: DeltaComparator, beacon_settings: BeaconSett
             console.print(f"  [red][Missing][/red]  {result.path}")
 
     # Summary counts
-    console.print(f"\n[bold]Summary:[/bold]")
+    console.print("\n[bold]Summary:[/bold]")
     if summary.modified:
         console.print(f"  [yellow]Modified:[/yellow] {len(summary.modified)} files")
     if summary.added:
@@ -780,9 +826,13 @@ def _show_delta_summary(comparator: DeltaComparator, beacon_settings: BeaconSett
 
     # Tips
     if summary.missing:
-        console.print("\n[dim]Tip: Run 'abc sync' to download missing artifacts from warehouse.[/dim]")
+        console.print(
+            "\n[dim]Tip: Run 'abc sync' to download missing artifacts from warehouse.[/dim]"
+        )
     if summary.modified:
-        console.print("[dim]Tip: Run 'abc delta <file>' to see detailed diff for a modified file.[/dim]")
+        console.print(
+            "[dim]Tip: Run 'abc delta <file>' to see detailed diff for a modified file.[/dim]"
+        )
 
 
 def _show_detailed_diff(
@@ -795,7 +845,9 @@ def _show_detailed_diff(
     # Check if file is tracked in beacon.yaml
     all_paths = _collect_artifact_paths(comparator, beacon_settings)
     if file_path not in all_paths:
-        console.print(f"[red]Error:[/red] File '{file_path}' is not tracked in beacon.yaml.")
+        console.print(
+            f"[red]Error:[/red] File '{file_path}' is not tracked in beacon.yaml."
+        )
         console.print("Only artifacts declared in beacon.yaml can be compared.")
         sys.exit(1)
 
@@ -803,16 +855,22 @@ def _show_detailed_diff(
     result = comparator.compare_file(file_path)
 
     if result.status == DeltaStatus.IDENTICAL:
-        console.print(f"[green]No differences found.[/green] Local and warehouse versions of '{file_path}' are identical.")
+        console.print(
+            f"[green]No differences found.[/green] Local and warehouse versions of '{file_path}' are identical."
+        )
         return
 
     if result.status == DeltaStatus.MISSING:
-        console.print(f"[red][Missing][/red] '{file_path}' has not been synced locally.")
+        console.print(
+            f"[red][Missing][/red] '{file_path}' has not been synced locally."
+        )
         console.print("[dim]Run 'abc sync' to download it.[/dim]")
         return
 
     if result.status == DeltaStatus.ADDED:
-        console.print(f"[green][Added][/green] '{file_path}' exists locally but not in warehouse.")
+        console.print(
+            f"[green][Added][/green] '{file_path}' exists locally but not in warehouse."
+        )
         return
 
     # Show detailed diff
@@ -824,7 +882,9 @@ def _show_detailed_diff(
         console.print("[dim]No differences to display.[/dim]")
 
 
-def _collect_artifact_paths(comparator: DeltaComparator, beacon_settings: BeaconSettings) -> set:
+def _collect_artifact_paths(
+    comparator: DeltaComparator, beacon_settings: BeaconSettings
+) -> set:
     """Collect all artifact paths from beacon.yaml, expanding globs."""
     sync_engine = SyncEngine(
         warehouse_path=comparator.warehouse_path,
@@ -847,9 +907,11 @@ def _collect_artifact_paths(comparator: DeltaComparator, beacon_settings: Beacon
 
 @main.command(name="init", hidden=True)
 @click.argument("name", required=False)
-def deprecated_init(name: Optional[str] = None) -> None:
+def deprecated_init(name: str | None = None) -> None:
     """Deprecated: Use 'abc warehouse init' instead."""
-    console.print("[red]Error:[/red] 'abc init' has been moved to 'abc warehouse init'.")
+    console.print(
+        "[red]Error:[/red] 'abc init' has been moved to 'abc warehouse init'."
+    )
     console.print("\n[bold]New command:[/bold]")
     if name:
         console.print(f"  abc warehouse init {name}")
@@ -875,14 +937,14 @@ def update(*, project: Path | None) -> None:
         sys.exit(1)
 
     if not (beacon_dir / "beacon.yaml").exists():
-        console.print(f"[red]Error:[/red] No beacon.yaml found.")
+        console.print("[red]Error:[/red] No beacon.yaml found.")
         console.print("Run 'abc setup' to create artifact configuration.")
         sys.exit(1)
 
-    console.print(f"[blue]Updating artifacts from warehouse...[/blue]")
+    console.print("[blue]Updating artifacts from warehouse...[/blue]")
 
     try:
-        from .core.settings import WarehouseSettings, BeaconSettings
+        from .core.settings import BeaconSettings, WarehouseSettings
         from .core.sync import SyncEngine
 
         warehouse_settings = WarehouseSettings()
@@ -892,7 +954,9 @@ def update(*, project: Path | None) -> None:
         artifacts_dir = beacon_dir / "artifacts"
         artifacts_dir.mkdir(exist_ok=True)
 
-        sync_engine = SyncEngine(warehouse_path=warehouse_path, artifacts_path=artifacts_dir)
+        sync_engine = SyncEngine(
+            warehouse_path=warehouse_path, artifacts_path=artifacts_dir
+        )
 
         artifact_paths: list[str] = []
 
@@ -908,7 +972,9 @@ def update(*, project: Path | None) -> None:
         for skill_name in beacon_settings.artifacts.skills:
             skill_dir = warehouse_path / "skills" / skill_name
             if skill_dir.exists() and skill_dir.is_dir():
-                artifact_paths.extend(sync_engine.expand_glob(f"skills/{skill_name}/**/*"))
+                artifact_paths.extend(
+                    sync_engine.expand_glob(f"skills/{skill_name}/**/*")
+                )
             else:
                 artifact_paths.append(f"skills/{skill_name}")
 
@@ -929,9 +995,11 @@ def update(*, project: Path | None) -> None:
                 error_count += 1
                 console.print(f"  [red]✗[/red] {artifact_path}: {result.error_message}")
 
-        console.print(f"\n[bold green]✓ Update complete![/bold green]")
+        console.print("\n[bold green]✓ Update complete![/bold green]")
         console.print(f"  [blue]Updated:[/blue] {overwritten_count} files")
-        console.print(f"  [blue]New:[/blue] {copied_count - overwritten_count if copied_count > overwritten_count else 0} files")
+        console.print(
+            f"  [blue]New:[/blue] {copied_count - overwritten_count if copied_count > overwritten_count else 0} files"
+        )
         if error_count > 0:
             console.print(f"  [red]Errors:[/red] {error_count} files")
 
@@ -947,7 +1015,7 @@ def update(*, project: Path | None) -> None:
     type=click.Path(exists=True, file_okay=False, path_type=Path),
     help="Path to warehouse repository (auto-detected if not provided)",
 )
-def list_cmd(*, warehouse: Optional[Path]) -> None:
+def list_cmd(*, warehouse: Path | None) -> None:
     """List available warehouse content."""
     warehouse_root = warehouse or find_warehouse_root()
     if not warehouse_root:
@@ -995,7 +1063,7 @@ def list_cmd(*, warehouse: Optional[Path]) -> None:
     help="Path to project root (auto-detected if not provided)",
 )
 @click.confirmation_option(prompt="Are you sure you want to remove synced artifacts?")
-def clean(*, project: Optional[Path]) -> None:
+def clean(*, project: Path | None) -> None:
     """Remove synced artifacts from project (.agentic-beacon/artifacts/)."""
     import shutil
 
@@ -1015,7 +1083,7 @@ def clean(*, project: Optional[Path]) -> None:
     type=click.Path(exists=True, file_okay=False, path_type=Path),
     help="Path to project root (auto-detected if not provided)",
 )
-def status(*, project: Optional[Path]) -> None:
+def status(*, project: Path | None) -> None:
     """Show current warehouse installation status."""
     project_root = project or find_project_root()
     beacon_dir = project_root / ".agentic-beacon"
@@ -1032,19 +1100,23 @@ def status(*, project: Optional[Path]) -> None:
     if config_file.exists():
         try:
             from .core.settings import WarehouseSettings
+
             warehouse_settings = WarehouseSettings()
-            console.print(f"[blue]Warehouse:[/blue] {warehouse_settings.warehouse.local_path}")
+            console.print(
+                f"[blue]Warehouse:[/blue] {warehouse_settings.warehouse.local_path}"
+            )
         except Exception:
             console.print(f"[blue]Config:[/blue] {config_file}")
 
     if not artifacts_dir.exists():
-        console.print(f"\n[yellow]No artifacts synced yet.[/yellow]")
+        console.print("\n[yellow]No artifacts synced yet.[/yellow]")
         console.print("Run 'abc sync' to download artifacts from warehouse.")
         sys.exit(0)
 
     # Show beacon.yaml configuration
     if beacon_yaml.exists():
         from .core.settings import BeaconSettings
+
         beacon_settings = BeaconSettings.from_yaml(beacon_yaml)
 
         if beacon_settings.artifacts.contexts:
@@ -1077,6 +1149,7 @@ def status(*, project: Optional[Path]) -> None:
 
     # Count synced files
     import os
+
     file_count = sum(len(files) for _, _, files in os.walk(str(artifacts_dir)))
     console.print(f"[blue]Artifacts location:[/blue] {artifacts_dir}")
     console.print(f"[blue]Total synced files:[/blue] {file_count}")
@@ -1090,7 +1163,9 @@ def _interactive_select(
         return []
 
     console.print(f"\n[bold]{prompt}[/bold]")
-    console.print("[dim]Enter numbers separated by commas, or 'all' for all options[/dim]")
+    console.print(
+        "[dim]Enter numbers separated by commas, or 'all' for all options[/dim]"
+    )
 
     for i, option in enumerate(options, 1):
         console.print(f"  {i}. {option}")

--- a/libs/beacon/src/beacon/core/delta.py
+++ b/libs/beacon/src/beacon/core/delta.py
@@ -16,14 +16,16 @@ from pydantic import BaseModel
 
 class DeltaStatus(Enum):
     """Status of a compared artifact."""
+
     IDENTICAL = "identical"
     MODIFIED = "modified"
-    ADDED = "added"       # Exists locally but not in warehouse
-    MISSING = "missing"   # In beacon.yaml but not synced locally
+    ADDED = "added"  # Exists locally but not in warehouse
+    MISSING = "missing"  # In beacon.yaml but not synced locally
 
 
 class ComparisonResult(BaseModel):
     """Result of comparing a single artifact."""
+
     path: str
     status: DeltaStatus
     local_hash: str | None = None
@@ -35,6 +37,7 @@ class ComparisonResult(BaseModel):
 @dataclass
 class DeltaSummary:
     """Summary of all artifact comparisons."""
+
     results: list[ComparisonResult] = field(default_factory=list)
 
     @property
@@ -77,10 +80,16 @@ class DeltaComparator:
         """
         self.warehouse_path = Path(self.warehouse_path).resolve()
         self.artifacts_path = Path(self.artifacts_path).resolve()
-        logger.debug("DeltaComparator initialized: warehouse={}, artifacts={}", self.warehouse_path, self.artifacts_path)
+        logger.debug(
+            "DeltaComparator initialized: warehouse={}, artifacts={}",
+            self.warehouse_path,
+            self.artifacts_path,
+        )
 
         if not self.warehouse_path.is_dir():
-            raise ValueError(f"Warehouse path is not a valid directory: {self.warehouse_path}")
+            raise ValueError(
+                f"Warehouse path is not a valid directory: {self.warehouse_path}"
+            )
 
     def compute_hash(self, file_path: Path | str) -> str:
         """Compute SHA256 hash of a file.
@@ -107,7 +116,7 @@ class DeltaComparator:
         actual_path = file_path.resolve()
 
         sha256 = hashlib.sha256()
-        with open(actual_path, 'rb') as f:
+        with open(actual_path, "rb") as f:
             while chunk := f.read(8192):
                 sha256.update(chunk)
         return sha256.hexdigest()
@@ -126,7 +135,12 @@ class DeltaComparator:
 
         local_exists = local_file.is_file()
         warehouse_exists = warehouse_file.is_file()
-        logger.debug("Comparing {}: local_exists={}, warehouse_exists={}", relative_path, local_exists, warehouse_exists)
+        logger.debug(
+            "Comparing {}: local_exists={}, warehouse_exists={}",
+            relative_path,
+            local_exists,
+            warehouse_exists,
+        )
 
         if not local_exists and not warehouse_exists:
             return ComparisonResult(
@@ -278,7 +292,8 @@ class DeltaComparator:
             return f"Error reading files: {e}"
 
         diff = difflib.unified_diff(
-            lines1, lines2,
+            lines1,
+            lines2,
             fromfile=f"warehouse/{file1.name}",
             tofile=f"local/{file2.name}",
             lineterm="",

--- a/libs/beacon/src/beacon/core/gitignore.py
+++ b/libs/beacon/src/beacon/core/gitignore.py
@@ -10,7 +10,6 @@ from pathlib import Path
 
 from loguru import logger
 
-
 # Entries that should be in .gitignore
 GITIGNORE_ENTRIES = [
     ".agentic-beacon/config.toml",
@@ -87,11 +86,13 @@ class GitignoreManager:
 
         try:
             self.gitignore_path.write_text(new_content, encoding="utf-8")
-            logger.debug("Updated .gitignore with {} entries: {}", len(missing_entries), missing_entries)
+            logger.debug(
+                "Updated .gitignore with {} entries: {}",
+                len(missing_entries),
+                missing_entries,
+            )
         except PermissionError as e:
-            raise PermissionError(
-                f"Cannot write to {self.gitignore_path}: {e}"
-            ) from e
+            raise PermissionError(f"Cannot write to {self.gitignore_path}: {e}") from e
 
         return True
 

--- a/libs/beacon/src/beacon/core/settings.py
+++ b/libs/beacon/src/beacon/core/settings.py
@@ -9,7 +9,6 @@ Uses Pydantic Settings for type-safe configuration.
 
 import os
 from pathlib import Path
-from typing import ClassVar, Optional
 
 import yaml
 from pydantic import BaseModel, Field, field_validator
@@ -26,7 +25,6 @@ from .exceptions import (
     YAMLParseError,
 )
 
-
 # ========== Beacon.yaml Settings Models ==========
 
 
@@ -40,7 +38,7 @@ class ArtifactsConfig(BaseModel):
 
 class BeaconSettings(BaseModel):
     """Beacon.yaml settings structure.
-    
+
     This is not a BaseSettings subclass because beacon.yaml has a custom structure
     that requires manual parsing and validation.
     """
@@ -74,7 +72,7 @@ class BeaconSettings(BaseModel):
             raise IsADirectoryError(f"Expected file, found directory: {path}")
 
         try:
-            with open(path, "r", encoding="utf-8") as f:
+            with open(path, encoding="utf-8") as f:
                 data = yaml.safe_load(f)
         except PermissionError as e:
             raise PermissionError(f"Cannot read file {path}: {e}") from e
@@ -133,10 +131,10 @@ class BeaconSettings(BaseModel):
             PermissionError: If cannot write to path
         """
         path = Path(path)
-        
+
         # Ensure parent directory exists
         path.parent.mkdir(parents=True, exist_ok=True)
-        
+
         # Create beacon config structure
         config_dict = {"artifacts": self.artifacts.model_dump()}
 
@@ -224,10 +222,10 @@ class WarehouseConfig(BaseModel):
 
 class WarehouseSettings(BaseSettings):
     """Warehouse connection settings from config.toml.
-    
+
     Uses Pydantic Settings with TOML file support for type-safe configuration.
     This class acts as both the settings container and the reader.
-    
+
     Note: The warehouse field is loaded automatically from config.toml via
     Pydantic Settings. When instantiating without arguments, the TOML file
     is read and the field is populated. Type checkers may show a warning
@@ -252,8 +250,8 @@ class WarehouseSettings(BaseSettings):
     ) -> tuple[PydanticBaseSettingsSource, ...]:
         """
         Customize settings sources to use TOML config file only.
-        
-        No environment variables for config.toml settings since this is 
+
+        No environment variables for config.toml settings since this is
         project-specific local configuration.
         """
         return (
@@ -266,30 +264,29 @@ class WarehouseSettings(BaseSettings):
     @classmethod
     def from_path(cls, local_path: str | Path) -> "WarehouseSettings":
         """Create warehouse settings from a warehouse path and write to default location.
-        
+
         Args:
             local_path: Path to warehouse
-            
+
         Returns:
             WarehouseSettings instance
         """
         # Validate and normalize path
         config = WarehouseConfig(local_path=str(local_path))
-        
+
         # Write to default location
         beacon_dir = Path(".agentic-beacon")
         beacon_dir.mkdir(parents=True, exist_ok=True)
-        
+
         toml_path = beacon_dir / "config.toml"
         toml_content = f"""[warehouse]
 local_path = "{config.local_path}"
 """
         with open(toml_path, "w", encoding="utf-8") as f:
             f.write(toml_content)
-        
+
         # Now load via BaseSettings
         return cls()  # type: ignore[call-arg]  # warehouse populated from TOML file
-
 
     def to_toml(self, path: str | Path) -> None:
         """Write warehouse settings to TOML file.
@@ -301,7 +298,7 @@ local_path = "{config.local_path}"
             PermissionError: If cannot write to path
         """
         path = Path(path)
-        
+
         # Ensure parent directory exists
         path.parent.mkdir(parents=True, exist_ok=True)
 
@@ -337,7 +334,7 @@ def validate_beacon_directory(base_dir: str | Path = ".") -> Path:
         PermissionError: If directory exists but is unreadable
     """
     config_dir = Path(base_dir).resolve() / ".agentic-beacon"
-    
+
     if not config_dir.exists():
         raise DirectoryNotFoundError(
             f"Project not initialized. .agentic-beacon directory not found at {config_dir}. "
@@ -345,9 +342,7 @@ def validate_beacon_directory(base_dir: str | Path = ".") -> Path:
         )
 
     if not config_dir.is_dir():
-        raise NotADirectoryError(
-            f"Expected directory, found file: {config_dir}"
-        )
+        raise NotADirectoryError(f"Expected directory, found file: {config_dir}")
 
     # Check if directory is readable
     if not os.access(config_dir, os.R_OK):

--- a/libs/beacon/src/beacon/core/sync.py
+++ b/libs/beacon/src/beacon/core/sync.py
@@ -6,9 +6,10 @@ from warehouse to project's .agentic-beacon/artifacts/ directory.
 
 import hashlib
 import shutil
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Callable, Literal
+from typing import Literal
 
 from loguru import logger
 from pydantic import BaseModel
@@ -60,7 +61,11 @@ class SyncEngine:
         """Normalize paths to Path objects."""
         self.warehouse_path = Path(self.warehouse_path)
         self.artifacts_path = Path(self.artifacts_path)
-        logger.debug("SyncEngine initialized: warehouse={}, artifacts={}", self.warehouse_path, self.artifacts_path)
+        logger.debug(
+            "SyncEngine initialized: warehouse={}, artifacts={}",
+            self.warehouse_path,
+            self.artifacts_path,
+        )
 
     def copy_file(self, relative_path: str, preserve: bool = False) -> SyncResult:
         """Copy a single file from warehouse to artifacts directory.
@@ -82,7 +87,7 @@ class SyncEngine:
                 success=False,
                 action="error",
                 source_path=source_file,
-                error_message=f"Source file not found: {source_file}"
+                error_message=f"Source file not found: {source_file}",
             )
 
         # Check if destination exists and is unchanged (idempotent check)
@@ -93,7 +98,7 @@ class SyncEngine:
                     success=True,
                     action="skipped",
                     source_path=source_file,
-                    dest_path=dest_file
+                    dest_path=dest_file,
                 )
 
             # File differs - check preserve flag
@@ -103,7 +108,7 @@ class SyncEngine:
                     success=True,
                     action="preserved",
                     source_path=source_file,
-                    dest_path=dest_file
+                    dest_path=dest_file,
                 )
 
         # Create parent directories and copy file
@@ -122,7 +127,7 @@ class SyncEngine:
                 success=True,
                 action="copied",
                 source_path=source_file,
-                dest_path=dest_file
+                dest_path=dest_file,
             )
         except PermissionError as e:
             logger.debug("Permission denied copying {}: {}", relative_path, e)
@@ -130,7 +135,7 @@ class SyncEngine:
                 success=False,
                 action="error",
                 source_path=source_file,
-                error_message=f"Permission denied: {e}"
+                error_message=f"Permission denied: {e}",
             )
         except OSError as e:
             logger.debug("OS error copying {}: {}", relative_path, e)
@@ -138,7 +143,7 @@ class SyncEngine:
                 success=False,
                 action="error",
                 source_path=source_file,
-                error_message=str(e)
+                error_message=str(e),
             )
 
     def sync_all(
@@ -262,7 +267,7 @@ class SyncEngine:
             Hex digest of file hash
         """
         sha256 = hashlib.sha256()
-        with open(file_path, 'rb') as f:
+        with open(file_path, "rb") as f:
             while chunk := f.read(8192):
                 sha256.update(chunk)
         return sha256.hexdigest()

--- a/libs/beacon/src/beacon/distributor.py
+++ b/libs/beacon/src/beacon/distributor.py
@@ -118,38 +118,37 @@ class WarehouseDistributor:
     def delta(self) -> dict[str, Any]:
         """
         Compare target .opencode with warehouse to find differences.
-        
+
         Detects:
         - New files in target (potential contributions back to warehouse)
         - Modified files in target (local customizations)
         - Files in warehouse but not in target (missing content)
-        
+
         Returns:
             Dictionary with new_in_target, modified_in_target, missing_in_target lists
         """
-        import hashlib
-        
+
         if not self.opencode_dir.exists():
             raise ValueError(
                 f"No .opencode directory found at {self.opencode_dir}. Run setup first."
             )
-        
+
         logger.info("Comparing target with warehouse")
-        
+
         config = self._read_config()
         contexts = config.get("contexts", [])
         knowledge_scopes = config.get("knowledge_scopes", [])
         skills = config.get("skills", [])
-        
+
         new_in_target = []
         modified_in_target = []
         missing_in_target = []
-        
+
         # Check contexts
         for context in contexts:
             warehouse_file = self.warehouse_root / "contexts" / f"AGENTS.{context}.md"
             target_file = self.opencode_dir / "contexts" / f"AGENTS.{context}.md"
-            
+
             if target_file.exists():
                 if warehouse_file.exists():
                     # Compare hashes
@@ -159,84 +158,90 @@ class WarehouseDistributor:
                     new_in_target.append(f"contexts/AGENTS.{context}.md")
             elif warehouse_file.exists():
                 missing_in_target.append(f"contexts/AGENTS.{context}.md")
-        
+
         # Check knowledge files
         for scope in knowledge_scopes:
             warehouse_dir = self.warehouse_root / "knowledge" / scope
             target_dir = self.opencode_dir / "knowledge" / scope
-            
+
             if not warehouse_dir.exists() or not target_dir.exists():
                 continue
-                
+
             # Get all markdown files in both directories
             warehouse_files = {
-                f.relative_to(warehouse_dir): f 
-                for f in warehouse_dir.rglob("*.md")
+                f.relative_to(warehouse_dir): f for f in warehouse_dir.rglob("*.md")
             }
             target_files = {
-                f.relative_to(target_dir): f 
-                for f in target_dir.rglob("*.md")
+                f.relative_to(target_dir): f for f in target_dir.rglob("*.md")
             }
-            
+
             # Find new files in target
             for rel_path in target_files:
                 if rel_path not in warehouse_files:
                     new_in_target.append(f"knowledge/{scope}/{rel_path}")
-                elif not self._files_identical(warehouse_files[rel_path], target_files[rel_path]):
+                elif not self._files_identical(
+                    warehouse_files[rel_path], target_files[rel_path]
+                ):
                     modified_in_target.append(f"knowledge/{scope}/{rel_path}")
-            
+
             # Find missing files in target
             for rel_path in warehouse_files:
                 if rel_path not in target_files:
                     missing_in_target.append(f"knowledge/{scope}/{rel_path}")
-        
+
         # Check skills
         for skill in skills:
             warehouse_dir = self.warehouse_root / "skills" / skill
             target_dir = self.opencode_dir / "skills" / skill
-            
+
             if not warehouse_dir.exists() or not target_dir.exists():
                 continue
-                
+
             warehouse_files = {
-                f.relative_to(warehouse_dir): f 
-                for f in warehouse_dir.rglob("*") if f.is_file()
+                f.relative_to(warehouse_dir): f
+                for f in warehouse_dir.rglob("*")
+                if f.is_file()
             }
             target_files = {
-                f.relative_to(target_dir): f 
-                for f in target_dir.rglob("*") if f.is_file()
+                f.relative_to(target_dir): f
+                for f in target_dir.rglob("*")
+                if f.is_file()
             }
-            
+
             for rel_path in target_files:
                 if rel_path not in warehouse_files:
                     new_in_target.append(f"skills/{skill}/{rel_path}")
-                elif not self._files_identical(warehouse_files[rel_path], target_files[rel_path]):
+                elif not self._files_identical(
+                    warehouse_files[rel_path], target_files[rel_path]
+                ):
                     modified_in_target.append(f"skills/{skill}/{rel_path}")
-            
+
             for rel_path in warehouse_files:
                 if rel_path not in target_files:
                     missing_in_target.append(f"skills/{skill}/{rel_path}")
-        
+
         result = {
             "new_in_target": new_in_target,
             "modified_in_target": modified_in_target,
             "missing_in_target": missing_in_target,
         }
-        
-        logger.info(f"Delta complete: {len(new_in_target)} new, {len(modified_in_target)} modified, {len(missing_in_target)} missing")
+
+        logger.info(
+            f"Delta complete: {len(new_in_target)} new, {len(modified_in_target)} modified, {len(missing_in_target)} missing"
+        )
         return result
-    
+
     def _files_identical(self, file1: Path, file2: Path) -> bool:
         """Check if two files have identical content using SHA256."""
         import hashlib
-        
+
         def file_hash(path: Path) -> str:
             sha256 = hashlib.sha256()
             with open(path, "rb") as f:
                 for chunk in iter(lambda: f.read(4096), b""):
                     sha256.update(chunk)
             return sha256.hexdigest()
-        
+
         return file_hash(file1) == file_hash(file2)
 
     def _create_directory_structure(self) -> None:

--- a/libs/beacon/src/beacon/initializer.py
+++ b/libs/beacon/src/beacon/initializer.py
@@ -2,7 +2,7 @@
 
 import subprocess
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any
 
 from loguru import logger
 
@@ -23,8 +23,8 @@ class WarehouseInitializer:
         self,
         *,
         org_name: str = "Your Organization",
-        languages: Optional[list[str]] = None,
-        domains: Optional[list[str]] = None,
+        languages: list[str] | None = None,
+        domains: list[str] | None = None,
         init_git: bool = True,
     ) -> dict[str, Any]:
         """
@@ -254,8 +254,8 @@ abc setup --warehouse ~/warehouse --all
 
 ### 2. Follow Structure
 
-**Contexts:** Brief summary + pointer to knowledge  
-**Knowledge:** Detailed explanation with examples  
+**Contexts:** Brief summary + pointer to knowledge
+**Knowledge:** Detailed explanation with examples
 **Skills:** Step-by-step procedures
 
 ### 3. Test Locally

--- a/libs/beacon/src/beacon/warehouse/validator.py
+++ b/libs/beacon/src/beacon/warehouse/validator.py
@@ -5,15 +5,13 @@ meet the required format before being connected to a project.
 """
 
 from pathlib import Path
-from typing import Optional
 
 from beacon.core.settings import ValidationResult
-from beacon.core.exceptions import WarehouseValidationError
 
 
 class WarehouseValidator:
     """Validates warehouse directory structure.
-    
+
     A valid warehouse must contain:
     - Required directories: contexts/, knowledge/, skills/, docs/
     - Required file: README.md
@@ -36,36 +34,31 @@ class WarehouseValidator:
 
     def validate(self, path: str | Path) -> ValidationResult:
         """Validate a warehouse directory structure.
-        
+
         Args:
             path: Path to the warehouse directory
-            
+
         Returns:
             ValidationResult with validation status and any errors
         """
         errors = []
-        
+
         # Resolve path (handle ~, .., relative paths)
         try:
             warehouse_path = Path(path).expanduser().resolve()
         except Exception as e:
-            return ValidationResult(
-                valid=False,
-                errors=[f"Invalid path: {e}"]
-            )
+            return ValidationResult(valid=False, errors=[f"Invalid path: {e}"])
 
         # Check if path exists
         if not warehouse_path.exists():
             return ValidationResult(
-                valid=False,
-                errors=[f"Path not found: {warehouse_path}"]
+                valid=False, errors=[f"Path not found: {warehouse_path}"]
             )
 
         # Check if path is a directory
         if not warehouse_path.is_dir():
             return ValidationResult(
-                valid=False,
-                errors=[f"Path is not a directory: {warehouse_path}"]
+                valid=False, errors=[f"Path is not a directory: {warehouse_path}"]
             )
 
         # Check for .agentic-beacon/artifacts/ (indicates this is a project, not a warehouse)
@@ -75,7 +68,7 @@ class WarehouseValidator:
                 errors=[
                     "This appears to be a project directory, not a warehouse. "
                     "Warehouse should not contain .agentic-beacon/artifacts/"
-                ]
+                ],
             )
 
         # Validate required directories
@@ -104,24 +97,21 @@ class WarehouseValidator:
                 f"Missing README file (expected one of: {', '.join(self.OPTIONAL_FILES)})"
             )
 
-        return ValidationResult(
-            valid=len(errors) == 0,
-            errors=errors
-        )
+        return ValidationResult(valid=len(errors) == 0, errors=errors)
 
     def resolve_path(self, path: str | Path) -> Path:
         """Resolve a path to absolute form, handling ~, .., and symlinks.
-        
+
         Args:
             path: Path to resolve
-            
+
         Returns:
             Resolved absolute path
-            
+
         Raises:
             ValueError: If path is empty
         """
         if not path:
             raise ValueError("Path cannot be empty")
-        
+
         return Path(path).expanduser().resolve()

--- a/libs/beacon/tests/cli/test_delta_command.py
+++ b/libs/beacon/tests/cli/test_delta_command.py
@@ -3,11 +3,9 @@
 Following TDD workflow for tasks 9.1-9.7.
 """
 
-import os
 import pytest
-from pathlib import Path
-from click.testing import CliRunner
 from beacon.cli import main
+from click.testing import CliRunner
 
 
 @pytest.fixture

--- a/libs/beacon/tests/cli/test_e2e_happy_path.py
+++ b/libs/beacon/tests/cli/test_e2e_happy_path.py
@@ -14,12 +14,11 @@ unit tests:
     pytest -m "not integration"    # only unit tests (default CI run)
     pytest                         # everything
 """
-import pytest
-from pathlib import Path
-from click.testing import CliRunner
-import yaml
 
+import pytest
+import yaml
 from beacon.cli import main
+from click.testing import CliRunner
 
 pytestmark = pytest.mark.integration
 
@@ -36,10 +35,15 @@ def e2e_warehouse(tmp_path):
     result = runner.invoke(
         main,
         [
-            "warehouse", "init", "my-warehouse",
-            "--path", str(tmp_path),
-            "--org", "Test Org",
-            "--languages", "python",
+            "warehouse",
+            "init",
+            "my-warehouse",
+            "--path",
+            str(tmp_path),
+            "--org",
+            "Test Org",
+            "--languages",
+            "python",
             "--no-interactive",
             "--no-git",
         ],
@@ -77,6 +81,7 @@ def e2e_project(tmp_path, e2e_warehouse, monkeypatch):
 # Step 1 — warehouse init creates the expected structure
 # ---------------------------------------------------------------------------
 
+
 def test_e2e_warehouse_init_creates_structure(e2e_warehouse):
     """warehouse init produces contexts/, knowledge/, skills/, docs/, README.md."""
     assert (e2e_warehouse / "contexts").is_dir()
@@ -90,6 +95,7 @@ def test_e2e_warehouse_init_creates_structure(e2e_warehouse):
 # ---------------------------------------------------------------------------
 # Step 2 — abc list shows all three sections including Contexts
 # ---------------------------------------------------------------------------
+
 
 def test_e2e_list_shows_contexts(e2e_project):
     project_dir, warehouse, runner = e2e_project
@@ -107,6 +113,7 @@ def test_e2e_list_shows_contexts(e2e_project):
 # Step 3 — warehouse connect
 # ---------------------------------------------------------------------------
 
+
 def test_e2e_warehouse_connect(e2e_project):
     project_dir, warehouse, runner = e2e_project
 
@@ -123,6 +130,7 @@ def test_e2e_warehouse_connect(e2e_project):
 # ---------------------------------------------------------------------------
 # Step 4 — setup --manual produces clean beacon.yaml template
 # ---------------------------------------------------------------------------
+
 
 def test_e2e_setup_manual_template(e2e_project):
     project_dir, warehouse, runner = e2e_project
@@ -143,6 +151,7 @@ def test_e2e_setup_manual_template(e2e_project):
     raw = beacon_yaml.read_text()
     # No duplicate keys (Bug #1 regression)
     import re
+
     assert len(re.findall(r"^\s{2}skills:", raw, re.MULTILINE)) == 1
     # Context comments use current path format (Bug #1/#4 regression)
     assert "AGENTS.global.md" not in raw
@@ -152,6 +161,7 @@ def test_e2e_setup_manual_template(e2e_project):
 # ---------------------------------------------------------------------------
 # Step 5 — sync copies all declared artifacts
 # ---------------------------------------------------------------------------
+
 
 def test_e2e_sync_copies_artifacts(e2e_project):
     project_dir, warehouse, runner = e2e_project
@@ -227,6 +237,7 @@ def test_e2e_sync_glob_pattern(e2e_project):
 # Step 6 — status shows ✓ for synced contexts and skills
 # ---------------------------------------------------------------------------
 
+
 def test_e2e_status_shows_check_marks_for_synced(e2e_project):
     """status correctly shows ✓ for synced items (Bug #2 regression)."""
     project_dir, warehouse, runner = e2e_project
@@ -254,6 +265,7 @@ def test_e2e_status_shows_check_marks_for_synced(e2e_project):
 # ---------------------------------------------------------------------------
 # Step 7 — delta detects no changes, then detects a local modification
 # ---------------------------------------------------------------------------
+
 
 def test_e2e_delta_clean(e2e_project):
     project_dir, warehouse, runner = e2e_project
@@ -290,7 +302,14 @@ def test_e2e_delta_detects_modification(e2e_project):
     runner.invoke(main, ["sync"])
 
     # Locally modify a synced artifact
-    synced = project_dir / ".agentic-beacon" / "artifacts" / "knowledge" / "python" / "standards.md"
+    synced = (
+        project_dir
+        / ".agentic-beacon"
+        / "artifacts"
+        / "knowledge"
+        / "python"
+        / "standards.md"
+    )
     synced.write_text(synced.read_text() + "- Local addition\n")
 
     result = runner.invoke(main, ["delta"])
@@ -303,6 +322,7 @@ def test_e2e_delta_detects_modification(e2e_project):
 # ---------------------------------------------------------------------------
 # Step 8 — sync --preserve skips locally modified file
 # ---------------------------------------------------------------------------
+
 
 def test_e2e_sync_preserve(e2e_project):
     project_dir, warehouse, runner = e2e_project
@@ -318,7 +338,14 @@ def test_e2e_sync_preserve(e2e_project):
     )
     runner.invoke(main, ["sync"])
 
-    synced = project_dir / ".agentic-beacon" / "artifacts" / "knowledge" / "python" / "standards.md"
+    synced = (
+        project_dir
+        / ".agentic-beacon"
+        / "artifacts"
+        / "knowledge"
+        / "python"
+        / "standards.md"
+    )
     synced.write_text(synced.read_text() + "- Local addition\n")
     original_content = synced.read_text()
 
@@ -332,6 +359,7 @@ def test_e2e_sync_preserve(e2e_project):
 # ---------------------------------------------------------------------------
 # Step 9 — sync --prune removes artifacts dropped from beacon.yaml
 # ---------------------------------------------------------------------------
+
 
 def test_e2e_sync_prune(e2e_project):
     project_dir, warehouse, runner = e2e_project
@@ -361,15 +389,30 @@ def test_e2e_sync_prune(e2e_project):
 
     assert result.exit_code == 0
     assert "Pruned: 1" in result.output
-    dropped = project_dir / ".agentic-beacon" / "artifacts" / "knowledge" / "decisions" / "use-uv.md"
+    dropped = (
+        project_dir
+        / ".agentic-beacon"
+        / "artifacts"
+        / "knowledge"
+        / "decisions"
+        / "use-uv.md"
+    )
     assert not dropped.exists()
-    kept = project_dir / ".agentic-beacon" / "artifacts" / "knowledge" / "python" / "standards.md"
+    kept = (
+        project_dir
+        / ".agentic-beacon"
+        / "artifacts"
+        / "knowledge"
+        / "python"
+        / "standards.md"
+    )
     assert kept.exists()
 
 
 # ---------------------------------------------------------------------------
 # Step 10 — update pulls in an upstream warehouse change
 # ---------------------------------------------------------------------------
+
 
 def test_e2e_update_picks_up_upstream_change(e2e_project):
     project_dir, warehouse, runner = e2e_project
@@ -394,13 +437,21 @@ def test_e2e_update_picks_up_upstream_change(e2e_project):
     assert result.exit_code == 0
     assert "Updated: 1" in result.output
 
-    synced = project_dir / ".agentic-beacon" / "artifacts" / "knowledge" / "python" / "standards.md"
+    synced = (
+        project_dir
+        / ".agentic-beacon"
+        / "artifacts"
+        / "knowledge"
+        / "python"
+        / "standards.md"
+    )
     assert "No bare excepts" in synced.read_text()
 
 
 # ---------------------------------------------------------------------------
 # Step 11 — clean removes the artifacts directory
 # ---------------------------------------------------------------------------
+
 
 def test_e2e_clean(e2e_project):
     project_dir, warehouse, runner = e2e_project

--- a/libs/beacon/tests/cli/test_setup_command.py
+++ b/libs/beacon/tests/cli/test_setup_command.py
@@ -8,30 +8,30 @@ Following TDD workflow for tasks 4.1-4.6:
 - Task 4.5: Interactive workflow selection
 - Task 4.6: Non-interactive flags
 """
-import pytest
-from pathlib import Path
-from click.testing import CliRunner
-from beacon.cli import main
-import yaml
 
+import yaml
+from beacon.cli import main
+from click.testing import CliRunner
 
 # ========== Task 4.1: Setup Command Implementation ==========
 
 
-def test_setup_with_warehouse_connected_shows_prompt(valid_warehouse, temp_dir, monkeypatch):
+def test_setup_with_warehouse_connected_shows_prompt(
+    valid_warehouse, temp_dir, monkeypatch
+):
     """TC1: Setup with warehouse connected → Interactive prompt shown."""
     runner = CliRunner()
-    
+
     project_dir = temp_dir / "project"
     project_dir.mkdir()
     monkeypatch.chdir(project_dir)
-    
+
     # Connect warehouse first
     runner.invoke(main, ["warehouse", "connect", "--path", str(valid_warehouse)])
-    
+
     # Run setup with skip option
     result = runner.invoke(main, ["setup"], input="3\n")
-    
+
     assert result.exit_code == 0
     # Should show workflow options
     assert "workflow" in result.output.lower() or "setup" in result.output.lower()
@@ -40,18 +40,18 @@ def test_setup_with_warehouse_connected_shows_prompt(valid_warehouse, temp_dir, 
 def test_setup_without_warehouse_connected_shows_error(temp_dir, monkeypatch):
     """TC2: Setup without warehouse connected → Error message."""
     runner = CliRunner()
-    
+
     project_dir = temp_dir / "project"
     project_dir.mkdir()
-    
+
     # Create .agentic-beacon but no config.toml (no warehouse connected)
     beacon_dir = project_dir / ".agentic-beacon"
     beacon_dir.mkdir()
-    
+
     monkeypatch.chdir(project_dir)
-    
+
     result = runner.invoke(main, ["setup"])
-    
+
     assert result.exit_code == 1
     assert "warehouse" in result.output.lower()
     assert "connect" in result.output.lower()
@@ -60,22 +60,22 @@ def test_setup_without_warehouse_connected_shows_error(temp_dir, monkeypatch):
 def test_setup_when_beacon_yaml_exists(valid_warehouse, temp_dir, monkeypatch):
     """TC3: Setup when beacon.yaml already exists → Prompt or skip."""
     runner = CliRunner()
-    
+
     project_dir = temp_dir / "project"
     project_dir.mkdir()
     monkeypatch.chdir(project_dir)
-    
+
     # Connect warehouse
     runner.invoke(main, ["warehouse", "connect", "--path", str(valid_warehouse)])
-    
+
     # Create existing beacon.yaml
     beacon_dir = project_dir / ".agentic-beacon"
     beacon_yaml = beacon_dir / "beacon.yaml"
     beacon_yaml.write_text("artifacts:\n  knowledge: []\n")
-    
+
     # Try setup again
     result = runner.invoke(main, ["setup", "--manual"])
-    
+
     # Should either skip or ask to overwrite
     assert result.exit_code == 0 or "already exists" in result.output.lower()
 
@@ -83,18 +83,18 @@ def test_setup_when_beacon_yaml_exists(valid_warehouse, temp_dir, monkeypatch):
 def test_setup_with_manual_flag(valid_warehouse, temp_dir, monkeypatch):
     """TC4: Setup with --manual flag → Creates template directly."""
     runner = CliRunner()
-    
+
     project_dir = temp_dir / "project"
     project_dir.mkdir()
     monkeypatch.chdir(project_dir)
-    
+
     # Connect warehouse
     runner.invoke(main, ["warehouse", "connect", "--path", str(valid_warehouse)])
-    
+
     result = runner.invoke(main, ["setup", "--manual"])
-    
+
     assert result.exit_code == 0
-    
+
     beacon_yaml = project_dir / ".agentic-beacon" / "beacon.yaml"
     assert beacon_yaml.exists()
 
@@ -102,13 +102,13 @@ def test_setup_with_manual_flag(valid_warehouse, temp_dir, monkeypatch):
 def test_setup_without_agentic_beacon_dir_shows_error(temp_dir, monkeypatch):
     """TC7: Setup without .agentic-beacon → Error with actionable message."""
     runner = CliRunner()
-    
+
     project_dir = temp_dir / "project"
     project_dir.mkdir()
     monkeypatch.chdir(project_dir)
-    
+
     result = runner.invoke(main, ["setup"])
-    
+
     assert result.exit_code == 1
     # Should mention warehouse connection or setup
     assert "warehouse" in result.output.lower() or "connect" in result.output.lower()
@@ -117,22 +117,24 @@ def test_setup_without_agentic_beacon_dir_shows_error(temp_dir, monkeypatch):
 # ========== Task 4.2: Beacon.yaml Template Generation ==========
 
 
-def test_template_creates_file_with_correct_structure(valid_warehouse, temp_dir, monkeypatch):
+def test_template_creates_file_with_correct_structure(
+    valid_warehouse, temp_dir, monkeypatch
+):
     """TC1: Template generation creates file with artifacts structure."""
     runner = CliRunner()
-    
+
     project_dir = temp_dir / "project"
     project_dir.mkdir()
     monkeypatch.chdir(project_dir)
-    
+
     runner.invoke(main, ["warehouse", "connect", "--path", str(valid_warehouse)])
     result = runner.invoke(main, ["setup", "--manual"])
-    
+
     assert result.exit_code == 0
-    
+
     beacon_yaml = project_dir / ".agentic-beacon" / "beacon.yaml"
     assert beacon_yaml.exists()
-    
+
     content = yaml.safe_load(beacon_yaml.read_text())
     assert "artifacts" in content
 
@@ -140,16 +142,16 @@ def test_template_creates_file_with_correct_structure(valid_warehouse, temp_dir,
 def test_template_is_valid_yaml(valid_warehouse, temp_dir, monkeypatch):
     """TC2: Template is valid YAML that parses without errors."""
     runner = CliRunner()
-    
+
     project_dir = temp_dir / "project"
     project_dir.mkdir()
     monkeypatch.chdir(project_dir)
-    
+
     runner.invoke(main, ["warehouse", "connect", "--path", str(valid_warehouse)])
     runner.invoke(main, ["setup", "--manual"])
-    
+
     beacon_yaml = project_dir / ".agentic-beacon" / "beacon.yaml"
-    
+
     # Should parse without exception
     content = yaml.safe_load(beacon_yaml.read_text())
     assert isinstance(content, dict)
@@ -158,17 +160,17 @@ def test_template_is_valid_yaml(valid_warehouse, temp_dir, monkeypatch):
 def test_template_has_all_three_artifact_types(valid_warehouse, temp_dir, monkeypatch):
     """TC3: Template has knowledge, skills, contexts."""
     runner = CliRunner()
-    
+
     project_dir = temp_dir / "project"
     project_dir.mkdir()
     monkeypatch.chdir(project_dir)
-    
+
     runner.invoke(main, ["warehouse", "connect", "--path", str(valid_warehouse)])
     runner.invoke(main, ["setup", "--manual"])
-    
+
     beacon_yaml = project_dir / ".agentic-beacon" / "beacon.yaml"
     content = yaml.safe_load(beacon_yaml.read_text())
-    
+
     assert "knowledge" in content["artifacts"]
     assert "skills" in content["artifacts"]
     assert "contexts" in content["artifacts"]
@@ -177,17 +179,17 @@ def test_template_has_all_three_artifact_types(valid_warehouse, temp_dir, monkey
 def test_template_has_empty_lists(valid_warehouse, temp_dir, monkeypatch):
     """TC4: All artifact types are empty lists."""
     runner = CliRunner()
-    
+
     project_dir = temp_dir / "project"
     project_dir.mkdir()
     monkeypatch.chdir(project_dir)
-    
+
     runner.invoke(main, ["warehouse", "connect", "--path", str(valid_warehouse)])
     runner.invoke(main, ["setup", "--manual"])
-    
+
     beacon_yaml = project_dir / ".agentic-beacon" / "beacon.yaml"
     content = yaml.safe_load(beacon_yaml.read_text())
-    
+
     assert content["artifacts"]["knowledge"] == []
     assert content["artifacts"]["skills"] == []
     assert content["artifacts"]["contexts"] == []
@@ -196,17 +198,17 @@ def test_template_has_empty_lists(valid_warehouse, temp_dir, monkeypatch):
 def test_template_includes_commented_examples(valid_warehouse, temp_dir, monkeypatch):
     """TC5: Template includes helpful comment examples."""
     runner = CliRunner()
-    
+
     project_dir = temp_dir / "project"
     project_dir.mkdir()
     monkeypatch.chdir(project_dir)
-    
+
     runner.invoke(main, ["warehouse", "connect", "--path", str(valid_warehouse)])
     runner.invoke(main, ["setup", "--manual"])
-    
+
     beacon_yaml = project_dir / ".agentic-beacon" / "beacon.yaml"
     content_text = beacon_yaml.read_text()
-    
+
     # Should have comments (lines starting with #)
     assert "#" in content_text
 
@@ -214,16 +216,16 @@ def test_template_includes_commented_examples(valid_warehouse, temp_dir, monkeyp
 def test_template_comments_are_valid(valid_warehouse, temp_dir, monkeypatch):
     """TC6: Comments start with # and don't break YAML parsing."""
     runner = CliRunner()
-    
+
     project_dir = temp_dir / "project"
     project_dir.mkdir()
     monkeypatch.chdir(project_dir)
-    
+
     runner.invoke(main, ["warehouse", "connect", "--path", str(valid_warehouse)])
     runner.invoke(main, ["setup", "--manual"])
-    
+
     beacon_yaml = project_dir / ".agentic-beacon" / "beacon.yaml"
-    
+
     # Should still parse correctly despite comments
     content = yaml.safe_load(beacon_yaml.read_text())
     assert content is not None
@@ -232,7 +234,9 @@ def test_template_comments_are_valid(valid_warehouse, temp_dir, monkeypatch):
 # ========== Regression: Bug #1 — duplicate skills key ==========
 
 
-def test_template_has_no_duplicate_artifact_keys(valid_warehouse, temp_dir, monkeypatch):
+def test_template_has_no_duplicate_artifact_keys(
+    valid_warehouse, temp_dir, monkeypatch
+):
     """Regression #1: beacon.yaml template must not have duplicate YAML keys.
 
     A duplicate 'skills' key caused the first block to be silently discarded
@@ -252,6 +256,7 @@ def test_template_has_no_duplicate_artifact_keys(valid_warehouse, temp_dir, monk
 
     # Count how many times each top-level artifact key appears as a YAML key
     import re
+
     knowledge_count = len(re.findall(r"^\s{2}knowledge:", raw_text, re.MULTILINE))
     skills_count = len(re.findall(r"^\s{2}skills:", raw_text, re.MULTILINE))
     contexts_count = len(re.findall(r"^\s{2}contexts:", raw_text, re.MULTILINE))
@@ -261,7 +266,9 @@ def test_template_has_no_duplicate_artifact_keys(valid_warehouse, temp_dir, monk
     assert contexts_count == 1, f"Expected 1 'contexts:' key, found {contexts_count}"
 
 
-def test_template_context_comments_use_full_path(valid_warehouse, temp_dir, monkeypatch):
+def test_template_context_comments_use_full_path(
+    valid_warehouse, temp_dir, monkeypatch
+):
     """Regression #1/#4: Context examples in template use full path (contexts/AGENTS.md).
 
     Old stale examples showed 'AGENTS.global.md' (old naming convention, no prefix),
@@ -289,20 +296,20 @@ def test_template_context_comments_use_full_path(valid_warehouse, temp_dir, monk
 def test_template_roundtrip_parses_correctly(valid_warehouse, temp_dir, monkeypatch):
     """TC10: Template can be loaded and re-saved without corruption."""
     runner = CliRunner()
-    
+
     project_dir = temp_dir / "project"
     project_dir.mkdir()
     monkeypatch.chdir(project_dir)
-    
+
     runner.invoke(main, ["warehouse", "connect", "--path", str(valid_warehouse)])
     runner.invoke(main, ["setup", "--manual"])
-    
+
     beacon_yaml = project_dir / ".agentic-beacon" / "beacon.yaml"
-    
+
     # Load and re-save
     content = yaml.safe_load(beacon_yaml.read_text())
     new_yaml = yaml.dump(content)
-    
+
     # Should parse again
     reparsed = yaml.safe_load(new_yaml)
     assert reparsed["artifacts"]["knowledge"] == []
@@ -314,18 +321,18 @@ def test_template_roundtrip_parses_correctly(valid_warehouse, temp_dir, monkeypa
 def test_setup_interactive_manual_workflow(valid_warehouse, temp_dir, monkeypatch):
     """TC2: Select manual workflow → Creates empty beacon.yaml."""
     runner = CliRunner()
-    
+
     project_dir = temp_dir / "project"
     project_dir.mkdir()
     monkeypatch.chdir(project_dir)
-    
+
     runner.invoke(main, ["warehouse", "connect", "--path", str(valid_warehouse)])
-    
+
     # Select option 2 (manual)
     result = runner.invoke(main, ["setup"], input="2\n")
-    
+
     assert result.exit_code == 0
-    
+
     beacon_yaml = project_dir / ".agentic-beacon" / "beacon.yaml"
     assert beacon_yaml.exists()
 
@@ -333,18 +340,18 @@ def test_setup_interactive_manual_workflow(valid_warehouse, temp_dir, monkeypatc
 def test_setup_interactive_skip_workflow(valid_warehouse, temp_dir, monkeypatch):
     """TC3: Select skip → No beacon.yaml created."""
     runner = CliRunner()
-    
+
     project_dir = temp_dir / "project"
     project_dir.mkdir()
     monkeypatch.chdir(project_dir)
-    
+
     runner.invoke(main, ["warehouse", "connect", "--path", str(valid_warehouse)])
-    
+
     # Select option 3 (skip)
     result = runner.invoke(main, ["setup"], input="3\n")
-    
+
     assert result.exit_code == 0
-    
+
     beacon_yaml = project_dir / ".agentic-beacon" / "beacon.yaml"
     assert not beacon_yaml.exists()
 
@@ -355,18 +362,18 @@ def test_setup_interactive_skip_workflow(valid_warehouse, temp_dir, monkeypatch)
 def test_setup_manual_flag_bypasses_prompt(valid_warehouse, temp_dir, monkeypatch):
     """TC: --manual flag skips interactive prompt."""
     runner = CliRunner()
-    
+
     project_dir = temp_dir / "project"
     project_dir.mkdir()
     monkeypatch.chdir(project_dir)
-    
+
     runner.invoke(main, ["warehouse", "connect", "--path", str(valid_warehouse)])
-    
+
     result = runner.invoke(main, ["setup", "--manual"])
-    
+
     assert result.exit_code == 0
     # Should not show interactive prompt
     assert "Select" not in result.output or "workflow" not in result.output.lower()
-    
+
     beacon_yaml = project_dir / ".agentic-beacon" / "beacon.yaml"
     assert beacon_yaml.exists()

--- a/libs/beacon/tests/cli/test_status_command.py
+++ b/libs/beacon/tests/cli/test_status_command.py
@@ -3,10 +3,10 @@
 Regression tests for:
 - Bug #2: status showed ✗ for synced contexts and skills due to wrong path construction
 """
+
 import pytest
-from pathlib import Path
-from click.testing import CliRunner
 from beacon.cli import main
+from click.testing import CliRunner
 
 
 @pytest.fixture
@@ -86,7 +86,9 @@ def test_status_shows_check_for_synced_skill(connected_project):
     assert "✓" in result.output
 
 
-def test_status_shows_cross_for_unsynced_context(valid_warehouse, temp_dir, monkeypatch):
+def test_status_shows_cross_for_unsynced_context(
+    valid_warehouse, temp_dir, monkeypatch
+):
     """Status shows ✗ for a context declared in beacon.yaml but not yet synced."""
     runner = CliRunner()
 

--- a/libs/beacon/tests/cli/test_sync_command.py
+++ b/libs/beacon/tests/cli/test_sync_command.py
@@ -9,12 +9,9 @@ Following TDD workflow for tasks 7.1-7.7:
 - Task 7.6: Empty beacon.yaml handling
 - Task 7.7: Invalid glob pattern handling
 """
-import pytest
-from pathlib import Path
-from click.testing import CliRunner
-from beacon.cli import main
-import yaml
 
+from beacon.cli import main
+from click.testing import CliRunner
 
 # ========== Task 7.1: ABC Sync Command Implementation ==========
 
@@ -22,30 +19,34 @@ import yaml
 def test_sync_with_valid_configuration(valid_warehouse, temp_dir, monkeypatch):
     """TC1: First sync with empty artifacts dir → All artifacts copied."""
     runner = CliRunner()
-    
+
     project_dir = temp_dir / "project"
     project_dir.mkdir()
     monkeypatch.chdir(project_dir)
-    
+
     # Create test files in warehouse
     (valid_warehouse / "knowledge" / "test.md").write_text("# Test")
-    
+
     # Connect warehouse
     runner.invoke(main, ["warehouse", "connect", "--path", str(valid_warehouse)])
-    
+
     # Create beacon.yaml
     runner.invoke(main, ["setup", "--manual"])
     beacon_yaml = project_dir / ".agentic-beacon" / "beacon.yaml"
-    beacon_yaml.write_text("artifacts:\n  knowledge:\n    - knowledge/test.md\n  skills: []\n  contexts: []\n")
-    
+    beacon_yaml.write_text(
+        "artifacts:\n  knowledge:\n    - knowledge/test.md\n  skills: []\n  contexts: []\n"
+    )
+
     # Run sync
     result = runner.invoke(main, ["sync"])
-    
+
     assert result.exit_code == 0
     assert "sync" in result.output.lower() or "✓" in result.output
-    
+
     # Verify file was copied
-    synced_file = project_dir / ".agentic-beacon" / "artifacts" / "knowledge" / "test.md"
+    synced_file = (
+        project_dir / ".agentic-beacon" / "artifacts" / "knowledge" / "test.md"
+    )
     assert synced_file.exists()
     assert synced_file.read_text() == "# Test"
 
@@ -53,29 +54,33 @@ def test_sync_with_valid_configuration(valid_warehouse, temp_dir, monkeypatch):
 def test_sync_is_idempotent(valid_warehouse, temp_dir, monkeypatch):
     """TC2: Second sync with no changes → No files copied (idempotent)."""
     runner = CliRunner()
-    
+
     project_dir = temp_dir / "project"
     project_dir.mkdir()
     monkeypatch.chdir(project_dir)
-    
+
     # Setup
     (valid_warehouse / "knowledge" / "test.md").write_text("# Test")
     runner.invoke(main, ["warehouse", "connect", "--path", str(valid_warehouse)])
     runner.invoke(main, ["setup", "--manual"])
     beacon_yaml = project_dir / ".agentic-beacon" / "beacon.yaml"
-    beacon_yaml.write_text("artifacts:\n  knowledge:\n    - knowledge/test.md\n  skills: []\n  contexts: []\n")
-    
+    beacon_yaml.write_text(
+        "artifacts:\n  knowledge:\n    - knowledge/test.md\n  skills: []\n  contexts: []\n"
+    )
+
     # First sync
     result1 = runner.invoke(main, ["sync"])
     assert result1.exit_code == 0
-    
-    synced_file = project_dir / ".agentic-beacon" / "artifacts" / "knowledge" / "test.md"
+
+    synced_file = (
+        project_dir / ".agentic-beacon" / "artifacts" / "knowledge" / "test.md"
+    )
     mtime1 = synced_file.stat().st_mtime
-    
+
     # Second sync - should be idempotent
     result2 = runner.invoke(main, ["sync"])
     assert result2.exit_code == 0
-    
+
     # File should not have been re-copied
     mtime2 = synced_file.stat().st_mtime
     assert mtime2 == mtime1
@@ -84,25 +89,27 @@ def test_sync_is_idempotent(valid_warehouse, temp_dir, monkeypatch):
 def test_sync_with_glob_patterns(valid_warehouse, temp_dir, monkeypatch):
     """TC8: beacon.yaml with globs → All matching files synced."""
     runner = CliRunner()
-    
+
     project_dir = temp_dir / "project"
     project_dir.mkdir()
     monkeypatch.chdir(project_dir)
-    
+
     # Create multiple files matching pattern
     (valid_warehouse / "knowledge" / "python").mkdir(parents=True, exist_ok=True)
     (valid_warehouse / "knowledge" / "python" / "file1.md").write_text("# File 1")
     (valid_warehouse / "knowledge" / "python" / "file2.md").write_text("# File 2")
-    
+
     runner.invoke(main, ["warehouse", "connect", "--path", str(valid_warehouse)])
     runner.invoke(main, ["setup", "--manual"])
     beacon_yaml = project_dir / ".agentic-beacon" / "beacon.yaml"
-    beacon_yaml.write_text("artifacts:\n  knowledge:\n    - knowledge/python/*.md\n  skills: []\n  contexts: []\n")
-    
+    beacon_yaml.write_text(
+        "artifacts:\n  knowledge:\n    - knowledge/python/*.md\n  skills: []\n  contexts: []\n"
+    )
+
     result = runner.invoke(main, ["sync"])
-    
+
     assert result.exit_code == 0
-    
+
     # Verify both files were copied
     artifacts_dir = project_dir / ".agentic-beacon" / "artifacts"
     assert (artifacts_dir / "knowledge" / "python" / "file1.md").exists()
@@ -115,19 +122,21 @@ def test_sync_with_glob_patterns(valid_warehouse, temp_dir, monkeypatch):
 def test_sync_without_warehouse_connection(temp_dir, monkeypatch):
     """TC1: No config.toml exists → Error message about connection."""
     runner = CliRunner()
-    
+
     project_dir = temp_dir / "project"
     project_dir.mkdir()
-    
+
     # Create .agentic-beacon but no config.toml
     beacon_dir = project_dir / ".agentic-beacon"
     beacon_dir.mkdir()
-    (beacon_dir / "beacon.yaml").write_text("artifacts:\n  knowledge: []\n  skills: []\n  contexts: []\n")
-    
+    (beacon_dir / "beacon.yaml").write_text(
+        "artifacts:\n  knowledge: []\n  skills: []\n  contexts: []\n"
+    )
+
     monkeypatch.chdir(project_dir)
-    
+
     result = runner.invoke(main, ["sync"])
-    
+
     assert result.exit_code == 1
     assert "warehouse" in result.output.lower()
     assert "connect" in result.output.lower()
@@ -139,16 +148,16 @@ def test_sync_without_warehouse_connection(temp_dir, monkeypatch):
 def test_sync_without_beacon_yaml(valid_warehouse, temp_dir, monkeypatch):
     """TC: No beacon.yaml → Error with actionable message."""
     runner = CliRunner()
-    
+
     project_dir = temp_dir / "project"
     project_dir.mkdir()
     monkeypatch.chdir(project_dir)
-    
+
     # Connect warehouse but don't create beacon.yaml
     runner.invoke(main, ["warehouse", "connect", "--path", str(valid_warehouse)])
-    
+
     result = runner.invoke(main, ["sync"])
-    
+
     assert result.exit_code == 1
     assert "beacon.yaml" in result.output.lower()
     assert "setup" in result.output.lower()
@@ -160,19 +169,24 @@ def test_sync_without_beacon_yaml(valid_warehouse, temp_dir, monkeypatch):
 def test_sync_with_empty_beacon_yaml(valid_warehouse, temp_dir, monkeypatch):
     """TC: Empty beacon.yaml → No-op, friendly message."""
     runner = CliRunner()
-    
+
     project_dir = temp_dir / "project"
     project_dir.mkdir()
     monkeypatch.chdir(project_dir)
-    
+
     runner.invoke(main, ["warehouse", "connect", "--path", str(valid_warehouse)])
     runner.invoke(main, ["setup", "--manual"])
-    
+
     # beacon.yaml with empty lists
     beacon_yaml = project_dir / ".agentic-beacon" / "beacon.yaml"
-    beacon_yaml.write_text("artifacts:\n  knowledge: []\n  skills: []\n  contexts: []\n")
-    
+    beacon_yaml.write_text(
+        "artifacts:\n  knowledge: []\n  skills: []\n  contexts: []\n"
+    )
+
     result = runner.invoke(main, ["sync"])
-    
+
     assert result.exit_code == 0
-    assert "no artifacts" in result.output.lower() or "nothing to sync" in result.output.lower()
+    assert (
+        "no artifacts" in result.output.lower()
+        or "nothing to sync" in result.output.lower()
+    )

--- a/libs/beacon/tests/cli/test_warehouse_connect.py
+++ b/libs/beacon/tests/cli/test_warehouse_connect.py
@@ -2,18 +2,17 @@
 
 Following TDD workflow for tasks 3.1-3.7:
 - Task 3.1: Warehouse command group
-- Task 3.2: Connect command with --path parameter  
+- Task 3.2: Connect command with --path parameter
 - Task 3.3: Interactive prompt workflow
 - Task 3.4: Warehouse validation integration
 - Task 3.5: Connection persistence
 - Task 3.6: Success confirmation messaging
 - Task 3.7: Progress indicators
 """
-import pytest
-from pathlib import Path
-from click.testing import CliRunner
-from beacon.cli import main
 
+import pytest
+from beacon.cli import main
+from click.testing import CliRunner
 
 # ========== Task 3.1: Warehouse Command Group ==========
 
@@ -22,7 +21,7 @@ def test_warehouse_command_group_exists():
     """TC: warehouse command group is created and accessible."""
     runner = CliRunner()
     result = runner.invoke(main, ["warehouse", "--help"])
-    
+
     assert result.exit_code == 0
     assert "Warehouse management commands" in result.output
 
@@ -31,7 +30,7 @@ def test_warehouse_command_shows_subcommands():
     """TC: warehouse --help shows init and connect subcommands."""
     runner = CliRunner()
     result = runner.invoke(main, ["warehouse", "--help"])
-    
+
     assert result.exit_code == 0
     assert "init" in result.output
     assert "connect" in result.output
@@ -41,7 +40,7 @@ def test_warehouse_connect_help_accessible():
     """TC: warehouse connect --help shows command help."""
     runner = CliRunner()
     result = runner.invoke(main, ["warehouse", "connect", "--help"])
-    
+
     assert result.exit_code == 0
     assert "Connect project to a local warehouse" in result.output
     assert "--path" in result.output
@@ -53,20 +52,22 @@ def test_warehouse_connect_help_accessible():
 def test_connect_with_valid_warehouse_path(valid_warehouse, temp_dir, monkeypatch):
     """TC1: Valid warehouse path → Exit code 0, config.toml created, success message."""
     runner = CliRunner()
-    
+
     project_dir = temp_dir / "project"
     project_dir.mkdir()
     monkeypatch.chdir(project_dir)
-    
-    result = runner.invoke(main, ["warehouse", "connect", "--path", str(valid_warehouse)])
-    
+
+    result = runner.invoke(
+        main, ["warehouse", "connect", "--path", str(valid_warehouse)]
+    )
+
     assert result.exit_code == 0
     assert "✓ Warehouse structure validated" in result.output
     assert "✓ Connected to warehouse" in result.output
-    
+
     config_path = project_dir / ".agentic-beacon" / "config.toml"
     assert config_path.exists()
-    
+
     config_content = config_path.read_text()
     assert "[warehouse]" in config_content
     assert "local_path" in config_content
@@ -75,19 +76,21 @@ def test_connect_with_valid_warehouse_path(valid_warehouse, temp_dir, monkeypatc
 def test_connect_with_invalid_warehouse_structure(temp_dir, monkeypatch):
     """TC2: Invalid warehouse structure → Exit code 1, no config.toml, validation errors displayed."""
     runner = CliRunner()
-    
+
     invalid_warehouse = temp_dir / "invalid-warehouse"
     invalid_warehouse.mkdir()
-    
+
     project_dir = temp_dir / "project"
     project_dir.mkdir()
     monkeypatch.chdir(project_dir)
-    
-    result = runner.invoke(main, ["warehouse", "connect", "--path", str(invalid_warehouse)])
-    
+
+    result = runner.invoke(
+        main, ["warehouse", "connect", "--path", str(invalid_warehouse)]
+    )
+
     assert result.exit_code == 1
     assert "Invalid warehouse structure" in result.output
-    
+
     config_path = project_dir / ".agentic-beacon" / "config.toml"
     assert not config_path.exists()
 
@@ -95,38 +98,40 @@ def test_connect_with_invalid_warehouse_structure(temp_dir, monkeypatch):
 def test_connect_with_nonexistent_path(temp_dir, monkeypatch):
     """TC3: Non-existent path → Exit code 1, error message."""
     runner = CliRunner()
-    
+
     nonexistent_path = temp_dir / "does-not-exist"
-    
+
     project_dir = temp_dir / "project"
     project_dir.mkdir()
     monkeypatch.chdir(project_dir)
-    
-    result = runner.invoke(main, ["warehouse", "connect", "--path", str(nonexistent_path)])
-    
+
+    result = runner.invoke(
+        main, ["warehouse", "connect", "--path", str(nonexistent_path)]
+    )
+
     assert result.exit_code == 1
 
 
 def test_connect_with_file_not_directory(temp_dir, monkeypatch):
     """TC4: Path is file not directory → Exit code 1, error."""
     runner = CliRunner()
-    
+
     file_path = temp_dir / "not-a-directory.txt"
     file_path.write_text("test")
-    
+
     project_dir = temp_dir / "project"
     project_dir.mkdir()
     monkeypatch.chdir(project_dir)
-    
+
     result = runner.invoke(main, ["warehouse", "connect", "--path", str(file_path)])
-    
+
     assert result.exit_code == 1
 
 
 def test_connect_overwrites_existing_connection(valid_warehouse, temp_dir, monkeypatch):
     """TC5: Already connected → Overwrites with new connection."""
     runner = CliRunner()
-    
+
     warehouse2 = temp_dir / "warehouse2"
     warehouse2.mkdir()
     (warehouse2 / "contexts").mkdir()
@@ -134,39 +139,45 @@ def test_connect_overwrites_existing_connection(valid_warehouse, temp_dir, monke
     (warehouse2 / "skills").mkdir()
     (warehouse2 / "docs").mkdir()
     (warehouse2 / "README.md").write_text("# Warehouse 2")
-    
+
     project_dir = temp_dir / "project"
     project_dir.mkdir()
     monkeypatch.chdir(project_dir)
-    
-    result1 = runner.invoke(main, ["warehouse", "connect", "--path", str(valid_warehouse)])
+
+    result1 = runner.invoke(
+        main, ["warehouse", "connect", "--path", str(valid_warehouse)]
+    )
     assert result1.exit_code == 0
-    
+
     config_path = project_dir / ".agentic-beacon" / "config.toml"
     first_content = config_path.read_text()
     assert str(valid_warehouse) in first_content
-    
+
     result2 = runner.invoke(main, ["warehouse", "connect", "--path", str(warehouse2)])
     assert result2.exit_code == 0
-    
+
     second_content = config_path.read_text()
     assert str(warehouse2) in second_content
     assert str(valid_warehouse) not in second_content
 
 
-def test_connect_creates_agentic_beacon_directory(valid_warehouse, temp_dir, monkeypatch):
+def test_connect_creates_agentic_beacon_directory(
+    valid_warehouse, temp_dir, monkeypatch
+):
     """TC8: No .agentic-beacon directory → Creates directory, then saves config."""
     runner = CliRunner()
-    
+
     project_dir = temp_dir / "project"
     project_dir.mkdir()
     monkeypatch.chdir(project_dir)
-    
+
     beacon_dir = project_dir / ".agentic-beacon"
     assert not beacon_dir.exists()
-    
-    result = runner.invoke(main, ["warehouse", "connect", "--path", str(valid_warehouse)])
-    
+
+    result = runner.invoke(
+        main, ["warehouse", "connect", "--path", str(valid_warehouse)]
+    )
+
     assert result.exit_code == 0
     assert beacon_dir.exists()
     assert beacon_dir.is_dir()
@@ -179,17 +190,15 @@ def test_connect_creates_agentic_beacon_directory(valid_warehouse, temp_dir, mon
 def test_connect_interactive_prompts_for_path(valid_warehouse, temp_dir, monkeypatch):
     """TC: Interactive mode prompts for warehouse path when --path not provided."""
     runner = CliRunner()
-    
+
     project_dir = temp_dir / "project"
     project_dir.mkdir()
     monkeypatch.chdir(project_dir)
-    
+
     result = runner.invoke(
-        main, 
-        ["warehouse", "connect"],
-        input=str(valid_warehouse) + "\n"
+        main, ["warehouse", "connect"], input=str(valid_warehouse) + "\n"
     )
-    
+
     assert result.exit_code == 0
     assert "Warehouse path" in result.output
     assert "✓ Connected to warehouse" in result.output
@@ -201,20 +210,22 @@ def test_connect_interactive_prompts_for_path(valid_warehouse, temp_dir, monkeyp
 def test_connect_validates_before_persisting(temp_dir, monkeypatch):
     """TC: Validation runs before persistence, errors displayed clearly."""
     runner = CliRunner()
-    
+
     invalid_warehouse = temp_dir / "invalid"
     invalid_warehouse.mkdir()
-    
+
     project_dir = temp_dir / "project"
     project_dir.mkdir()
     monkeypatch.chdir(project_dir)
-    
-    result = runner.invoke(main, ["warehouse", "connect", "--path", str(invalid_warehouse)])
-    
+
+    result = runner.invoke(
+        main, ["warehouse", "connect", "--path", str(invalid_warehouse)]
+    )
+
     assert result.exit_code == 1
     assert "Invalid warehouse structure" in result.output
     assert "✗" in result.output or "Missing" in result.output
-    
+
     config_path = project_dir / ".agentic-beacon" / "config.toml"
     assert not config_path.exists()
 
@@ -222,38 +233,48 @@ def test_connect_validates_before_persisting(temp_dir, monkeypatch):
 def test_connect_validation_errors_are_detailed(temp_dir, monkeypatch):
     """TC: Validation errors list specific missing directories/files."""
     runner = CliRunner()
-    
+
     invalid_warehouse = temp_dir / "invalid"
     invalid_warehouse.mkdir()
-    
+
     project_dir = temp_dir / "project"
     project_dir.mkdir()
     monkeypatch.chdir(project_dir)
-    
-    result = runner.invoke(main, ["warehouse", "connect", "--path", str(invalid_warehouse)])
-    
+
+    result = runner.invoke(
+        main, ["warehouse", "connect", "--path", str(invalid_warehouse)]
+    )
+
     assert result.exit_code == 1
-    assert "contexts" in result.output or "knowledge" in result.output or "skills" in result.output
+    assert (
+        "contexts" in result.output
+        or "knowledge" in result.output
+        or "skills" in result.output
+    )
 
 
 # ========== Task 3.5: Connection Persistence ==========
 
 
-def test_connect_creates_config_toml_with_absolute_path(valid_warehouse, temp_dir, monkeypatch):
+def test_connect_creates_config_toml_with_absolute_path(
+    valid_warehouse, temp_dir, monkeypatch
+):
     """TC: Creates .agentic-beacon/config.toml with absolute warehouse path."""
     runner = CliRunner()
-    
+
     project_dir = temp_dir / "project"
     project_dir.mkdir()
     monkeypatch.chdir(project_dir)
-    
-    result = runner.invoke(main, ["warehouse", "connect", "--path", str(valid_warehouse)])
-    
+
+    result = runner.invoke(
+        main, ["warehouse", "connect", "--path", str(valid_warehouse)]
+    )
+
     assert result.exit_code == 0
-    
+
     config_path = project_dir / ".agentic-beacon" / "config.toml"
     assert config_path.exists()
-    
+
     config_content = config_path.read_text()
     assert "[warehouse]" in config_content
     assert "local_path" in config_content
@@ -261,27 +282,31 @@ def test_connect_creates_config_toml_with_absolute_path(valid_warehouse, temp_di
     assert str(valid_warehouse) in config_content
 
 
-def test_connect_config_toml_has_correct_structure(valid_warehouse, temp_dir, monkeypatch):
+def test_connect_config_toml_has_correct_structure(
+    valid_warehouse, temp_dir, monkeypatch
+):
     """TC: config.toml contains correct TOML structure."""
     runner = CliRunner()
-    
+
     project_dir = temp_dir / "project"
     project_dir.mkdir()
     monkeypatch.chdir(project_dir)
-    
-    result = runner.invoke(main, ["warehouse", "connect", "--path", str(valid_warehouse)])
-    
+
+    result = runner.invoke(
+        main, ["warehouse", "connect", "--path", str(valid_warehouse)]
+    )
+
     assert result.exit_code == 0
-    
+
     config_path = project_dir / ".agentic-beacon" / "config.toml"
     config_content = config_path.read_text()
-    
+
     # Use tomllib (Python 3.11+) or skip test if not available
     try:
         import tomllib
     except ImportError:
         pytest.skip("tomllib/tomli not available")
-    
+
     parsed = tomllib.loads(config_content)
     assert "warehouse" in parsed
     assert "local_path" in parsed["warehouse"]
@@ -293,13 +318,15 @@ def test_connect_config_toml_has_correct_structure(valid_warehouse, temp_dir, mo
 def test_connect_shows_validation_confirmation(valid_warehouse, temp_dir, monkeypatch):
     """TC: Success message includes validation confirmation."""
     runner = CliRunner()
-    
+
     project_dir = temp_dir / "project"
     project_dir.mkdir()
     monkeypatch.chdir(project_dir)
-    
-    result = runner.invoke(main, ["warehouse", "connect", "--path", str(valid_warehouse)])
-    
+
+    result = runner.invoke(
+        main, ["warehouse", "connect", "--path", str(valid_warehouse)]
+    )
+
     assert result.exit_code == 0
     assert "✓ Warehouse structure validated" in result.output
 
@@ -307,13 +334,15 @@ def test_connect_shows_validation_confirmation(valid_warehouse, temp_dir, monkey
 def test_connect_shows_connection_confirmation(valid_warehouse, temp_dir, monkeypatch):
     """TC: Success message includes connection confirmation with path."""
     runner = CliRunner()
-    
+
     project_dir = temp_dir / "project"
     project_dir.mkdir()
     monkeypatch.chdir(project_dir)
-    
-    result = runner.invoke(main, ["warehouse", "connect", "--path", str(valid_warehouse)])
-    
+
+    result = runner.invoke(
+        main, ["warehouse", "connect", "--path", str(valid_warehouse)]
+    )
+
     assert result.exit_code == 0
     assert "✓ Connected to warehouse" in result.output
     # Check that Location field is shown (path may be wrapped by Rich console)
@@ -323,13 +352,15 @@ def test_connect_shows_connection_confirmation(valid_warehouse, temp_dir, monkey
 def test_connect_shows_next_steps(valid_warehouse, temp_dir, monkeypatch):
     """TC: Success message suggests next commands to run."""
     runner = CliRunner()
-    
+
     project_dir = temp_dir / "project"
     project_dir.mkdir()
     monkeypatch.chdir(project_dir)
-    
-    result = runner.invoke(main, ["warehouse", "connect", "--path", str(valid_warehouse)])
-    
+
+    result = runner.invoke(
+        main, ["warehouse", "connect", "--path", str(valid_warehouse)]
+    )
+
     assert result.exit_code == 0
     assert "Next Steps" in result.output
     assert "abc setup" in result.output
@@ -342,47 +373,57 @@ def test_connect_shows_next_steps(valid_warehouse, temp_dir, monkeypatch):
 def test_connect_shows_validation_progress(valid_warehouse, temp_dir, monkeypatch):
     """TC: Shows progress message during validation."""
     runner = CliRunner()
-    
+
     project_dir = temp_dir / "project"
     project_dir.mkdir()
     monkeypatch.chdir(project_dir)
-    
-    result = runner.invoke(main, ["warehouse", "connect", "--path", str(valid_warehouse)])
-    
+
+    result = runner.invoke(
+        main, ["warehouse", "connect", "--path", str(valid_warehouse)]
+    )
+
     assert result.exit_code == 0
     assert "Validating" in result.output
 
 
-def test_connect_shows_connection_saved_progress(valid_warehouse, temp_dir, monkeypatch):
+def test_connect_shows_connection_saved_progress(
+    valid_warehouse, temp_dir, monkeypatch
+):
     """TC: Shows progress message when connection is saved."""
     runner = CliRunner()
-    
+
     project_dir = temp_dir / "project"
     project_dir.mkdir()
     monkeypatch.chdir(project_dir)
-    
-    result = runner.invoke(main, ["warehouse", "connect", "--path", str(valid_warehouse)])
-    
+
+    result = runner.invoke(
+        main, ["warehouse", "connect", "--path", str(valid_warehouse)]
+    )
+
     assert result.exit_code == 0
     assert "✓ Connection saved" in result.output
 
 
-def test_connect_progress_indicators_appear_in_order(valid_warehouse, temp_dir, monkeypatch):
+def test_connect_progress_indicators_appear_in_order(
+    valid_warehouse, temp_dir, monkeypatch
+):
     """TC: Progress indicators appear in logical order."""
     runner = CliRunner()
-    
+
     project_dir = temp_dir / "project"
     project_dir.mkdir()
     monkeypatch.chdir(project_dir)
-    
-    result = runner.invoke(main, ["warehouse", "connect", "--path", str(valid_warehouse)])
-    
+
+    result = runner.invoke(
+        main, ["warehouse", "connect", "--path", str(valid_warehouse)]
+    )
+
     assert result.exit_code == 0
-    
+
     output = result.output
     validating_pos = output.find("Validating")
     validated_pos = output.find("✓ Warehouse structure validated")
     saved_pos = output.find("✓ Connection saved")
     connected_pos = output.find("✓ Connected to warehouse")
-    
+
     assert validating_pos < validated_pos < saved_pos < connected_pos

--- a/libs/beacon/tests/conftest.py
+++ b/libs/beacon/tests/conftest.py
@@ -1,8 +1,10 @@
 """pytest configuration and shared fixtures."""
-import pytest
-from pathlib import Path
-import tempfile
+
 import shutil
+import tempfile
+from pathlib import Path
+
+import pytest
 
 
 @pytest.fixture

--- a/libs/beacon/tests/core/test_beacon_yaml_parser.py
+++ b/libs/beacon/tests/core/test_beacon_yaml_parser.py
@@ -12,16 +12,20 @@ Test Coverage:
 - TC9: File is directory not file → Raises IsADirectoryError
 - TC10: Permission denied reading file → Raises PermissionError with clear message
 """
-import pytest
+
 from pathlib import Path
+
+import pytest
+from beacon.core.exceptions import ValidationError, YAMLParseError
 from beacon.core.settings import BeaconSettings
-from beacon.core.exceptions import YAMLParseError, ValidationError
 
 
 class TestBeaconYAMLParser:
     """Test suite for BeaconSettings.from_yaml() - Task 1.1"""
 
-    def test_tc1_valid_complete_beacon_yaml(self, temp_dir, sample_beacon_yaml_complete):
+    def test_tc1_valid_complete_beacon_yaml(
+        self, temp_dir, sample_beacon_yaml_complete
+    ):
         """TC1: Valid complete beacon.yaml → Returns BeaconSettings with all artifact types populated"""
         beacon_file = temp_dir / "beacon.yaml"
         beacon_file.write_text(sample_beacon_yaml_complete)
@@ -74,8 +78,11 @@ artifacts:
 
         with pytest.raises(YAMLParseError) as exc_info:
             BeaconSettings.from_yaml(str(beacon_file))
-        
-        assert "syntax" in str(exc_info.value).lower() or "parse" in str(exc_info.value).lower()
+
+        assert (
+            "syntax" in str(exc_info.value).lower()
+            or "parse" in str(exc_info.value).lower()
+        )
 
     def test_tc5_missing_artifacts_root_key(self, temp_dir):
         """TC5: Missing artifacts root key → Raises ValidationError "Missing required 'artifacts' section" """
@@ -87,7 +94,7 @@ knowledge:
 
         with pytest.raises(ValidationError) as exc_info:
             BeaconSettings.from_yaml(str(beacon_file))
-        
+
         assert "artifacts" in str(exc_info.value).lower()
 
     def test_tc6_artifact_type_not_a_list(self, temp_dir):
@@ -100,9 +107,12 @@ artifacts:
 
         with pytest.raises(ValidationError) as exc_info:
             BeaconSettings.from_yaml(str(beacon_file))
-        
+
         # Pydantic should complain about type mismatch
-        assert "list" in str(exc_info.value).lower() or "type" in str(exc_info.value).lower()
+        assert (
+            "list" in str(exc_info.value).lower()
+            or "type" in str(exc_info.value).lower()
+        )
 
     def test_tc7_unknown_artifact_type(self, temp_dir):
         """TC7: Unknown artifact type → Raises ValidationError listing unknown type"""
@@ -117,10 +127,12 @@ artifacts:
 
         with pytest.raises(ValidationError) as exc_info:
             BeaconSettings.from_yaml(str(beacon_file))
-        
+
         error_str = str(exc_info.value).lower()
         # Should mention the unknown field
-        assert "unknown" in error_str or "extra" in error_str or "unexpected" in error_str
+        assert (
+            "unknown" in error_str or "extra" in error_str or "unexpected" in error_str
+        )
 
     def test_tc8_file_not_found(self, temp_dir):
         """TC8: File not found → Raises FileNotFoundError with helpful message"""
@@ -128,8 +140,10 @@ artifacts:
 
         with pytest.raises(FileNotFoundError) as exc_info:
             BeaconSettings.from_yaml(str(non_existent_file))
-        
-        assert "non_existent.yaml" in str(exc_info.value) or str(non_existent_file) in str(exc_info.value)
+
+        assert "non_existent.yaml" in str(exc_info.value) or str(
+            non_existent_file
+        ) in str(exc_info.value)
 
     def test_tc9_file_is_directory(self, temp_dir):
         """TC9: File is directory not file → Raises IsADirectoryError"""
@@ -139,20 +153,25 @@ artifacts:
         with pytest.raises(IsADirectoryError):
             BeaconSettings.from_yaml(str(dir_path))
 
-    @pytest.mark.skipif(not hasattr(Path, 'chmod'), reason="chmod not available on this platform")
+    @pytest.mark.skipif(
+        not hasattr(Path, "chmod"), reason="chmod not available on this platform"
+    )
     def test_tc10_permission_denied(self, temp_dir, sample_beacon_yaml_complete):
         """TC10: Permission denied reading file → Raises PermissionError with clear message"""
         beacon_file = temp_dir / "beacon.yaml"
         beacon_file.write_text(sample_beacon_yaml_complete)
-        
+
         # Remove read permissions
         beacon_file.chmod(0o000)
-        
+
         try:
             with pytest.raises(PermissionError) as exc_info:
                 BeaconSettings.from_yaml(str(beacon_file))
-            
-            assert "permission" in str(exc_info.value).lower() or "denied" in str(exc_info.value).lower()
+
+            assert (
+                "permission" in str(exc_info.value).lower()
+                or "denied" in str(exc_info.value).lower()
+            )
         finally:
             # Restore permissions for cleanup
             beacon_file.chmod(0o644)

--- a/libs/beacon/tests/core/test_config_toml_parser.py
+++ b/libs/beacon/tests/core/test_config_toml_parser.py
@@ -12,9 +12,11 @@ Test Coverage:
 - TC9: local_path is not a string → Raises ValidationError "local_path must be string"
 - TC10: Extra unknown keys in config → Ignored gracefully (extra="ignore" in model_config)
 """
-import pytest
+
 import os
 from pathlib import Path
+
+import pytest
 from beacon.core.settings import WarehouseSettings
 from pydantic import ValidationError
 
@@ -22,7 +24,9 @@ from pydantic import ValidationError
 class TestConfigTomlParser:
     """Test suite for WarehouseSettings - Task 1.2"""
 
-    def test_tc1_valid_config_with_warehouse_section(self, temp_dir, sample_config_toml_valid):
+    def test_tc1_valid_config_with_warehouse_section(
+        self, temp_dir, sample_config_toml_valid
+    ):
         """TC1: Valid config.toml with warehouse section → Returns WarehouseSettings with local_path set"""
         config_file = temp_dir / ".agentic-beacon" / "config.toml"
         config_file.parent.mkdir(exist_ok=True)
@@ -33,7 +37,7 @@ class TestConfigTomlParser:
         try:
             os.chdir(temp_dir)
             settings = WarehouseSettings()
-            
+
             assert isinstance(settings, WarehouseSettings)
             assert settings.warehouse.local_path == "/absolute/path/to/warehouse"
         finally:
@@ -52,13 +56,15 @@ local_path = "/usr/local/warehouse"
         try:
             os.chdir(temp_dir)
             settings = WarehouseSettings()
-            
+
             assert settings.warehouse.local_path == "/usr/local/warehouse"
             assert Path(settings.warehouse.local_path).is_absolute()
         finally:
             os.chdir(original_cwd)
 
-    def test_tc3_relative_path_raises_error(self, temp_dir, sample_config_toml_relative):
+    def test_tc3_relative_path_raises_error(
+        self, temp_dir, sample_config_toml_relative
+    ):
         """TC3: Valid config with relative path → Raises ValidationError "local_path must be absolute" """
         config_file = temp_dir / ".agentic-beacon" / "config.toml"
         config_file.parent.mkdir(exist_ok=True)
@@ -67,10 +73,10 @@ local_path = "/usr/local/warehouse"
         original_cwd = os.getcwd()
         try:
             os.chdir(temp_dir)
-            
+
             with pytest.raises(ValidationError) as exc_info:
                 WarehouseSettings()
-            
+
             error_str = str(exc_info.value).lower()
             assert "absolute" in error_str or "path" in error_str
         finally:
@@ -88,12 +94,15 @@ key = "value"
         original_cwd = os.getcwd()
         try:
             os.chdir(temp_dir)
-            
+
             with pytest.raises(ValidationError) as exc_info:
                 WarehouseSettings()
-            
+
             # Pydantic should complain about missing required field
-            assert "local_path" in str(exc_info.value).lower() or "required" in str(exc_info.value).lower()
+            assert (
+                "local_path" in str(exc_info.value).lower()
+                or "required" in str(exc_info.value).lower()
+            )
         finally:
             os.chdir(original_cwd)
 
@@ -109,10 +118,10 @@ other_key = "value"
         original_cwd = os.getcwd()
         try:
             os.chdir(temp_dir)
-            
+
             with pytest.raises(ValidationError) as exc_info:
                 WarehouseSettings()
-            
+
             assert "local_path" in str(exc_info.value).lower()
         finally:
             os.chdir(original_cwd)
@@ -129,8 +138,8 @@ invalid syntax here
         original_cwd = os.getcwd()
         try:
             os.chdir(temp_dir)
-            
-            with pytest.raises(Exception):  # Pydantic or TOML parsing error
+
+            with pytest.raises(Exception):  # noqa: B017  # Pydantic or TOML parsing error
                 WarehouseSettings()
         finally:
             os.chdir(original_cwd)
@@ -147,10 +156,10 @@ local_path = ""
         original_cwd = os.getcwd()
         try:
             os.chdir(temp_dir)
-            
+
             with pytest.raises(ValidationError) as exc_info:
                 WarehouseSettings()
-            
+
             error_str = str(exc_info.value).lower()
             assert "empty" in error_str or "path" in error_str
         finally:
@@ -159,11 +168,11 @@ local_path = ""
     def test_tc8_config_file_not_found(self, temp_dir):
         """TC8: File not found → Pydantic raises validation error (no graceful handling for BaseSettings)"""
         # No config.toml created
-        
+
         original_cwd = os.getcwd()
         try:
             os.chdir(temp_dir)
-            
+
             with pytest.raises(ValidationError):
                 WarehouseSettings()
         finally:
@@ -181,10 +190,10 @@ local_path = 12345
         original_cwd = os.getcwd()
         try:
             os.chdir(temp_dir)
-            
+
             with pytest.raises(ValidationError) as exc_info:
                 WarehouseSettings()
-            
+
             error_str = str(exc_info.value).lower()
             assert "string" in error_str or "str" in error_str or "type" in error_str
         finally:
@@ -205,10 +214,10 @@ another_unknown = 123
         try:
             os.chdir(temp_dir)
             settings = WarehouseSettings()
-            
+
             # Should succeed without errors
             assert settings.warehouse.local_path == "/absolute/path/warehouse"
             # Unknown keys should not be accessible
-            assert not hasattr(settings, 'unknown_key')
+            assert not hasattr(settings, "unknown_key")
         finally:
             os.chdir(original_cwd)

--- a/libs/beacon/tests/core/test_delta_comparator.py
+++ b/libs/beacon/tests/core/test_delta_comparator.py
@@ -8,11 +8,12 @@ Following TDD workflow for tasks 8.1-8.6:
 - Task 8.6: Color output support
 """
 
-import os
 import pytest
-from pathlib import Path
-from beacon.core.delta import DeltaComparator, DeltaStatus, ComparisonResult, DeltaSummary
-
+from beacon.core.delta import (
+    ComparisonResult,
+    DeltaComparator,
+    DeltaStatus,
+)
 
 # ========== Task 8.1: DeltaComparator Class Creation ==========
 
@@ -169,6 +170,7 @@ def test_hash_file_is_directory(valid_warehouse, temp_dir):
 def test_hash_is_sha256(valid_warehouse, temp_dir):
     """TC11: Hash algorithm is SHA256 → Verify specific algorithm used."""
     import hashlib
+
     test_file = temp_dir / "test.md"
     test_file.write_text("test content")
 
@@ -328,7 +330,9 @@ def test_summary_filter_properties(valid_warehouse, temp_dir):
     (valid_warehouse / "knowledge" / "missing.md").write_text("warehouse only")
 
     comparator = DeltaComparator(valid_warehouse, artifacts_dir)
-    summary = comparator.compare_all(["knowledge/same.md", "knowledge/modified.md", "knowledge/missing.md"])
+    summary = comparator.compare_all(
+        ["knowledge/same.md", "knowledge/modified.md", "knowledge/missing.md"]
+    )
 
     assert len(summary.identical) == 1
     assert len(summary.modified) == 1

--- a/libs/beacon/tests/core/test_directory_validation.py
+++ b/libs/beacon/tests/core/test_directory_validation.py
@@ -12,11 +12,13 @@ Test Coverage:
 - TC9: Directory is empty → Passes (contents validated separately)
 - TC10: Validation called multiple times → Consistent results (idempotent)
 """
-import pytest
+
 import os
 from pathlib import Path
-from beacon.core.settings import validate_beacon_directory
+
+import pytest
 from beacon.core.exceptions import DirectoryNotFoundError
+from beacon.core.settings import validate_beacon_directory
 
 
 class TestDirectoryValidation:
@@ -38,13 +40,17 @@ class TestDirectoryValidation:
         original_cwd = os.getcwd()
         try:
             os.chdir(temp_dir)
-            
+
             with pytest.raises((DirectoryNotFoundError, FileNotFoundError)) as exc_info:
                 validate_beacon_directory()
-            
+
             error_msg = str(exc_info.value).lower()
             # Should have actionable message
-            assert "abc setup" in error_msg or "initialize" in error_msg or "not found" in error_msg
+            assert (
+                "abc setup" in error_msg
+                or "initialize" in error_msg
+                or "not found" in error_msg
+            )
         finally:
             os.chdir(original_cwd)
 
@@ -53,24 +59,24 @@ class TestDirectoryValidation:
         # Create a file instead of directory
         beacon_file = temp_dir / ".agentic-beacon"
         beacon_file.write_text("not a directory")
-        
+
         original_cwd = os.getcwd()
         try:
             os.chdir(temp_dir)
-            
+
             with pytest.raises(NotADirectoryError):
                 validate_beacon_directory()
         finally:
             os.chdir(original_cwd)
 
-    @pytest.mark.skipif(not hasattr(Path, 'chmod'), reason="chmod not available")
+    @pytest.mark.skipif(not hasattr(Path, "chmod"), reason="chmod not available")
     def test_tc4_directory_unreadable(self, temp_dir, beacon_dir):
         """TC4: Directory exists but unreadable → Raises PermissionError"""
         original_cwd = os.getcwd()
         try:
             os.chdir(temp_dir)
             beacon_dir.chmod(0o000)
-            
+
             try:
                 with pytest.raises(PermissionError):
                     validate_beacon_directory()
@@ -90,12 +96,14 @@ class TestDirectoryValidation:
         finally:
             os.chdir(original_cwd)
 
-    @pytest.mark.skip(reason="Feature not implemented: Directory tree traversal to find project root. Current implementation only checks current directory.")
+    @pytest.mark.skip(
+        reason="Feature not implemented: Directory tree traversal to find project root. Current implementation only checks current directory."
+    )
     def test_tc6_validation_from_subdirectory(self, temp_dir, beacon_dir):
         """TC6: Validation called from subdirectory → Still finds project root's .agentic-beacon"""
         subdir = temp_dir / "subdir" / "nested"
         subdir.mkdir(parents=True)
-        
+
         original_cwd = os.getcwd()
         try:
             os.chdir(subdir)
@@ -110,13 +118,13 @@ class TestDirectoryValidation:
         # Create outer .agentic-beacon
         outer_beacon = temp_dir / ".agentic-beacon"
         outer_beacon.mkdir()
-        
+
         # Create nested directory with its own .agentic-beacon
         inner_project = temp_dir / "inner_project"
         inner_project.mkdir()
         inner_beacon = inner_project / ".agentic-beacon"
         inner_beacon.mkdir()
-        
+
         original_cwd = os.getcwd()
         try:
             # From inner project, should find inner .agentic-beacon
@@ -124,7 +132,7 @@ class TestDirectoryValidation:
             result = validate_beacon_directory()
             assert isinstance(result, Path)
             assert result.name == ".agentic-beacon"
-            
+
             # From outer project, should find outer .agentic-beacon
             os.chdir(temp_dir)
             result = validate_beacon_directory()
@@ -133,19 +141,21 @@ class TestDirectoryValidation:
         finally:
             os.chdir(original_cwd)
 
-    @pytest.mark.skip(reason="Feature not implemented: Symlink resolution. Current implementation checks path existence but doesn't follow symlinks explicitly.")
-    @pytest.mark.skipif(not hasattr(os, 'symlink'), reason="symlinks not supported")
+    @pytest.mark.skip(
+        reason="Feature not implemented: Symlink resolution. Current implementation checks path existence but doesn't follow symlinks explicitly."
+    )
+    @pytest.mark.skipif(not hasattr(os, "symlink"), reason="symlinks not supported")
     def test_tc8_symbolic_link(self, temp_dir):
         """TC8: Symbolic link to directory → Follows symlink and validates target"""
         # Create actual directory
         actual_dir = temp_dir / "actual_beacon"
         actual_dir.mkdir()
-        
+
         # Create symlink
         symlink_path = temp_dir / ".agentic-beacon"
         try:
             os.symlink(actual_dir, symlink_path)
-            
+
             original_cwd = os.getcwd()
             try:
                 os.chdir(temp_dir)
@@ -173,11 +183,11 @@ class TestDirectoryValidation:
         original_cwd = os.getcwd()
         try:
             os.chdir(temp_dir)
-            
+
             result1 = validate_beacon_directory()
             result2 = validate_beacon_directory()
             result3 = validate_beacon_directory()
-            
+
             assert result1 == result2 == result3
             assert isinstance(result1, Path)
         finally:

--- a/libs/beacon/tests/core/test_gitignore_manager.py
+++ b/libs/beacon/tests/core/test_gitignore_manager.py
@@ -8,10 +8,7 @@ Following TDD workflow for tasks 11.1-11.5:
 - Task 11.5: Append without destroying content
 """
 
-import pytest
-from pathlib import Path
-from beacon.core.gitignore import GitignoreManager, GITIGNORE_ENTRIES, SECTION_HEADER
-
+from beacon.core.gitignore import SECTION_HEADER, GitignoreManager
 
 # ========== Task 11.1 & 11.4: Create/update .gitignore with config.toml ==========
 
@@ -175,7 +172,9 @@ def test_proper_newline_separation(temp_dir):
 
     content = gitignore.read_text()
     # Should not have node_modules/ directly followed by # Agentic Beacon
-    assert "node_modules/\n\n" in content or "node_modules/\n# Agentic Beacon" in content
+    assert (
+        "node_modules/\n\n" in content or "node_modules/\n# Agentic Beacon" in content
+    )
 
 
 def test_comments_preserved(temp_dir):

--- a/libs/beacon/tests/core/test_settings_reading.py
+++ b/libs/beacon/tests/core/test_settings_reading.py
@@ -12,18 +12,22 @@ Test Coverage:
 - TC9: Load called multiple times → Idempotent behavior
 - TC10: Settings objects are independent → Can load one without the other
 """
-import pytest
+
 import os
-from pathlib import Path
+
+import pytest
+from beacon.core.exceptions import ValidationError as BeaconValidationError
+from beacon.core.exceptions import YAMLParseError
 from beacon.core.settings import BeaconSettings, WarehouseSettings
-from beacon.core.exceptions import YAMLParseError, ValidationError as BeaconValidationError
 from pydantic_core import ValidationError as PydanticValidationError
 
 
 class TestSettingsSelfReading:
     """Test suite for settings self-reading capabilities - Task 1.3"""
 
-    def test_tc1_warehouse_settings_auto_loads_toml(self, temp_dir, sample_config_toml_valid):
+    def test_tc1_warehouse_settings_auto_loads_toml(
+        self, temp_dir, sample_config_toml_valid
+    ):
         """TC1: WarehouseSettings() → Pydantic loads from config.toml automatically"""
         config_file = temp_dir / ".agentic-beacon" / "config.toml"
         config_file.parent.mkdir(exist_ok=True)
@@ -33,19 +37,21 @@ class TestSettingsSelfReading:
         try:
             os.chdir(temp_dir)
             settings = WarehouseSettings()
-            
+
             assert isinstance(settings, WarehouseSettings)
             assert settings.warehouse.local_path == "/absolute/path/to/warehouse"
         finally:
             os.chdir(original_cwd)
 
-    def test_tc2_beacon_settings_manually_parses_yaml(self, temp_dir, sample_beacon_yaml_complete):
+    def test_tc2_beacon_settings_manually_parses_yaml(
+        self, temp_dir, sample_beacon_yaml_complete
+    ):
         """TC2: BeaconSettings.from_yaml() → Manually parses YAML with validation"""
         beacon_file = temp_dir / "beacon.yaml"
         beacon_file.write_text(sample_beacon_yaml_complete)
 
         settings = BeaconSettings.from_yaml(str(beacon_file))
-        
+
         assert isinstance(settings, BeaconSettings)
         assert len(settings.artifacts.knowledge) > 0
 
@@ -54,7 +60,7 @@ class TestSettingsSelfReading:
         original_cwd = os.getcwd()
         try:
             os.chdir(temp_dir)
-            
+
             with pytest.raises((BeaconValidationError, PydanticValidationError)):
                 WarehouseSettings()
         finally:
@@ -63,7 +69,7 @@ class TestSettingsSelfReading:
     def test_tc4_beacon_yaml_missing_raises_error(self, temp_dir):
         """TC4: beacon.yaml missing → FileNotFoundError from from_yaml()"""
         non_existent = temp_dir / "missing.yaml"
-        
+
         with pytest.raises(FileNotFoundError):
             BeaconSettings.from_yaml(str(non_existent))
 
@@ -76,8 +82,8 @@ class TestSettingsSelfReading:
         original_cwd = os.getcwd()
         try:
             os.chdir(temp_dir)
-            
-            with pytest.raises(Exception):  # TOML parse or validation error
+
+            with pytest.raises(Exception):  # noqa: B017  # TOML parse or validation error
                 WarehouseSettings()
         finally:
             os.chdir(original_cwd)
@@ -122,27 +128,29 @@ class TestSettingsSelfReading:
 
         settings1 = BeaconSettings.from_yaml(str(beacon_file))
         settings2 = BeaconSettings.from_yaml(str(beacon_file))
-        
+
         # Should produce identical results
         assert settings1.artifacts.knowledge == settings2.artifacts.knowledge
         assert settings1.artifacts.skills == settings2.artifacts.skills
         assert settings1.artifacts.contexts == settings2.artifacts.contexts
 
-    def test_tc10_settings_are_independent(self, temp_dir, sample_beacon_yaml_complete, sample_config_toml_valid):
+    def test_tc10_settings_are_independent(
+        self, temp_dir, sample_beacon_yaml_complete, sample_config_toml_valid
+    ):
         """TC10: Settings objects are independent → Can load one without the other"""
         # Create only beacon.yaml
         beacon_file = temp_dir / "beacon.yaml"
         beacon_file.write_text(sample_beacon_yaml_complete)
-        
+
         # Should be able to load beacon without config
         beacon_settings = BeaconSettings.from_yaml(str(beacon_file))
         assert isinstance(beacon_settings, BeaconSettings)
-        
+
         # Create config.toml
         config_file = temp_dir / ".agentic-beacon" / "config.toml"
         config_file.parent.mkdir(exist_ok=True)
         config_file.write_text(sample_config_toml_valid)
-        
+
         # Should be able to load warehouse settings independently
         original_cwd = os.getcwd()
         try:

--- a/libs/beacon/tests/core/test_settings_writing.py
+++ b/libs/beacon/tests/core/test_settings_writing.py
@@ -12,11 +12,12 @@ Test Coverage:
 - TC9: WarehouseSettings() loads from written file → Pydantic reads TOML
 - TC10: BeaconSettings.from_yaml() loads from written file → Manual parser reads YAML
 """
-import pytest
+
 import os
 from pathlib import Path
+
+import pytest
 from beacon.core.settings import BeaconSettings, WarehouseSettings
-from beacon.core.exceptions import ValidationError
 
 
 class TestSettingsSelfWriting:
@@ -25,18 +26,18 @@ class TestSettingsSelfWriting:
     def test_tc1_warehouse_settings_from_path(self, temp_dir):
         """TC1: WarehouseSettings.from_path() → Validates path, writes TOML, returns settings"""
         warehouse_path = "/absolute/warehouse/path"
-        
+
         original_cwd = os.getcwd()
         try:
             os.chdir(temp_dir)
-            
+
             # Create settings from path
             settings = WarehouseSettings.from_path(warehouse_path)
-            
+
             # Verify settings were created correctly
             assert isinstance(settings, WarehouseSettings)
             assert settings.warehouse.local_path == warehouse_path
-            
+
             # Verify config.toml was written
             config_file = temp_dir / ".agentic-beacon" / "config.toml"
             assert config_file.exists()
@@ -55,11 +56,11 @@ class TestSettingsSelfWriting:
         try:
             os.chdir(temp_dir)
             settings = WarehouseSettings()
-            
+
             # Write to a different location
             output_file = temp_dir / "output_config.toml"
             settings.to_toml(str(output_file))
-            
+
             assert output_file.exists()
             assert "[warehouse]" in output_file.read_text()
         finally:
@@ -69,13 +70,13 @@ class TestSettingsSelfWriting:
         """TC3: beacon.to_yaml() → Writes beacon settings to YAML"""
         beacon_file = temp_dir / "beacon.yaml"
         beacon_file.write_text(sample_beacon_yaml_complete)
-        
+
         settings = BeaconSettings.from_yaml(str(beacon_file))
-        
+
         # Write to different location
         output_file = temp_dir / "output_beacon.yaml"
         settings.to_yaml(str(output_file))
-        
+
         assert output_file.exists()
         assert "artifacts:" in output_file.read_text()
 
@@ -84,11 +85,11 @@ class TestSettingsSelfWriting:
         original_cwd = os.getcwd()
         try:
             os.chdir(temp_dir)
-            
+
             # Relative paths should be rejected by validator
             with pytest.raises(ValueError) as exc_info:
                 WarehouseSettings.from_path("relative/path")
-            
+
             assert "absolute" in str(exc_info.value).lower()
         finally:
             os.chdir(original_cwd)
@@ -96,16 +97,17 @@ class TestSettingsSelfWriting:
     def test_tc5_tilde_expansion(self, temp_dir):
         """TC5: Write with ~ in path → Expands ~ to home directory"""
         import os
+
         original_cwd = os.getcwd()
         try:
             os.chdir(temp_dir)
-            
+
             # Use tilde path
             home = Path.home()
             warehouse_path = "~/test/warehouse"
-            
+
             settings = WarehouseSettings.from_path(warehouse_path)
-            
+
             # Should be expanded to absolute path with home directory
             assert settings.warehouse.local_path == str(home / "test" / "warehouse")
             assert settings.warehouse.local_path.startswith(str(home))
@@ -117,14 +119,14 @@ class TestSettingsSelfWriting:
         original_cwd = os.getcwd()
         try:
             os.chdir(temp_dir)
-            
+
             # Ensure directory doesn't exist
             beacon_dir = temp_dir / ".agentic-beacon"
             assert not beacon_dir.exists()
-            
+
             # Create settings - should create directory
-            settings = WarehouseSettings.from_path("/test/path")
-            
+            WarehouseSettings.from_path("/test/path")
+
             # Verify directory was created
             assert beacon_dir.exists()
             assert beacon_dir.is_dir()
@@ -136,12 +138,15 @@ class TestSettingsSelfWriting:
         original_cwd = os.getcwd()
         try:
             os.chdir(temp_dir)
-            
+
             # Empty path should raise error
             with pytest.raises(ValueError) as exc_info:
                 WarehouseSettings.from_path("")
-            
-            assert "empty" in str(exc_info.value).lower() or "path" in str(exc_info.value).lower()
+
+            assert (
+                "empty" in str(exc_info.value).lower()
+                or "path" in str(exc_info.value).lower()
+            )
         finally:
             os.chdir(original_cwd)
 
@@ -149,31 +154,33 @@ class TestSettingsSelfWriting:
         """TC8: Roundtrip write then read → Read returns exact same data"""
         beacon_file = temp_dir / "beacon.yaml"
         beacon_file.write_text(sample_beacon_yaml_complete)
-        
+
         # Load
         settings1 = BeaconSettings.from_yaml(str(beacon_file))
-        
+
         # Write
         output_file = temp_dir / "output.yaml"
         settings1.to_yaml(str(output_file))
-        
+
         # Read back
         settings2 = BeaconSettings.from_yaml(str(output_file))
-        
+
         # Should be identical
         assert settings1.artifacts.knowledge == settings2.artifacts.knowledge
         assert settings1.artifacts.skills == settings2.artifacts.skills
         assert settings1.artifacts.contexts == settings2.artifacts.contexts
 
-    def test_tc9_warehouse_loads_from_written_file(self, temp_dir, sample_config_toml_valid):
+    def test_tc9_warehouse_loads_from_written_file(
+        self, temp_dir, sample_config_toml_valid
+    ):
         """TC9: WarehouseSettings() loads from written file → Pydantic reads TOML"""
         config_dir = temp_dir / ".agentic-beacon"
         config_dir.mkdir()
         config_file = config_dir / "config.toml"
-        
+
         # Write manually
         config_file.write_text(sample_config_toml_valid)
-        
+
         # Load via Pydantic
         original_cwd = os.getcwd()
         try:
@@ -183,17 +190,19 @@ class TestSettingsSelfWriting:
         finally:
             os.chdir(original_cwd)
 
-    def test_tc10_beacon_loads_from_written_file(self, temp_dir, sample_beacon_yaml_complete):
+    def test_tc10_beacon_loads_from_written_file(
+        self, temp_dir, sample_beacon_yaml_complete
+    ):
         """TC10: BeaconSettings.from_yaml() loads from written file → Manual parser reads YAML"""
         beacon_file = temp_dir / "beacon.yaml"
-        
+
         # First create settings and write
         beacon_file.write_text(sample_beacon_yaml_complete)
         settings1 = BeaconSettings.from_yaml(str(beacon_file))
-        
+
         output_file = temp_dir / "written.yaml"
         settings1.to_yaml(str(output_file))
-        
+
         # Load from written file
         settings2 = BeaconSettings.from_yaml(str(output_file))
         assert len(settings2.artifacts.knowledge) == len(settings1.artifacts.knowledge)

--- a/libs/beacon/tests/core/test_structure_validation.py
+++ b/libs/beacon/tests/core/test_structure_validation.py
@@ -12,10 +12,10 @@ Test Coverage:
 - TC9: Mixed valid and invalid types → ValidationResult lists only invalid ones
 - TC10: Artifact paths with invalid characters → ValidationResult(valid=False) with path validation errors
 """
-import pytest
-from beacon.core.settings import BeaconSettings, BeaconYamlValidator
-from beacon.core.exceptions import ValidationError
 
+import pytest
+from beacon.core.exceptions import ValidationError
+from beacon.core.settings import BeaconSettings, BeaconYamlValidator
 
 # Create validator instance for tests
 validator = BeaconYamlValidator()
@@ -36,10 +36,10 @@ artifacts:
   contexts:
     - context1.md
 """)
-        
+
         settings = BeaconSettings.from_yaml(str(beacon_file))
         result = validator.validate_structure(settings)
-        
+
         assert result.valid is True
         assert len(result.errors) == 0
 
@@ -51,10 +51,10 @@ artifacts:
   knowledge:
     - file1.md
 """)
-        
+
         settings = BeaconSettings.from_yaml(str(beacon_file))
         result = validator.validate_structure(settings)
-        
+
         assert result.valid is True
 
     def test_tc3_unknown_artifact_type(self, temp_dir):
@@ -67,12 +67,15 @@ artifacts:
   plugins:
     - plugin1.md
 """)
-        
+
         # Should fail during parsing with ValidationError
         with pytest.raises(ValidationError) as exc_info:
             BeaconSettings.from_yaml(str(beacon_file))
-        
-        assert "plugins" in str(exc_info.value).lower() or "extra" in str(exc_info.value).lower()
+
+        assert (
+            "plugins" in str(exc_info.value).lower()
+            or "extra" in str(exc_info.value).lower()
+        )
 
     def test_tc4_non_string_item(self, temp_dir):
         """TC4: Artifact type with non-string item → ValidationResult(valid=False)"""
@@ -82,11 +85,14 @@ artifacts:
   knowledge:
     - 12345
 """)
-        
+
         with pytest.raises(ValidationError) as exc_info:
             BeaconSettings.from_yaml(str(beacon_file))
-        
-        assert "str" in str(exc_info.value).lower() or "string" in str(exc_info.value).lower()
+
+        assert (
+            "str" in str(exc_info.value).lower()
+            or "string" in str(exc_info.value).lower()
+        )
 
     def test_tc5_nested_list(self, temp_dir):
         """TC5: Artifact type with nested list → ValidationResult(valid=False)"""
@@ -94,10 +100,10 @@ artifacts:
         beacon_file.write_text("""
 artifacts:
   knowledge:
-    - 
+    -
       - nested.md
 """)
-        
+
         with pytest.raises(ValidationError):
             BeaconSettings.from_yaml(str(beacon_file))
 
@@ -109,20 +115,23 @@ artifacts:
   knowledge:
     key: value
 """)
-        
+
         with pytest.raises(ValidationError) as exc_info:
             BeaconSettings.from_yaml(str(beacon_file))
-        
-        assert "list" in str(exc_info.value).lower() or "array" in str(exc_info.value).lower()
+
+        assert (
+            "list" in str(exc_info.value).lower()
+            or "array" in str(exc_info.value).lower()
+        )
 
     def test_tc7_empty_lists(self, temp_dir, sample_beacon_yaml_empty):
         """TC7: Empty lists for all types → ValidationResult(valid=True)"""
         beacon_file = temp_dir / "beacon.yaml"
         beacon_file.write_text(sample_beacon_yaml_empty)
-        
+
         settings = BeaconSettings.from_yaml(str(beacon_file))
         result = validator.validate_structure(settings)
-        
+
         assert result.valid is True
 
     def test_tc8_multiple_unknown_types(self, temp_dir):
@@ -135,14 +144,16 @@ artifacts:
   extensions:
     - ext1.md
 """)
-        
+
         with pytest.raises(ValidationError) as exc_info:
             BeaconSettings.from_yaml(str(beacon_file))
-        
+
         # Should mention the unknown fields
         error_str = str(exc_info.value).lower()
         # At least one of the unknown types should be mentioned
-        assert "plugins" in error_str or "extensions" in error_str or "extra" in error_str
+        assert (
+            "plugins" in error_str or "extensions" in error_str or "extra" in error_str
+        )
 
     def test_tc9_mixed_valid_and_invalid(self, temp_dir):
         """TC9: Mixed valid and invalid types → ValidationResult lists only invalid ones"""
@@ -154,11 +165,14 @@ artifacts:
   invalid_type:
     - invalid.md
 """)
-        
+
         with pytest.raises(ValidationError) as exc_info:
             BeaconSettings.from_yaml(str(beacon_file))
-        
-        assert "invalid_type" in str(exc_info.value).lower() or "extra" in str(exc_info.value).lower()
+
+        assert (
+            "invalid_type" in str(exc_info.value).lower()
+            or "extra" in str(exc_info.value).lower()
+        )
 
     def test_tc10_invalid_path_characters(self, temp_dir):
         """TC10: Artifact paths with invalid characters → ValidationResult(valid=False)"""
@@ -171,7 +185,7 @@ artifacts:
     - valid/path/file.md
     - also-valid_file.md
 """)
-        
+
         # These should actually be valid paths
         settings = BeaconSettings.from_yaml(str(beacon_file))
         result = validator.validate_structure(settings)

--- a/libs/beacon/tests/core/test_sync_engine.py
+++ b/libs/beacon/tests/core/test_sync_engine.py
@@ -9,10 +9,10 @@ Covers tasks 6.1-6.5:
 
 Tasks 6.6-6.8 (--preserve, --prune, --verbose) covered in test_sync_preserve_prune.py.
 """
-import pytest
-import os
-from beacon.core.sync import SyncEngine
 
+import os
+
+from beacon.core.sync import SyncEngine
 
 # ========== Task 6.1 & 6.2: SyncEngine Creation and Pure Copy ==========
 
@@ -22,19 +22,16 @@ def test_sync_engine_copies_single_file(valid_warehouse, temp_dir):
     project_dir = temp_dir / "project"
     project_dir.mkdir()
     artifacts_dir = project_dir / ".agentic-beacon" / "artifacts"
-    
+
     # Create test file in warehouse
     test_file = valid_warehouse / "knowledge" / "test.md"
     test_file.parent.mkdir(parents=True, exist_ok=True)
     test_file.write_text("# Test content")
-    
-    engine = SyncEngine(
-        warehouse_path=valid_warehouse,
-        artifacts_path=artifacts_dir
-    )
-    
+
+    engine = SyncEngine(warehouse_path=valid_warehouse, artifacts_path=artifacts_dir)
+
     result = engine.copy_file("knowledge/test.md")
-    
+
     assert result.success
     copied_file = artifacts_dir / "knowledge" / "test.md"
     assert copied_file.exists()
@@ -48,19 +45,16 @@ def test_sync_engine_preserves_directory_structure(valid_warehouse, temp_dir):
     project_dir = temp_dir / "project"
     project_dir.mkdir()
     artifacts_dir = project_dir / ".agentic-beacon" / "artifacts"
-    
+
     # Create nested file in warehouse
     nested_file = valid_warehouse / "knowledge" / "languages" / "python" / "types.md"
     nested_file.parent.mkdir(parents=True, exist_ok=True)
     nested_file.write_text("# Python types")
-    
-    engine = SyncEngine(
-        warehouse_path=valid_warehouse,
-        artifacts_path=artifacts_dir
-    )
-    
+
+    engine = SyncEngine(warehouse_path=valid_warehouse, artifacts_path=artifacts_dir)
+
     result = engine.copy_file("knowledge/languages/python/types.md")
-    
+
     assert result.success
     copied_file = artifacts_dir / "knowledge" / "languages" / "python" / "types.md"
     assert copied_file.exists()
@@ -72,23 +66,20 @@ def test_sync_engine_overwrites_existing_file(valid_warehouse, temp_dir):
     project_dir = temp_dir / "project"
     project_dir.mkdir()
     artifacts_dir = project_dir / ".agentic-beacon" / "artifacts"
-    
+
     # Create file in both warehouse and artifacts
     warehouse_file = valid_warehouse / "knowledge" / "doc.md"
     warehouse_file.parent.mkdir(parents=True, exist_ok=True)
     warehouse_file.write_text("# Warehouse version")
-    
+
     local_file = artifacts_dir / "knowledge" / "doc.md"
     local_file.parent.mkdir(parents=True, exist_ok=True)
     local_file.write_text("# Old version")
-    
-    engine = SyncEngine(
-        warehouse_path=valid_warehouse,
-        artifacts_path=artifacts_dir
-    )
-    
+
+    engine = SyncEngine(warehouse_path=valid_warehouse, artifacts_path=artifacts_dir)
+
     result = engine.copy_file("knowledge/doc.md")
-    
+
     assert result.success
     assert local_file.read_text() == "# Warehouse version"
 
@@ -98,21 +89,18 @@ def test_sync_engine_no_symlinks_created(valid_warehouse, temp_dir):
     project_dir = temp_dir / "project"
     project_dir.mkdir()
     artifacts_dir = project_dir / ".agentic-beacon" / "artifacts"
-    
+
     # Create multiple files
     for i in range(3):
         test_file = valid_warehouse / "knowledge" / f"file{i}.md"
         test_file.parent.mkdir(parents=True, exist_ok=True)
         test_file.write_text(f"Content {i}")
-    
-    engine = SyncEngine(
-        warehouse_path=valid_warehouse,
-        artifacts_path=artifacts_dir
-    )
-    
+
+    engine = SyncEngine(warehouse_path=valid_warehouse, artifacts_path=artifacts_dir)
+
     for i in range(3):
         engine.copy_file(f"knowledge/file{i}.md")
-    
+
     # Verify none are symlinks
     for i in range(3):
         copied = artifacts_dir / "knowledge" / f"file{i}.md"
@@ -129,11 +117,13 @@ def test_expand_glob_with_double_star(valid_warehouse, tmp_path):
     (valid_warehouse / "knowledge" / "python" / "file1.md").write_text("test")
     (valid_warehouse / "knowledge" / "python" / "sub").mkdir(exist_ok=True)
     (valid_warehouse / "knowledge" / "python" / "sub" / "file2.md").write_text("test")
-    
-    engine = SyncEngine(warehouse_path=valid_warehouse, artifacts_path=tmp_path / "artifacts")
-    
+
+    engine = SyncEngine(
+        warehouse_path=valid_warehouse, artifacts_path=tmp_path / "artifacts"
+    )
+
     matches = engine.expand_glob("knowledge/python/**/*.md")
-    
+
     assert len(matches) == 2
     assert any("file1.md" in str(m) for m in matches)
     assert any("file2.md" in str(m) for m in matches)
@@ -146,21 +136,25 @@ def test_expand_glob_with_single_star(valid_warehouse, tmp_path):
     (valid_warehouse / "knowledge" / "file2.md").write_text("test")
     (valid_warehouse / "knowledge" / "sub").mkdir(exist_ok=True)
     (valid_warehouse / "knowledge" / "sub" / "file3.md").write_text("test")
-    
-    engine = SyncEngine(warehouse_path=valid_warehouse, artifacts_path=tmp_path / "artifacts")
-    
+
+    engine = SyncEngine(
+        warehouse_path=valid_warehouse, artifacts_path=tmp_path / "artifacts"
+    )
+
     matches = engine.expand_glob("knowledge/*.md")
-    
+
     assert len(matches) == 2  # Only top-level files, not subdirectory
     assert all("sub" not in str(m) for m in matches)
 
 
 def test_expand_glob_no_matches(valid_warehouse, tmp_path):
     """TC4: Pattern matching no files → Returns empty list, no error."""
-    engine = SyncEngine(warehouse_path=valid_warehouse, artifacts_path=tmp_path / "artifacts")
-    
+    engine = SyncEngine(
+        warehouse_path=valid_warehouse, artifacts_path=tmp_path / "artifacts"
+    )
+
     matches = engine.expand_glob("knowledge/nonexistent/**/*.md")
-    
+
     assert matches == []
 
 
@@ -169,11 +163,13 @@ def test_expand_glob_only_returns_files(valid_warehouse, tmp_path):
     (valid_warehouse / "knowledge" / "dir1").mkdir(parents=True, exist_ok=True)
     (valid_warehouse / "knowledge" / "dir1" / "file.md").write_text("test")
     (valid_warehouse / "knowledge" / "dir2").mkdir(exist_ok=True)
-    
-    engine = SyncEngine(warehouse_path=valid_warehouse, artifacts_path=tmp_path / "artifacts")
-    
+
+    engine = SyncEngine(
+        warehouse_path=valid_warehouse, artifacts_path=tmp_path / "artifacts"
+    )
+
     matches = engine.expand_glob("knowledge/**/*.md")
-    
+
     # Should only return file, not directories
     assert len(matches) == 1
     # Convert back to full paths to check they're files
@@ -188,31 +184,28 @@ def test_sync_skips_unchanged_files(valid_warehouse, temp_dir):
     project_dir = temp_dir / "project"
     project_dir.mkdir()
     artifacts_dir = project_dir / ".agentic-beacon" / "artifacts"
-    
+
     # Create test file
     test_file = valid_warehouse / "knowledge" / "doc.md"
     test_file.parent.mkdir(parents=True, exist_ok=True)
     test_file.write_text("# Content")
-    
-    engine = SyncEngine(
-        warehouse_path=valid_warehouse,
-        artifacts_path=artifacts_dir
-    )
-    
+
+    engine = SyncEngine(warehouse_path=valid_warehouse, artifacts_path=artifacts_dir)
+
     # First sync
     result1 = engine.copy_file("knowledge/doc.md")
     assert result1.success
     assert result1.action == "copied"
-    
+
     # Get modification time
     copied_file = artifacts_dir / "knowledge" / "doc.md"
     mtime1 = copied_file.stat().st_mtime
-    
+
     # Second sync - should detect no changes
     result2 = engine.copy_file("knowledge/doc.md")
     assert result2.success
     assert result2.action == "skipped"  # File unchanged
-    
+
     # File should not have been re-copied
     mtime2 = copied_file.stat().st_mtime
     assert mtime2 == mtime1

--- a/libs/beacon/tests/core/test_sync_preserve_prune.py
+++ b/libs/beacon/tests/core/test_sync_preserve_prune.py
@@ -3,10 +3,7 @@
 Following TDD workflow for tasks 6.6-6.8.
 """
 
-import pytest
-from pathlib import Path
-from beacon.core.sync import SyncEngine, SyncSummary
-
+from beacon.core.sync import SyncEngine
 
 # ========== Task 6.6: --preserve flag ==========
 
@@ -27,7 +24,9 @@ def test_preserve_skips_modified_local(valid_warehouse, temp_dir):
     assert result.success
     assert result.action == "preserved"
     # Local content should be unchanged
-    assert (artifacts_dir / "knowledge" / "doc.md").read_text() == "local modified version"
+    assert (
+        artifacts_dir / "knowledge" / "doc.md"
+    ).read_text() == "local modified version"
 
 
 def test_preserve_copies_new_files(valid_warehouse, temp_dir):
@@ -132,7 +131,7 @@ def test_verbose_logs_operations(valid_warehouse, temp_dir):
 
     engine = SyncEngine(valid_warehouse, artifacts_dir)
     log_messages = []
-    summary = engine.sync_all(
+    engine.sync_all(
         artifact_paths=["knowledge/doc.md"],
         verbose=True,
         log_fn=lambda msg: log_messages.append(msg),
@@ -156,7 +155,10 @@ def test_verbose_false_minimal_logs(valid_warehouse, temp_dir):
     )
 
     # Only error messages in log
-    assert all("Error" in msg for msg in summary.log_messages) or len(summary.log_messages) == 0
+    assert (
+        all("Error" in msg for msg in summary.log_messages)
+        or len(summary.log_messages) == 0
+    )
 
 
 # ========== sync_all Summary ==========
@@ -179,7 +181,11 @@ def test_sync_all_counts(valid_warehouse, temp_dir):
 
     engine = SyncEngine(valid_warehouse, artifacts_dir)
     summary = engine.sync_all(
-        artifact_paths=["knowledge/new.md", "knowledge/same.md", "knowledge/missing.md"],
+        artifact_paths=[
+            "knowledge/new.md",
+            "knowledge/same.md",
+            "knowledge/missing.md",
+        ],
     )
 
     assert summary.copied == 1

--- a/libs/beacon/tests/warehouse/test_distributor.py
+++ b/libs/beacon/tests/warehouse/test_distributor.py
@@ -5,10 +5,10 @@ Regression tests for:
   missing plain AGENTS.md files created by 'abc warehouse init'.
 - Bug #4: warehouse catalog Usage example showed old AGENTS.global.md format.
 """
+
 import pytest
-from pathlib import Path
-from beacon.distributor import WarehouseDistributor
 from beacon.cli import _generate_warehouse_catalog
+from beacon.distributor import WarehouseDistributor
 
 
 @pytest.fixture
@@ -52,9 +52,7 @@ def test_list_contexts_finds_plain_agents_md(warehouse_with_plain_agents_md, tem
 
     result = distributor.list_available()
 
-    assert len(result["contexts"]) == 1, (
-        f"Expected 1 context, got {result['contexts']}"
-    )
+    assert len(result["contexts"]) == 1, f"Expected 1 context, got {result['contexts']}"
     assert "contexts/AGENTS.md" in result["contexts"]
 
 

--- a/libs/beacon/tests/warehouse/test_files_validation.py
+++ b/libs/beacon/tests/warehouse/test_files_validation.py
@@ -12,10 +12,11 @@ Test Coverage:
 - TC9: All directories present, no README → Lists missing README only
 - TC10: Symlink to required file → Follows symlink and validates target exists
 """
-import pytest
+
 from pathlib import Path
+
+import pytest
 from beacon.warehouse import WarehouseValidator
-from beacon.core.settings import ValidationResult
 
 
 class TestWarehouseFilesValidation:
@@ -83,7 +84,7 @@ class TestWarehouseFilesValidation:
 
         assert result.valid is True
 
-    @pytest.mark.skipif(not hasattr(Path, 'chmod'), reason="chmod not available")
+    @pytest.mark.skipif(not hasattr(Path, "chmod"), reason="chmod not available")
     def test_tc5_context_file_unreadable_still_valid(self, temp_dir):
         """TC5: A context file is unreadable → Validation still passes (existence only)"""
         warehouse = temp_dir / "warehouse"
@@ -166,7 +167,9 @@ class TestWarehouseFilesValidation:
         # No errors about AGENTS.global.md — that is not enforced
         assert not any("AGENTS.global.md" in err for err in result.errors)
 
-    @pytest.mark.skipif(not hasattr(Path, 'symlink_to'), reason="symlinks not supported")
+    @pytest.mark.skipif(
+        not hasattr(Path, "symlink_to"), reason="symlinks not supported"
+    )
     def test_tc10_symlink_to_readme(self, temp_dir):
         """TC10: Symlink to README → Follows symlink and validates target exists"""
         warehouse = temp_dir / "warehouse"

--- a/libs/beacon/tests/warehouse/test_validator.py
+++ b/libs/beacon/tests/warehouse/test_validator.py
@@ -12,10 +12,12 @@ Test Coverage:
 - TC9: Path with spaces and special chars → Handles correctly
 - TC10: Symlink to valid warehouse → Follows symlink and validates target
 """
-import pytest
+
 from pathlib import Path
-from beacon.warehouse import WarehouseValidator
+
+import pytest
 from beacon.core.settings import ValidationResult
+from beacon.warehouse import WarehouseValidator
 
 
 class TestWarehouseValidator:
@@ -63,7 +65,10 @@ class TestWarehouseValidator:
 
         assert result.valid is False
         assert len(result.errors) > 0
-        assert any("not found" in err.lower() or "does not exist" in err.lower() for err in result.errors)
+        assert any(
+            "not found" in err.lower() or "does not exist" in err.lower()
+            for err in result.errors
+        )
 
     def test_tc4_path_is_file_not_directory(self, temp_dir):
         """TC4: Path is file not directory → ValidationResult(valid=False, errors=["Path is not a directory"])"""
@@ -74,7 +79,10 @@ class TestWarehouseValidator:
         result = validator.validate(str(file_path))
 
         assert result.valid is False
-        assert any("not a directory" in err.lower() or "not a dir" in err.lower() for err in result.errors)
+        assert any(
+            "not a directory" in err.lower() or "not a dir" in err.lower()
+            for err in result.errors
+        )
 
     def test_tc5_empty_directory(self, temp_dir):
         """TC5: Empty directory → ValidationResult(valid=False) with all missing directories listed"""
@@ -126,9 +134,10 @@ class TestWarehouseValidator:
         (warehouse / "README.md").write_text("# Warehouse")
 
         validator = WarehouseValidator()
-        
+
         # Use relative path
         import os
+
         original_cwd = os.getcwd()
         try:
             os.chdir(temp_dir)
@@ -152,7 +161,9 @@ class TestWarehouseValidator:
         assert isinstance(result, ValidationResult)
         # Should handle paths with spaces and special characters
 
-    @pytest.mark.skipif(not hasattr(Path, 'symlink_to'), reason="symlinks not supported")
+    @pytest.mark.skipif(
+        not hasattr(Path, "symlink_to"), reason="symlinks not supported"
+    )
     def test_tc10_symlink_to_valid_warehouse(self, temp_dir):
         """TC10: Symlink to valid warehouse → Follows symlink and validates target"""
         # Create actual warehouse
@@ -167,7 +178,7 @@ class TestWarehouseValidator:
         symlink = temp_dir / "warehouse_link"
         try:
             symlink.symlink_to(actual_warehouse)
-            
+
             validator = WarehouseValidator()
             result = validator.validate(str(symlink))
 

--- a/openspec/changes/config-based-artifact-management/design.md
+++ b/openspec/changes/config-based-artifact-management/design.md
@@ -78,11 +78,11 @@ artifacts:
     - languages/python/**/*.md          # Supports glob patterns
     - infrastructure/docker-standards.md
     - company-guidelines/git-commit-style.md
-  
+
   skills:
     - code-review
     - generate-unit-tests
-  
+
   contexts:
     - backend-microservice
 ```
@@ -412,7 +412,7 @@ $ abc delta knowledge/languages/python/fastapi-rules.md
 
 **Pre-release:**
 1. Update all internal examples and documentation to use `abc warehouse init`
-2. Update `examples/sample-warehouse/` generation scripts  
+2. Update `examples/sample-warehouse/` generation scripts
 3. Implement "project-setup" skill for agent-assisted beacon.yaml population
 4. Test three setup workflows (agent-assisted, copy, manual) on multiple platforms
 5. Create comprehensive documentation on config-based artifact management

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,8 @@ agentic-beacon = { workspace = true }
 dev = [
     "pytest>=7.0.0",
     "pytest-cov>=4.0.0",
+    "pre-commit>=3.0.0",
+    "ruff>=0.9.2",
 ]
 
 [tool.pytest.ini_options]
@@ -26,3 +28,29 @@ testpaths = ["libs/beacon/tests"]
 markers = [
     "integration: end-to-end tests that exercise the full CLI workflow (run with -m integration)",
 ]
+
+[tool.ruff.lint]
+select = [
+    "E",  # pycodestyle errors
+    "W",  # pycodestyle warnings
+    "F",  # pyflakes
+    "I",  # isort
+    "B",  # flake8-bugbear
+    "C4", # flake8-comprehensions
+    "UP", # pyupgrade
+]
+ignore = [
+    "E501", # line too long
+    "B008", # do not perform function calls in argument defaults
+    "C901", # too complex
+    "W191", # indentation contains tabs
+]
+
+[tool.ruff.lint.per-file-ignores]
+"__init__.py" = ["F401"]
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
+skip-magic-trailing-comma = false
+line-ending = "auto"

--- a/skills/record-knowledge/SKILL.md
+++ b/skills/record-knowledge/SKILL.md
@@ -303,5 +303,5 @@ When executing this skill:
 
 ---
 
-**Skill Version:** 1.0.0  
+**Skill Version:** 1.0.0
 **Last Updated:** 2026-03-07

--- a/uv.lock
+++ b/uv.lock
@@ -54,8 +54,10 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "ruff" },
 ]
 
 [package.metadata]
@@ -63,8 +65,10 @@ requires-dist = [{ name = "agentic-beacon", editable = "libs/beacon" }]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "pre-commit", specifier = ">=3.0.0" },
     { name = "pytest", specifier = ">=7.0.0" },
     { name = "pytest-cov", specifier = ">=4.0.0" },
+    { name = "ruff", specifier = ">=0.9.2" },
 ]
 
 [[package]]
@@ -134,6 +138,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d0/44/681604464ed9541673e486521497406fadcc15b5217c3e326b061696899a/cffi-2.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:28a3a209b96630bca57cce802da70c266eb08c6e97e5afd61a75611ee6c64592", size = 221584, upload-time = "2025-09-08T23:23:36.096Z" },
     { url = "https://files.pythonhosted.org/packages/25/8e/342a504ff018a2825d395d44d63a767dd8ebc927ebda557fecdaca3ac33a/cffi-2.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7553fb2090d71822f02c629afe6042c299edf91ba1bf94951165613553984512", size = 224443, upload-time = "2025-09-08T23:23:37.328Z" },
     { url = "https://files.pythonhosted.org/packages/e1/5e/b666bacbbc60fbf415ba9988324a132c9a7a0448a9a8f125074671c0f2c3/cffi-2.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c6c373cfc5c83a975506110d17457138c8c63016b563cc9ed6e056a82f13ce4", size = 223437, upload-time = "2025-09-08T23:23:38.945Z" },
+]
+
+[[package]]
+name = "cfgv"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/b5/721b8799b04bf9afe054a3899c6cf4e880fcf8563cc71c15610242490a0c/cfgv-3.5.0.tar.gz", hash = "sha256:d5b1034354820651caa73ede66a6294d6e95c1b00acc5e9b098e917404669132", size = 7334, upload-time = "2025-11-19T20:55:51.612Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl", hash = "sha256:a8dc6b26ad22ff227d2634a65cb388215ce6cc96bbcc5cfde7641ae87e8dacc0", size = 7445, upload-time = "2025-11-19T20:55:50.744Z" },
 ]
 
 [[package]]
@@ -343,12 +356,30 @@ wheels = [
 ]
 
 [[package]]
+name = "distlib"
+version = "0.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/96/8e/709914eb2b5749865801041647dc7f4e6d00b549cfe88b65ca192995f07c/distlib-0.4.0.tar.gz", hash = "sha256:feec40075be03a04501a973d81f633735b4b69f98b05450592310c0f401a4e0d", size = 614605, upload-time = "2025-07-17T16:52:00.465Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/6b/e0547afaf41bf2c42e52430072fa5658766e3d65bd4b03a563d1b6336f57/distlib-0.4.0-py2.py3-none-any.whl", hash = "sha256:9659f7d87e46584a30b5780e43ac7a2143098441670ff0a49d5f9034c54a6c16", size = 469047, upload-time = "2025-07-17T16:51:58.613Z" },
+]
+
+[[package]]
 name = "docutils"
 version = "0.22.4"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ae/b6/03bb70946330e88ffec97aefd3ea75ba575cb2e762061e0e62a213befee8/docutils-0.22.4.tar.gz", hash = "sha256:4db53b1fde9abecbb74d91230d32ab626d94f6badfc575d6db9194a49df29968", size = 2291750, upload-time = "2025-12-18T19:00:26.443Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/02/10/5da547df7a391dcde17f59520a231527b8571e6f46fc8efb02ccb370ab12/docutils-0.22.4-py3-none-any.whl", hash = "sha256:d0013f540772d1420576855455d050a2180186c91c15779301ac2ccb3eeb68de", size = 633196, upload-time = "2025-12-18T19:00:18.077Z" },
+]
+
+[[package]]
+name = "filelock"
+version = "3.25.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b3/8b/4c32ecde6bea6486a2a5d05340e695174351ff6b06cf651a74c005f9df00/filelock-3.25.1.tar.gz", hash = "sha256:b9a2e977f794ef94d77cdf7d27129ac648a61f585bff3ca24630c1629f701aa9", size = 40319, upload-time = "2026-03-09T19:38:47.309Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/b8/2f664b56a3b4b32d28d3d106c71783073f712ba43ff6d34b9ea0ce36dc7b/filelock-3.25.1-py3-none-any.whl", hash = "sha256:18972df45473c4aa2c7921b609ee9ca4925910cc3a0fb226c96b92fc224ef7bf", size = 26720, upload-time = "2026-03-09T19:38:45.718Z" },
 ]
 
 [[package]]
@@ -361,6 +392,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/6d/04/c2156091427636080787aac190019dc64096e56a23b7364d3c1764ee3a06/id-1.6.1.tar.gz", hash = "sha256:d0732d624fb46fd4e7bc4e5152f00214450953b9e772c182c1c22964def1a069", size = 18088, upload-time = "2026-02-04T16:19:41.26Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/42/77/de194443bf38daed9452139e960c632b0ef9f9a5dd9ce605fdf18ca9f1b1/id-1.6.1-py3-none-any.whl", hash = "sha256:f5ec41ed2629a508f5d0988eda142e190c9c6da971100612c4de9ad9f9b237ca", size = 14689, upload-time = "2026-02-04T16:19:40.051Z" },
+]
+
+[[package]]
+name = "identify"
+version = "2.6.17"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/84/376a3b96e5a8d33a7aa2c5b3b31a4b3c364117184bf0b17418055f6ace66/identify-2.6.17.tar.gz", hash = "sha256:f816b0b596b204c9fdf076ded172322f2723cf958d02f9c3587504834c8ff04d", size = 99579, upload-time = "2026-03-01T20:04:12.702Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/40/66/71c1227dff78aaeb942fed29dd5651f2aec166cc7c9aeea3e8b26a539b7d/identify-2.6.17-py2.py3-none-any.whl", hash = "sha256:be5f8412d5ed4b20f2bd41a65f920990bdccaa6a4a18a08f1eefdcd0bdd885f0", size = 99382, upload-time = "2026-03-01T20:04:11.439Z" },
 ]
 
 [[package]]
@@ -518,6 +558,15 @@ wheels = [
 ]
 
 [[package]]
+name = "nodeenv"
+version = "1.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.0"
 source = { registry = "https://pypi.org/simple" }
@@ -527,12 +576,37 @@ wheels = [
 ]
 
 [[package]]
+name = "platformdirs"
+version = "4.9.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/56/8d4c30c8a1d07013911a8fdbd8f89440ef9f08d07a1b50ab8ca8be5a20f9/platformdirs-4.9.4.tar.gz", hash = "sha256:1ec356301b7dc906d83f371c8f487070e99d3ccf9e501686456394622a01a934", size = 28737, upload-time = "2026-03-05T18:34:13.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/63/d7/97f7e3a6abb67d8080dd406fd4df842c2be0efaf712d1c899c32a075027c/platformdirs-4.9.4-py3-none-any.whl", hash = "sha256:68a9a4619a666ea6439f2ff250c12a853cd1cbd5158d258bd824a7df6be2f868", size = 21216, upload-time = "2026-03-05T18:34:12.172Z" },
+]
+
+[[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pre-commit"
+version = "4.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cfgv" },
+    { name = "identify" },
+    { name = "nodeenv" },
+    { name = "pyyaml" },
+    { name = "virtualenv" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/40/f1/6d86a29246dfd2e9b6237f0b5823717f60cad94d47ddc26afa916d21f525/pre_commit-4.5.1.tar.gz", hash = "sha256:eb545fcff725875197837263e977ea257a402056661f09dae08e4b149b030a61", size = 198232, upload-time = "2025-12-16T21:14:33.552Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/19/fd3ef348460c80af7bb4669ea7926651d1f95c23ff2df18b9d24bab4f3fa/pre_commit-4.5.1-py2.py3-none-any.whl", hash = "sha256:3b3afd891e97337708c1674210f8eba659b52a38ea5f822ff142d10786221f77", size = 226437, upload-time = "2025-12-16T21:14:32.409Z" },
 ]
 
 [[package]]
@@ -693,6 +767,19 @@ wheels = [
 ]
 
 [[package]]
+name = "python-discovery"
+version = "1.1.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "platformdirs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7a/16/6f3f5e9258f0733aaca19aa18e298cb3a629ae49363573e78d241abeef59/python_discovery-1.1.2.tar.gz", hash = "sha256:c500bd2153e3afc5f48a61d33ff570b6f3e710d36ceaaf882fa9bbe5cc2cec49", size = 56928, upload-time = "2026-03-09T20:02:28.402Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/48/8bdfaec240edb1a79b79201eff38b737fc3c29ce59e2e71271bdd8bafdda/python_discovery-1.1.2-py3-none-any.whl", hash = "sha256:d18edd61b382d62f8bcd004a71ebaabc87df31dbefb30aeed59f4fc6afa005be", size = 31486, upload-time = "2026-03-09T20:02:27.277Z" },
+]
+
+[[package]]
 name = "python-dotenv"
 version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
@@ -820,6 +907,31 @@ wheels = [
 ]
 
 [[package]]
+name = "ruff"
+version = "0.15.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/77/9b/840e0039e65fcf12758adf684d2289024d6140cde9268cc59887dc55189c/ruff-0.15.5.tar.gz", hash = "sha256:7c3601d3b6d76dce18c5c824fc8d06f4eef33d6df0c21ec7799510cde0f159a2", size = 4574214, upload-time = "2026-03-05T20:06:34.946Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/20/5369c3ce21588c708bcbe517a8fbe1a8dfdb5dfd5137e14790b1da71612c/ruff-0.15.5-py3-none-linux_armv6l.whl", hash = "sha256:4ae44c42281f42e3b06b988e442d344a5b9b72450ff3c892e30d11b29a96a57c", size = 10478185, upload-time = "2026-03-05T20:06:29.093Z" },
+    { url = "https://files.pythonhosted.org/packages/44/ed/e81dd668547da281e5dce710cf0bc60193f8d3d43833e8241d006720e42b/ruff-0.15.5-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:6edd3792d408ebcf61adabc01822da687579a1a023f297618ac27a5b51ef0080", size = 10859201, upload-time = "2026-03-05T20:06:32.632Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/8f/533075f00aaf19b07c5cd6aa6e5d89424b06b3b3f4583bfa9c640a079059/ruff-0.15.5-py3-none-macosx_11_0_arm64.whl", hash = "sha256:89f463f7c8205a9f8dea9d658d59eff49db05f88f89cc3047fb1a02d9f344010", size = 10184752, upload-time = "2026-03-05T20:06:40.312Z" },
+    { url = "https://files.pythonhosted.org/packages/66/0e/ba49e2c3fa0395b3152bad634c7432f7edfc509c133b8f4529053ff024fb/ruff-0.15.5-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ba786a8295c6574c1116704cf0b9e6563de3432ac888d8f83685654fe528fd65", size = 10534857, upload-time = "2026-03-05T20:06:19.581Z" },
+    { url = "https://files.pythonhosted.org/packages/59/71/39234440f27a226475a0659561adb0d784b4d247dfe7f43ffc12dd02e288/ruff-0.15.5-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fd4b801e57955fe9f02b31d20375ab3a5c4415f2e5105b79fb94cf2642c91440", size = 10309120, upload-time = "2026-03-05T20:06:00.435Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/87/4140aa86a93df032156982b726f4952aaec4a883bb98cb6ef73c347da253/ruff-0.15.5-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:391f7c73388f3d8c11b794dbbc2959a5b5afe66642c142a6effa90b45f6f5204", size = 11047428, upload-time = "2026-03-05T20:05:51.867Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/f7/4953e7e3287676f78fbe85e3a0ca414c5ca81237b7575bdadc00229ac240/ruff-0.15.5-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8dc18f30302e379fe1e998548b0f5e9f4dff907f52f73ad6da419ea9c19d66c8", size = 11914251, upload-time = "2026-03-05T20:06:22.887Z" },
+    { url = "https://files.pythonhosted.org/packages/77/46/0f7c865c10cf896ccf5a939c3e84e1cfaeed608ff5249584799a74d33835/ruff-0.15.5-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1cc6e7f90087e2d27f98dc34ed1b3ab7c8f0d273cc5431415454e22c0bd2a681", size = 11333801, upload-time = "2026-03-05T20:05:57.168Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/01/a10fe54b653061585e655f5286c2662ebddb68831ed3eaebfb0eb08c0a16/ruff-0.15.5-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c1cb7169f53c1ddb06e71a9aebd7e98fc0fea936b39afb36d8e86d36ecc2636a", size = 11206821, upload-time = "2026-03-05T20:06:03.441Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/0d/2132ceaf20c5e8699aa83da2706ecb5c5dcdf78b453f77edca7fb70f8a93/ruff-0.15.5-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:9b037924500a31ee17389b5c8c4d88874cc6ea8e42f12e9c61a3d754ff72f1ca", size = 11133326, upload-time = "2026-03-05T20:06:25.655Z" },
+    { url = "https://files.pythonhosted.org/packages/72/cb/2e5259a7eb2a0f87c08c0fe5bf5825a1e4b90883a52685524596bfc93072/ruff-0.15.5-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:65bb414e5b4eadd95a8c1e4804f6772bbe8995889f203a01f77ddf2d790929dd", size = 10510820, upload-time = "2026-03-05T20:06:37.79Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/20/b67ce78f9e6c59ffbdb5b4503d0090e749b5f2d31b599b554698a80d861c/ruff-0.15.5-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:d20aa469ae3b57033519c559e9bc9cd9e782842e39be05b50e852c7c981fa01d", size = 10302395, upload-time = "2026-03-05T20:05:54.504Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/e5/719f1acccd31b720d477751558ed74e9c88134adcc377e5e886af89d3072/ruff-0.15.5-py3-none-musllinux_1_2_i686.whl", hash = "sha256:15388dd28c9161cdb8eda68993533acc870aa4e646a0a277aa166de9ad5a8752", size = 10754069, upload-time = "2026-03-05T20:06:06.422Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/9c/d1db14469e32d98f3ca27079dbd30b7b44dbb5317d06ab36718dee3baf03/ruff-0.15.5-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:b30da330cbd03bed0c21420b6b953158f60c74c54c5f4c1dabbdf3a57bf355d2", size = 11304315, upload-time = "2026-03-05T20:06:10.867Z" },
+    { url = "https://files.pythonhosted.org/packages/28/3a/950367aee7c69027f4f422059227b290ed780366b6aecee5de5039d50fa8/ruff-0.15.5-py3-none-win32.whl", hash = "sha256:732e5ee1f98ba5b3679029989a06ca39a950cced52143a0ea82a2102cb592b74", size = 10551676, upload-time = "2026-03-05T20:06:13.705Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/00/bf077a505b4e649bdd3c47ff8ec967735ce2544c8e4a43aba42ee9bf935d/ruff-0.15.5-py3-none-win_amd64.whl", hash = "sha256:821d41c5fa9e19117616c35eaa3f4b75046ec76c65e7ae20a333e9a8696bc7fe", size = 11678972, upload-time = "2026-03-05T20:06:45.379Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/4e/cd76eca6db6115604b7626668e891c9dd03330384082e33662fb0f113614/ruff-0.15.5-py3-none-win_arm64.whl", hash = "sha256:b498d1c60d2fe5c10c45ec3f698901065772730b411f164ae270bb6bfcc4740b", size = 10965572, upload-time = "2026-03-05T20:06:16.984Z" },
+]
+
+[[package]]
 name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -880,6 +992,21 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+]
+
+[[package]]
+name = "virtualenv"
+version = "21.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "distlib" },
+    { name = "filelock" },
+    { name = "platformdirs" },
+    { name = "python-discovery" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/aa/92/58199fe10049f9703c2666e809c4f686c54ef0a68b0f6afccf518c0b1eb9/virtualenv-21.2.0.tar.gz", hash = "sha256:1720dc3a62ef5b443092e3f499228599045d7fea4c79199770499df8becf9098", size = 5840618, upload-time = "2026-03-09T17:24:38.013Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c6/59/7d02447a55b2e55755011a647479041bc92a82e143f96a8195cb33bd0a1c/virtualenv-21.2.0-py3-none-any.whl", hash = "sha256:1bd755b504931164a5a496d217c014d098426cddc79363ad66ac78125f9d908f", size = 5825084, upload-time = "2026-03-09T17:24:35.378Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
Integrates pre-commit framework with ruff for automated code linting and formatting across the repository.

## Changes
- **CI/CD**: Added pre-commit GitHub Actions workflow (`ci-precommit.yml`)
- **Configuration**: Added `.pre-commit-config.yaml` with ruff hooks
- **Dependencies**: Updated `pyproject.toml` with pre-commit and ruff configuration
- **Lock file**: Updated `uv.lock` with new dependencies
- **Code formatting**: Applied ruff formatting fixes across ~60 files including:
  - Documentation files (markdown)
  - Python source code in `libs/beacon`
  - Test files
  - Knowledge base documents

## Impact
- Enforces consistent code style and formatting
- Automates linting checks in CI pipeline
- Improves code quality and maintainability