### PR TITLE
feat: add abc skill install command to register skills as agent commands

### DIFF
--- a/libs/beacon/src/beacon/cli.py
+++ b/libs/beacon/src/beacon/cli.py
@@ -714,10 +714,11 @@ def sync(*, preserve: bool, prune: bool, verbose_flag: bool) -> None:
         if summary.errors > 0:
             console.print(f"  [red]Errors:[/red] {summary.errors} files")
 
-        # Remind users to wire contexts into their agent config
+        # Post-sync reminders
+        next_steps = []
+
         if beacon_settings.artifacts.contexts and summary.copied > 0:
-            console.print("\n[bold]Next Steps:[/bold]")
-            console.print(
+            next_steps.append(
                 "  Contexts were synced but won't load automatically.\n"
                 "  Register them in your agent's config file:\n"
                 "\n"
@@ -727,6 +728,17 @@ def sync(*, preserve: bool, prune: bool, verbose_flag: bool) -> None:
                 '  [bold]opencode.json[/bold] — add to "instructions" array:\n'
                 '    ".agentic-beacon/artifacts/contexts/<name>.md"'
             )
+
+        if beacon_settings.artifacts.skills and summary.copied > 0:
+            next_steps.append(
+                "  Skills were synced but aren't registered as agent commands yet.\n"
+                "  Run: [bold]abc skill install --all[/bold]"
+            )
+
+        if next_steps:
+            console.print("\n[bold]Next Steps:[/bold]")
+            for step in next_steps:
+                console.print(step)
 
     except Exception as e:
         console.print(f"\n[red]Error:[/red] Sync failed: {e}")
@@ -914,6 +926,198 @@ def _collect_artifact_paths(
             else:
                 paths.add(pattern)
     return paths
+
+
+# ========== Skill Commands ==========
+
+
+@main.group()
+def skill() -> None:
+    """Skill management commands."""
+    pass
+
+
+@skill.command(name="install")
+@click.argument("skill_name", required=False, metavar="SKILL_NAME")
+@click.option("--all", "install_all", is_flag=True, help="Install all synced skills")
+@click.option(
+    "--agent",
+    type=click.Choice(["opencode", "claudecode"], case_sensitive=False),
+    help="Target agent tool (auto-detected if not specified)",
+)
+def skill_install(
+    *,
+    skill_name: str | None,
+    install_all: bool,
+    agent: str | None,
+) -> None:
+    """
+    Register synced skills as slash commands for your agent tool.
+
+    Reads skills from .agentic-beacon/artifacts/skills/ and creates the
+    agent-specific command stubs needed for the agent to discover them.
+
+    Example:
+        abc skill install record-knowledge
+        abc skill install record-knowledge --agent claudecode
+        abc skill install --all
+        abc skill install --all --agent opencode
+    """
+    if not skill_name and not install_all:
+        console.print("[red]Error:[/red] Provide a skill name or use --all.")
+        console.print("  abc skill install <name>")
+        console.print("  abc skill install --all")
+        sys.exit(1)
+
+    if skill_name and install_all:
+        console.print("[red]Error:[/red] SKILL_NAME and --all are mutually exclusive.")
+        sys.exit(1)
+
+    beacon_dir = Path.cwd() / ".agentic-beacon"
+    if not beacon_dir.exists():
+        console.print("[red]Error:[/red] No .agentic-beacon directory found.")
+        console.print("Run 'abc warehouse connect' to connect to a warehouse first.")
+        sys.exit(1)
+
+    artifacts_skills_dir = beacon_dir / "artifacts" / "skills"
+    if not artifacts_skills_dir.exists():
+        console.print("[red]Error:[/red] No synced skills found.")
+        console.print("Run 'abc sync' to sync skills from the warehouse first.")
+        sys.exit(1)
+
+    # Resolve target agents
+    project_root = Path.cwd()
+    agents = _detect_agents(project_root) if not agent else [agent.lower()]
+
+    if not agents:
+        console.print(
+            "[red]Error:[/red] Could not detect an agent tool in this project."
+        )
+        console.print(
+            "Use --agent opencode or --agent claudecode to specify one explicitly."
+        )
+        sys.exit(1)
+
+    # Resolve skills to install
+    if install_all:
+        skill_dirs = [d for d in artifacts_skills_dir.iterdir() if d.is_dir()]
+        if not skill_dirs:
+            console.print("[yellow]No synced skills found to install.[/yellow]")
+            sys.exit(0)
+        skills_to_install = [d.name for d in skill_dirs]
+    else:
+        skill_dir = artifacts_skills_dir / skill_name  # type: ignore[arg-type]
+        if not skill_dir.exists():
+            console.print(
+                f"[red]Error:[/red] Skill '{skill_name}' not found in synced artifacts."
+            )
+            console.print("Run 'abc sync' to sync it from the warehouse first.")
+            sys.exit(1)
+        skills_to_install = [skill_name]  # type: ignore[list-item]
+
+    # Install
+    installed: list[str] = []
+    errors: list[str] = []
+
+    for name in skills_to_install:
+        skill_md_path = artifacts_skills_dir / name / "SKILL.md"
+        if not skill_md_path.exists():
+            errors.append(f"{name}: SKILL.md not found in artifacts")
+            continue
+        content = skill_md_path.read_text(encoding="utf-8")
+        description = _extract_skill_description(content)
+
+        for target_agent in agents:
+            try:
+                if target_agent == "opencode":
+                    _install_skill_opencode(project_root, name, content, description)
+                else:
+                    _install_skill_claudecode(project_root, name, content)
+                installed.append(f"{name} ({target_agent})")
+            except Exception as e:
+                errors.append(f"{name} ({target_agent}): {e}")
+
+    # Report
+    if installed:
+        console.print("\n[bold green]✓ Skills installed[/bold green]")
+        for entry in installed:
+            console.print(f"  [green]✓[/green] {entry}")
+    if errors:
+        console.print("\n[bold red]Errors[/bold red]")
+        for entry in errors:
+            console.print(f"  [red]✗[/red] {entry}")
+
+    if installed and not errors:
+        _print_skill_next_steps(agents)
+
+    if errors:
+        sys.exit(1)
+
+
+def _detect_agents(project_root: Path) -> list[str]:
+    """Detect which agent tools are configured in the project."""
+    agents = []
+    if (project_root / "opencode.json").exists():
+        agents.append("opencode")
+    if (project_root / ".claude").exists():
+        agents.append("claudecode")
+    return agents
+
+
+def _extract_skill_description(content: str) -> str:
+    """Extract description value from SKILL.md YAML frontmatter."""
+    if not content.startswith("---"):
+        return ""
+    try:
+        end = content.index("---", 3)
+        for line in content[3:end].splitlines():
+            if line.startswith("description:"):
+                return line.split(":", 1)[1].strip()
+    except ValueError:
+        pass
+    return ""
+
+
+def _install_skill_opencode(
+    project_root: Path, skill_name: str, content: str, description: str
+) -> None:
+    """Install a skill for OpenCode: skill file + thin command stub."""
+    # Copy full skill to .opencode/skills/<name>/SKILL.md
+    skill_dest = project_root / ".opencode" / "skills" / skill_name
+    skill_dest.mkdir(parents=True, exist_ok=True)
+    (skill_dest / "SKILL.md").write_text(content)
+
+    # Create thin command stub in .opencode/command/<name>.md
+    command_dir = project_root / ".opencode" / "command"
+    command_dir.mkdir(parents=True, exist_ok=True)
+    stub = (
+        f"---\ndescription: {description}\n---\n\n"
+        f"Use the **skill** tool to load and execute the `{skill_name}` skill "
+        f"with any provided arguments.\n"
+    )
+    (command_dir / f"{skill_name}.md").write_text(stub)
+
+
+def _install_skill_claudecode(
+    project_root: Path, skill_name: str, content: str
+) -> None:
+    """Install a skill for Claude Code: copy SKILL.md to .claude/skills/<name>/."""
+    dest = project_root / ".claude" / "skills" / skill_name
+    dest.mkdir(parents=True, exist_ok=True)
+    (dest / "SKILL.md").write_text(content)
+
+
+def _print_skill_next_steps(agents: list[str]) -> None:
+    """Print agent-specific guidance after install."""
+    console.print("\n[bold]Next Steps:[/bold]")
+    if "opencode" in agents:
+        console.print(
+            "  [bold]OpenCode[/bold] — restart your session to pick up new commands"
+        )
+    if "claudecode" in agents:
+        console.print(
+            "  [bold]Claude Code[/bold] — skills are available as /skill-name in new sessions"
+        )
 
 
 # ========== Legacy Commands ==========

--- a/libs/beacon/tests/cli/test_skill_install_command.py
+++ b/libs/beacon/tests/cli/test_skill_install_command.py
@@ -1,0 +1,210 @@
+"""Tests for abc skill install command."""
+
+import pytest
+from beacon.cli import main
+from click.testing import CliRunner
+
+SAMPLE_SKILL_MD = """\
+---
+name: my-skill
+description: A sample skill for testing
+license: MIT
+compatibility: opencode
+---
+
+# Skill: My Skill
+
+## Purpose
+Does something useful.
+
+## Process
+1. Step one
+2. Step two
+"""
+
+
+@pytest.fixture
+def project_with_synced_skill(tmp_path, monkeypatch):
+    """Project directory with a synced skill artifact and warehouse connected."""
+    monkeypatch.chdir(tmp_path)
+
+    # .agentic-beacon structure
+    beacon_dir = tmp_path / ".agentic-beacon"
+    beacon_dir.mkdir()
+    (beacon_dir / "config.toml").write_text(
+        '[warehouse]\nlocal_path = "/some/warehouse"\n'
+    )
+
+    skill_dir = beacon_dir / "artifacts" / "skills" / "my-skill"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(SAMPLE_SKILL_MD)
+
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# Claude Code installation
+# ---------------------------------------------------------------------------
+
+
+def test_skill_install_claudecode_copies_skill_md(project_with_synced_skill):
+    tmp_path = project_with_synced_skill
+    runner = CliRunner()
+
+    # Create .claude/ so auto-detection picks it up
+    (tmp_path / ".claude").mkdir()
+
+    result = runner.invoke(
+        main, ["skill", "install", "my-skill", "--agent", "claudecode"]
+    )
+
+    assert result.exit_code == 0, result.output
+    installed = tmp_path / ".claude" / "skills" / "my-skill" / "SKILL.md"
+    assert installed.exists()
+    assert installed.read_text() == SAMPLE_SKILL_MD
+
+
+def test_skill_install_claudecode_is_idempotent(project_with_synced_skill):
+    tmp_path = project_with_synced_skill
+    runner = CliRunner()
+    (tmp_path / ".claude").mkdir()
+
+    runner.invoke(main, ["skill", "install", "my-skill", "--agent", "claudecode"])
+    result = runner.invoke(
+        main, ["skill", "install", "my-skill", "--agent", "claudecode"]
+    )
+
+    assert result.exit_code == 0
+    assert (tmp_path / ".claude" / "skills" / "my-skill" / "SKILL.md").exists()
+
+
+# ---------------------------------------------------------------------------
+# OpenCode installation
+# ---------------------------------------------------------------------------
+
+
+def test_skill_install_opencode_creates_skill_and_stub(project_with_synced_skill):
+    tmp_path = project_with_synced_skill
+    runner = CliRunner()
+
+    result = runner.invoke(
+        main, ["skill", "install", "my-skill", "--agent", "opencode"]
+    )
+
+    assert result.exit_code == 0, result.output
+
+    # Full skill file
+    skill_file = tmp_path / ".opencode" / "skills" / "my-skill" / "SKILL.md"
+    assert skill_file.exists()
+    assert skill_file.read_text() == SAMPLE_SKILL_MD
+
+    # Thin command stub
+    command_file = tmp_path / ".opencode" / "command" / "my-skill.md"
+    assert command_file.exists()
+    stub = command_file.read_text()
+    assert "description: A sample skill for testing" in stub
+    assert "my-skill" in stub
+    # Stub should not contain full skill body
+    assert "Step one" not in stub
+
+
+# ---------------------------------------------------------------------------
+# --all flag
+# ---------------------------------------------------------------------------
+
+
+def test_skill_install_all_installs_every_synced_skill(project_with_synced_skill):
+    tmp_path = project_with_synced_skill
+
+    # Add a second skill
+    second_dir = tmp_path / ".agentic-beacon" / "artifacts" / "skills" / "other-skill"
+    second_dir.mkdir()
+    (second_dir / "SKILL.md").write_text(
+        "---\nname: other-skill\ndescription: Another skill\n---\n\n# Skill: Other\n"
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["skill", "install", "--all", "--agent", "claudecode"])
+
+    assert result.exit_code == 0, result.output
+    assert (tmp_path / ".claude" / "skills" / "my-skill" / "SKILL.md").exists()
+    assert (tmp_path / ".claude" / "skills" / "other-skill" / "SKILL.md").exists()
+
+
+# ---------------------------------------------------------------------------
+# Auto-detection
+# ---------------------------------------------------------------------------
+
+
+def test_skill_install_autodetects_claudecode(project_with_synced_skill):
+    tmp_path = project_with_synced_skill
+    (tmp_path / ".claude").mkdir()
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["skill", "install", "my-skill"])
+
+    assert result.exit_code == 0, result.output
+    assert (tmp_path / ".claude" / "skills" / "my-skill" / "SKILL.md").exists()
+
+
+def test_skill_install_autodetects_opencode(project_with_synced_skill):
+    tmp_path = project_with_synced_skill
+    (tmp_path / "opencode.json").write_text("{}")
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["skill", "install", "my-skill"])
+
+    assert result.exit_code == 0, result.output
+    assert (tmp_path / ".opencode" / "skills" / "my-skill" / "SKILL.md").exists()
+    assert (tmp_path / ".opencode" / "command" / "my-skill.md").exists()
+
+
+def test_skill_install_autodetects_both_agents(project_with_synced_skill):
+    tmp_path = project_with_synced_skill
+    (tmp_path / "opencode.json").write_text("{}")
+    (tmp_path / ".claude").mkdir()
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["skill", "install", "my-skill"])
+
+    assert result.exit_code == 0, result.output
+    assert (tmp_path / ".claude" / "skills" / "my-skill" / "SKILL.md").exists()
+    assert (tmp_path / ".opencode" / "command" / "my-skill.md").exists()
+
+
+# ---------------------------------------------------------------------------
+# Error cases
+# ---------------------------------------------------------------------------
+
+
+def test_skill_install_errors_without_name_or_all(project_with_synced_skill):
+    runner = CliRunner()
+    result = runner.invoke(main, ["skill", "install"])
+    assert result.exit_code != 0
+
+
+def test_skill_install_errors_when_skill_not_synced(project_with_synced_skill):
+    runner = CliRunner()
+    result = runner.invoke(
+        main, ["skill", "install", "nonexistent-skill", "--agent", "claudecode"]
+    )
+    assert result.exit_code != 0
+    assert "not found" in result.output.lower()
+
+
+def test_skill_install_errors_without_beacon_dir(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(
+        main, ["skill", "install", "my-skill", "--agent", "claudecode"]
+    )
+    assert result.exit_code != 0
+    assert ".agentic-beacon" in result.output
+
+
+def test_skill_install_errors_when_no_agent_detected(project_with_synced_skill):
+    """No opencode.json and no .claude/ → cannot auto-detect."""
+    runner = CliRunner()
+    result = runner.invoke(main, ["skill", "install", "my-skill"])
+    assert result.exit_code != 0
+    assert "detect" in result.output.lower() or "agent" in result.output.lower()


### PR DESCRIPTION
## Summary

- Adds `abc skill install [SKILL_NAME] [--all] [--agent opencode|claudecode]`
- Reads synced skills from `.agentic-beacon/artifacts/skills/` and creates agent-specific command stubs
- Post-sync nudge added: `abc sync` now reminds users to run `abc skill install --all` after syncing skills

## What it generates

**Claude Code** (`--agent claudecode`):
- Copies `SKILL.md` → `.claude/skills/<name>/SKILL.md`

**OpenCode** (`--agent opencode`):
- Copies full skill → `.opencode/skills/<name>/SKILL.md`
- Creates thin command stub → `.opencode/command/<name>.md`

**Auto-detection** (no `--agent`):
- `opencode.json` present → OpenCode
- `.claude/` present → Claude Code
- Both present → installs for both

## Test plan

- [ ] `pytest` — all 223 tests pass
- [ ] `abc skill install --help` — verify help text
- [ ] Sync a skill, run `abc skill install <name> --agent claudecode`, verify `.claude/skills/<name>/SKILL.md` created
- [ ] Run `abc skill install <name> --agent opencode`, verify `.opencode/command/<name>.md` stub and `.opencode/skills/<name>/SKILL.md` created

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)