### PR TITLE
docs: document abc skill install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ The `abc` CLI provides practical tools for:
 - **Initialization** - Create new warehouses with proper structure (`abc warehouse init`)
 - **Connection** - Link projects to warehouses (`abc warehouse connect`)
 - **Distribution** - Sync artifacts to projects (`abc sync`)
+- **Skill Installation** - Register synced skills as slash commands in your agent (`abc skill install`)
 - **Discovery** - Find local changes that could benefit other teams (`abc delta`)
 - **Management** - Track installed content and maintain sync (`abc status`, `abc update`, `abc clean`)
 
@@ -171,8 +172,7 @@ agentic-beacon/
 │   ├── lessons/
 │   └── facts/
 ├── libs/beacon/          # CLI source code
-├── skills/               # Project-specific skills
-│   └── record-knowledge/
+├── skills/               # Project-specific skills (README only)
 ├── AGENTS.md             # Project context (uses progressive disclosure)
 ├── opencode.json         # Context loading configuration
 └── README.md             # This file
@@ -211,6 +211,7 @@ agentic-beacon/
 | `abc warehouse connect` | Connect a project to a warehouse |
 | `abc setup` | Create `beacon.yaml` (manual or agent-assisted) |
 | `abc sync` | Sync artifacts declared in `beacon.yaml` to the project |
+| `abc skill install` | Register synced skills as slash commands for your agent |
 | `abc status` | Show current connection and sync status |
 | `abc delta` | Compare synced artifacts with warehouse (find local changes) |
 | `abc update` | Re-sync and overwrite local artifacts from warehouse |
@@ -230,8 +231,9 @@ agentic-beacon/
 2. **Connect**: `abc warehouse connect --path ~/your-warehouse`
 3. **Configure**: `abc setup --manual` then edit `beacon.yaml`
 4. **Sync**: `abc sync`
-5. **Stay current**: `abc update` after warehouse changes
-6. **Contribute**: Use `abc delta` to find new patterns worth sharing back
+5. **Install skills**: `abc skill install --all` to register skills as agent slash commands
+6. **Stay current**: `abc update` after warehouse changes
+7. **Contribute**: Use `abc delta` to find new patterns worth sharing back
 
 ## 🔧 Technical Details
 

--- a/guides/creating-skills.md
+++ b/guides/creating-skills.md
@@ -242,7 +242,7 @@ git commit -m "feat: add generate-tests skill"
 git push
 ```
 
-### Step 4: Declare it in your project
+### Step 4: Declare it in your project and sync
 
 ```yaml
 # .agentic-beacon/beacon.yaml
@@ -255,26 +255,42 @@ artifacts:
 abc sync
 ```
 
+### Step 5: Install as an agent slash command
+
+Syncing copies the skill files to disk — but to invoke the skill with a slash command, you need to register it with your agent:
+
+```bash
+abc skill install generate-tests
+```
+
+Or install everything at once:
+
+```bash
+abc skill install --all
+```
+
+This makes the skill available as `/generate-tests` in Claude Code or OpenCode. The agent auto-detects which tool you're using based on the presence of `.claude/` or `opencode.json`.
+
 ---
 
 ## Invoking a Skill
 
-Skills are invoked by asking your AI agent to use them. The exact syntax depends on your agent:
+After running `abc skill install`, invoke the skill directly in your agent:
 
-**OpenCode / Claude:**
+**Claude Code:**
 ```
 /generate-tests src/services/user_service.py
 ```
 
-**Cursor / Copilot:**
+**OpenCode:**
 ```
-Use the generate-tests skill to write tests for UserService.create_user()
+/generate-tests src/services/user_service.py
 ```
 
-**General prompt:**
+**Generic agents (Cursor, Copilot, etc.) — reference the file directly:**
 ```
+Use the generate-tests skill to write tests for UserService.create_user()
 Follow the skill at .agentic-beacon/artifacts/skills/generate-tests/SKILL.md
-to write tests for this function: [paste function]
 ```
 
 ---

--- a/guides/getting-started.md
+++ b/guides/getting-started.md
@@ -213,7 +213,31 @@ Next Steps:
   ...
 ```
 
-### Step 6: Wire contexts into your agent
+### Step 6: Install skills as agent slash commands
+
+If your `beacon.yaml` includes skills, register them so your agent can invoke them with `/skill-name`:
+
+```bash
+# Auto-detect your agent (Claude Code or OpenCode) and install all skills
+abc skill install --all
+
+# Or install a specific skill
+abc skill install code-review
+
+# Or specify the agent explicitly
+abc skill install --all --agent claudecode
+abc skill install --all --agent opencode
+```
+
+**What this does:**
+- **Claude Code** — copies `SKILL.md` to `.claude/skills/<name>/SKILL.md` (committed to git, shared with teammates)
+- **OpenCode** — copies the full skill to `.opencode/skills/<name>/SKILL.md` and creates a thin command stub at `.opencode/command/<name>.md`
+
+After installation, invoke the skill in your agent with `/code-review` (or whatever the skill name is).
+
+> **Auto-detection:** `abc skill install` detects your agent automatically if `opencode.json` or `.claude/` exists in your project. Use `--agent` to specify explicitly if both are present.
+
+### Step 7: Wire contexts into your agent
 
 **This step is required.** Syncing copies files to disk, but your AI agent won't load them unless they're registered in its config file.
 

--- a/guides/warehouse-creation.md
+++ b/guides/warehouse-creation.md
@@ -82,7 +82,7 @@ skills/
 
 The skill name is the directory name. Projects reference it with a glob pattern like `skills/your-skill-name/**/*`.
 
-`abc warehouse init` pre-populates `skills/record-knowledge/` — a skill for capturing decisions, lessons, and facts into the knowledge base. Projects that sync it can use `/record-knowledge` to record knowledge directly from the agent.
+`abc warehouse init` pre-populates `skills/record-knowledge/` — a skill for capturing decisions, lessons, and facts into the knowledge base. Projects that sync it and run `abc skill install record-knowledge` can use `/record-knowledge` to record knowledge directly from the agent.
 
 See [Creating Skills](./creating-skills.md) for how to write effective `SKILL.md` files.
 


### PR DESCRIPTION
## Summary

- Add `abc skill install` to the CLI reference table in README
- Add skill install as step 6 in the getting-started workflow (between sync and wire contexts)
- Update creating-skills guide: new Step 5 after sync, and revised "Invoking a Skill" section
- Update warehouse-creation guide: mention `abc skill install` needed before `/record-knowledge` works
- Fix README repo structure tree: remove `skills/record-knowledge/` entry (deleted in #11)

## Test plan

- [ ] Read through getting-started.md — skill install step appears after sync, before wiring contexts
- [ ] Read through creating-skills.md — install step present in "Adding a Skill" workflow; invoking section updated
- [ ] Check README CLI table — `abc skill install` row present
- [ ] Check README For Teams — step 5 is skill install

🤖 Generated with [Claude Code](https://claude.com/claude-code)