### PR TITLE
feat: add abc contribute command and fix abc delta for locally-added files

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ The `abc` CLI provides practical tools for:
 - **Connection** - Link projects to warehouses (`abc warehouse connect`)
 - **Distribution** - Sync artifacts to projects (`abc sync`)
 - **Skill Installation** - Register synced skills as slash commands in your agent (`abc skill install`)
+- **Contribution** - Copy agent-improved artifacts back to the warehouse (`abc contribute`)
 - **Discovery** - Find local changes that could benefit other teams (`abc delta`)
 - **Management** - Track installed content and maintain sync (`abc status`, `abc update`, `abc clean`)
 
@@ -194,6 +195,7 @@ agentic-beacon/
 ### Practical Guides (guides/)
 - **[Getting Started](./guides/getting-started.md)** - Full onboarding walkthrough
 - **[Warehouse Creation](./guides/warehouse-creation.md)** - Creating and structuring a warehouse
+- **[Contributing Back](./guides/warehouse-contribution-guide.md)** - Copy agent improvements back to the warehouse
 - **[beacon.yaml Reference](./guides/beacon-yaml-reference.md)** - Full configuration schema
 - **[Team Collaboration](./guides/team-collaboration.md)** - Multi-team workflows
 - **[Advanced Patterns](./guides/advanced-patterns.md)** - Glob patterns, sync flags, delta workflow
@@ -212,6 +214,7 @@ agentic-beacon/
 | `abc setup` | Create `beacon.yaml` (manual or agent-assisted) |
 | `abc sync` | Sync artifacts declared in `beacon.yaml` to the project |
 | `abc skill install` | Register synced skills as slash commands for your agent |
+| `abc contribute` | Copy local artifact changes back to the warehouse |
 | `abc status` | Show current connection and sync status |
 | `abc delta` | Compare synced artifacts with warehouse (find local changes) |
 | `abc update` | Re-sync and overwrite local artifacts from warehouse |
@@ -232,8 +235,8 @@ agentic-beacon/
 3. **Configure**: `abc setup --manual` then edit `beacon.yaml`
 4. **Sync**: `abc sync`
 5. **Install skills**: `abc skill install --all` to register skills as agent slash commands
-6. **Stay current**: `abc update` after warehouse changes
-7. **Contribute**: Use `abc delta` to find new patterns worth sharing back
+6. **Contribute**: `abc contribute --all` to share agent improvements back to the warehouse
+7. **Stay current**: `abc update` after warehouse changes
 
 ## 🔧 Technical Details
 

--- a/guides/warehouse-contribution-guide.md
+++ b/guides/warehouse-contribution-guide.md
@@ -1,294 +1,169 @@
-# Warehouse Contribution Guide
+# Contributing Back to the Warehouse
 
-Guide for contributing improvements to your organization's agentic engineering warehouse.
-
-**Last Updated:** 2026-03-10
+When your agent improves a synced artifact — a context file, a knowledge document, or a skill — those improvements live in `.agentic-beacon/artifacts/` and are gitignored by default. Use `abc contribute` to copy them back to the warehouse so the whole team benefits.
 
 ---
 
-## Overview
+## The Contribution Workflow
 
-This guide is for teams contributing to their **organization's warehouse instance** (created from this template), not the template repository itself.
+### 1. Your agent edits a synced artifact
 
----
+Agents often edit artifacts in place during a session. For example:
 
-## Contribution Workflow
-
-### 1. Test Locally in Your Project
-
-Before contributing back to the warehouse, validate changes in your project:
-
-**For Context Files:**
-```bash
-# Edit the synced context file in your project
-vim .agentic-beacon/artifacts/contexts/python.md
-
-# Test with your AI agent — verify it follows the updated instructions
-# When happy, copy your changes back to the warehouse clone
+```
+.agentic-beacon/artifacts/knowledge/python/type-hints.md   ← agent improved this
+.agentic-beacon/artifacts/skills/code-review/SKILL.md       ← agent refined this
 ```
 
-**For Knowledge Files:**
-```bash
-# Edit the synced knowledge file
-vim .agentic-beacon/artifacts/knowledge/languages/python/lessons/new-lesson.md
+These changes are local-only. To share them, you need to contribute them back.
 
-# Reference from context and test
-# Verify agents can access and use the knowledge
-```
-
-**For Skills:**
-```bash
-# Modify the synced skill in your project
-vim .agentic-beacon/artifacts/skills/my-skill/SKILL.md
-
-# Test the skill
-/my-skill "test input"
-
-# Verify it works as expected
-```
-
----
-
-### 2. Prepare Contribution
-
-Once validated locally, prepare for warehouse contribution:
+### 2. Review what changed
 
 ```bash
-# Clone warehouse repository (if you don't have it already)
-git clone git@github.com:your-org/your-warehouse.git
-cd your-warehouse
-
-# Create feature branch
-git checkout -b add-python-type-hints-lesson
-
-# Copy your modified files from the project
-cp /path/to/project/.agentic-beacon/artifacts/knowledge/languages/python/lessons/type-hints.md \
-   knowledge/languages/python/lessons/
-
-# Update context to reference new knowledge (if needed)
-vim contexts/python.md
+abc delta
 ```
 
----
+Shows a summary of all differences between your local artifacts and the warehouse:
 
-### 3. Create Pull Request
+```
+Delta Summary
+──────────────────────────────────────
+MODIFIED  knowledge/python/type-hints.md
+MODIFIED  skills/code-review/SKILL.md
+ADDED     knowledge/python/new-lesson.md
+```
 
-**What to include in PR:**
+Inspect a specific file:
 
-1. **Clear title** following conventional commits:
-   ```
-   feat(python): add lesson on type hints best practices
-   fix(context): correct typo in global.md
-   docs(knowledge): improve PostgreSQL decision rationale
-   ```
+```bash
+abc delta knowledge/python/type-hints.md
+```
 
-2. **Description with context:**
-   ```markdown
-   ## Summary
-   Adds lesson on Python type hints based on recurring agent mistakes.
+### 3. Contribute changes back
 
-   ## Testing
-   - Tested in project X for 2 weeks
-   - Agents now correctly avoid quoted type annotations
-   - No issues observed
+Copy a single file back to the warehouse:
 
-   ## Impacted Files
-   - contexts/python.md - added pointer
-   - knowledge/languages/python/lessons/type-hints.md - new lesson
+```bash
+abc contribute knowledge/python/type-hints.md
+```
 
-   ## Related Issues
-   Closes #42
-   ```
+Or contribute everything that changed at once:
 
-3. **Documentation updates:**
-   - Update skills/README.md if adding new skill
-   - Update knowledge/README.md if adding new knowledge structure
-   - Add examples if introducing new patterns
+```bash
+abc contribute --all
+```
 
----
+Preview before committing:
 
-### 4. Review Process
+```bash
+abc contribute --all --dry-run
+```
 
-**For warehouse maintainers:**
+`abc contribute` copies the files and prints the exact git commands to run next.
 
-1. **Validation checklist:**
-   - [ ] Follows warehouse structure conventions
-   - [ ] Knowledge files in correct scope (global/languages/domains)
-   - [ ] Context references are correct paths
-   - [ ] No project-specific details leaked into generic content
-   - [ ] Examples are generic and reusable
+### 4. Commit in the warehouse
 
-2. **Quality checks:**
-   - [ ] Markdown formatting correct
-   - [ ] No broken links
-   - [ ] Code examples tested
-   - [ ] Follows progressive disclosure (context brief, knowledge detailed)
+```bash
+cd ~/team-warehouse
+git diff                    # Review what changed
+git add .
+git commit -m "feat(python): improve type hints guide with 3.10+ syntax"
+git push
+```
 
-3. **Testing (if infrastructure exists):**
-   - [ ] CI validates markdown syntax
-   - [ ] CI checks for broken links
-   - [ ] Skills tested against test projects
+### 5. Teammates pick it up
 
----
-
-### 5. Merge and Distribution
-
-Once approved and merged:
-
-1. **Distribution:** Teams pull the warehouse and re-sync their projects:
-   ```bash
-   cd ~/team-warehouse && git pull
-   cd ~/my-project && abc sync
-   ```
-
-2. **Communication:**
-   - Announce significant changes to teams
-   - Update CHANGELOG.md in warehouse
-   - Tag releases for major updates
+```bash
+cd ~/team-warehouse && git pull
+cd my-project && abc sync
+```
 
 ---
 
 ## Contribution Types
 
-### Adding New Context
+### Improving an existing artifact
 
-**When:** Your team uses a new language/domain not in warehouse
+The most common case — your agent refines a context, knowledge file, or skill during a session.
 
-**Process:**
 ```bash
-# 1. Create context file
-vim contexts/go.md
-
-# 2. Create corresponding knowledge directory
-mkdir -p knowledge/languages/go/decisions
-mkdir -p knowledge/languages/go/lessons
-
-# 3. Add initial knowledge files
-vim knowledge/languages/go/decisions/error-handling.md
-
-# 4. Submit PR
-git add contexts/go.md knowledge/languages/go/
-git commit -m "feat(go): add Go language context and error handling guidance"
+abc delta                                      # See what changed
+abc contribute knowledge/python/type-hints.md  # Contribute the change
+cd ~/team-warehouse
+git commit -m "docs(python): clarify type hint guidance"
 ```
 
-### Adding Knowledge to Existing Context
+### Adding a new artifact
 
-**When:** You discover a pattern/lesson worth sharing
+If your agent created a new file that should live in the warehouse:
 
-**Process:**
+1. Add it to `beacon.yaml` so it's tracked
+2. Run `abc sync` (to register it)
+3. Run `abc contribute knowledge/python/new-lesson.md`
+
+Or just use `--all` which picks up both `MODIFIED` and `ADDED` files.
+
+### Adding a new skill
+
 ```bash
-# 1. Add knowledge file in correct scope
-vim knowledge/languages/python/lessons/async-await-mistakes.md
+# 1. Create the skill directory in the warehouse
+mkdir -p ~/team-warehouse/skills/generate-tests
+# Write SKILL.md into the warehouse directly — no need to contribute
 
-# 2. Reference from context
-vim contexts/python.md
-# Add: **See:** [Async/await mistakes](...)
+# 2. Declare it in beacon.yaml
+# artifacts:
+#   skills:
+#     - skills/generate-tests/**/*
 
-# 3. Submit PR
-git commit -m "feat(python): add async/await common mistakes lesson"
-```
-
-### Adding New Skill
-
-**When:** You create a reusable workflow
-
-**Process:**
-```bash
-# 1. Create skill directory
-mkdir -p skills/code-review
-
-# 2. Add SKILL.md and supporting files
-vim skills/code-review/SKILL.md
-vim skills/code-review/templates/review-checklist.md
-
-# 3. Update skills catalog
-vim skills/README.md
-# Add entry for code-review skill
-
-# 4. Submit PR
-git commit -m "feat(skills): add code review workflow skill"
-```
-
-### Updating Existing Content
-
-**When:** Improving or correcting existing content
-
-**Process:**
-```bash
-# 1. Make changes
-vim knowledge/global/decisions/conventional-commits.md
-
-# 2. Document what changed and why
-git commit -m "docs(global): clarify conventional commits scope usage
-
-- Add examples for optional scope
-- Clarify when scope is recommended vs required
-- Based on team feedback from 3 projects"
+# 3. Sync and install
+abc sync
+abc skill install generate-tests
 ```
 
 ---
 
-## Best Practices
+## Contribution Checklist
 
-### Keep It Generic
+Before committing to the warehouse:
 
-**❌ Bad (project-specific):**
+- [ ] Tested the artifact in a real project — agent actually used it correctly
+- [ ] Content is generic — no project-specific paths, credentials, or names
+- [ ] No broken references or links
+- [ ] Commit message describes **why** the change helps (not just what changed)
+
+---
+
+## Pull Request Workflow (for team warehouses)
+
+If your warehouse uses PRs rather than direct push:
+
+```bash
+cd ~/team-warehouse
+git checkout -b improve-python-type-hints
+git add .
+git commit -m "feat(python): add str | None guidance for Python 3.10+"
+git push -u origin improve-python-type-hints
+# Open PR on GitHub/GitLab
+```
+
+**PR description template:**
+
 ```markdown
-## Database Connection
+## Summary
+<What changed and why it helps agents>
 
-Our production database is at db.acme.com:5432
-Use the `ACME_DB_PASSWORD` environment variable
+## Testing
+- Tested in [project name] for [duration]
+- Agents now correctly [specific behavior]
+
+## Impacted Files
+- knowledge/python/type-hints.md
 ```
-
-**✅ Good (generic and reusable):**
-```markdown
-## Database Connection
-
-**Fact:** Database connection details should be in environment variables
-
-**Pattern:**
-- Host: `DATABASE_HOST`
-- Port: `DATABASE_PORT`
-- Password: `DATABASE_PASSWORD`
-```
-
-### Follow Pointer Conventions
-
-**Proactive pointers** (`Read:`):
-- Critical patterns affecting every file
-- Common failure modes
-- Standards requiring internalization
-
-**Reactive pointers** (`See:`):
-- Troubleshooting guides
-- Detailed explanations
-- Reference material for edge cases
-
-### Test Thoroughly
-
-Before contributing:
-- [ ] Tested in at least one real project
-- [ ] Verified agents use the content correctly
-- [ ] Checked for no unintended side effects
-- [ ] Validated all links and references work
-
-### Document Context
-
-In your PR description, explain:
-- **Why** this is needed (problem it solves)
-- **How** you tested it (which projects, duration)
-- **Impact** on existing content (breaking changes?)
 
 ---
 
-## Getting Help
+## Next Steps
 
-**For questions about contributing:**
-- Check warehouse documentation
-- Ask in team chat/channel
-- Contact warehouse maintainers
-
-**For issues with the template structure:**
-- See [Template Repository](https://github.com/Shadowsong27/agentic-engineering-warehouse-template)
-
----
+- **[Getting Started](./getting-started.md)** — Sync workflow overview
+- **[Advanced Patterns](./advanced-patterns.md)** — `abc delta` in depth
+- **[Creating Skills](./creating-skills.md)** — Writing effective SKILL.md files

--- a/libs/beacon/src/beacon/cli.py
+++ b/libs/beacon/src/beacon/cli.py
@@ -1,5 +1,6 @@
 """CLI interface for Beacon - Distribute knowledge contexts for AI development."""
 
+import shutil
 import sys
 from pathlib import Path
 
@@ -911,21 +912,234 @@ def _show_detailed_diff(
 def _collect_artifact_paths(
     comparator: DeltaComparator, beacon_settings: BeaconSettings
 ) -> set:
-    """Collect all artifact paths from beacon.yaml, expanding globs."""
+    """Collect all artifact paths from beacon.yaml, expanding globs.
+
+    Globs both the warehouse and local artifacts directory so that locally-added
+    files (not yet in the warehouse) are included.
+    """
     sync_engine = SyncEngine(
         warehouse_path=comparator.warehouse_path,
         artifacts_path=comparator.artifacts_path,
     )
-    paths = set()
+    paths: set[str] = set()
     for artifact_type in ["knowledge", "skills", "contexts"]:
         patterns = getattr(beacon_settings.artifacts, artifact_type)
         for pattern in patterns:
             if "*" in pattern or "?" in pattern or "[" in pattern:
-                matches = sync_engine.expand_glob(pattern)
-                paths.update(matches)
+                paths.update(sync_engine.expand_glob(pattern))
+                # Also glob local artifacts to catch ADDED files
+                if comparator.artifacts_path.exists():
+                    for match in comparator.artifacts_path.glob(pattern):
+                        if match.is_file():
+                            paths.add(str(match.relative_to(comparator.artifacts_path)))
             else:
                 paths.add(pattern)
     return paths
+
+
+# ========== Contribute Command ==========
+
+
+@main.command()
+@click.argument("file", required=False, type=str)
+@click.option(
+    "--all",
+    "contribute_all",
+    is_flag=True,
+    help="Contribute all modified and added artifacts",
+)
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    help="Preview what would be contributed without copying",
+)
+def contribute(*, file: str | None, contribute_all: bool, dry_run: bool) -> None:
+    """Copy local artifact changes back to the warehouse for sharing.
+
+    After editing synced artifacts and verifying they work with your agent,
+    use this command to copy them back to the warehouse so the whole team
+    benefits from the improvements.
+
+    Examples:
+
+        abc contribute knowledge/python/type-hints.md   # Single file
+
+        abc contribute --all                            # All modified/added
+
+        abc contribute --all --dry-run                  # Preview only
+    """
+    if not file and not contribute_all:
+        console.print(
+            "[red]Error:[/red] Specify a file or use --all to contribute all changes."
+        )
+        console.print("\nExamples:")
+        console.print("  abc contribute knowledge/python/type-hints.md")
+        console.print("  abc contribute --all")
+        sys.exit(1)
+
+    if file and contribute_all:
+        console.print("[red]Error:[/red] Cannot use both a file argument and --all.")
+        sys.exit(1)
+
+    beacon_dir = Path.cwd() / ".agentic-beacon"
+    if not beacon_dir.exists():
+        console.print("[red]Error:[/red] No .agentic-beacon directory found.")
+        console.print("Run 'abc warehouse connect' to connect to a warehouse first.")
+        sys.exit(1)
+
+    config_file = beacon_dir / "config.toml"
+    if not config_file.exists():
+        console.print("[red]Error:[/red] No warehouse connected.")
+        console.print("Run 'abc warehouse connect --path <warehouse>' first.")
+        sys.exit(1)
+
+    beacon_yaml = beacon_dir / "beacon.yaml"
+    if not beacon_yaml.exists():
+        console.print("[red]Error:[/red] No beacon.yaml found.")
+        console.print("Run 'abc setup' to create artifact configuration.")
+        sys.exit(1)
+
+    try:
+        warehouse_settings = WarehouseSettings()
+        warehouse_path = Path(warehouse_settings.warehouse.local_path)
+
+        if not warehouse_path.exists():
+            console.print(
+                f"[red]Error:[/red] Warehouse path no longer exists: {warehouse_path}"
+            )
+            console.print(
+                "Run 'abc warehouse connect --path <warehouse>' to reconnect."
+            )
+            sys.exit(1)
+
+        artifacts_dir = beacon_dir / "artifacts"
+        beacon_settings = BeaconSettings.from_yaml(beacon_yaml)
+        comparator = DeltaComparator(
+            warehouse_path=warehouse_path,
+            artifacts_path=artifacts_dir,
+        )
+
+        if dry_run:
+            console.print("[dim]Dry run — no files will be copied.[/dim]\n")
+
+        if file:
+            _contribute_single(
+                comparator,
+                beacon_settings,
+                warehouse_path,
+                artifacts_dir,
+                file,
+                dry_run,
+            )
+        else:
+            _contribute_all(
+                comparator, beacon_settings, warehouse_path, artifacts_dir, dry_run
+            )
+
+    except Exception as e:
+        console.print(f"\n[red]Error:[/red] Contribute failed: {e}")
+        logger.exception("Contribute failed")
+        sys.exit(1)
+
+
+def _contribute_single(
+    comparator: DeltaComparator,
+    beacon_settings: BeaconSettings,
+    warehouse_path: Path,
+    artifacts_dir: Path,
+    file_path: str,
+    dry_run: bool,
+) -> None:
+    """Contribute a single artifact back to the warehouse."""
+    all_paths = _collect_artifact_paths(comparator, beacon_settings)
+    if file_path not in all_paths:
+        console.print(f"[red]Error:[/red] '{file_path}' is not tracked in beacon.yaml.")
+        console.print("Only artifacts declared in beacon.yaml can be contributed.")
+        sys.exit(1)
+
+    local_path = artifacts_dir / file_path
+    if not local_path.exists():
+        console.print(f"[red]Error:[/red] '{file_path}' has not been synced locally.")
+        console.print("Run 'abc sync' to download it first.")
+        sys.exit(1)
+
+    result = comparator.compare_file(file_path)
+    if result.status == DeltaStatus.IDENTICAL:
+        console.print(
+            f"[yellow]Nothing to contribute.[/yellow] "
+            f"'{file_path}' is identical to the warehouse version."
+        )
+        return
+
+    _copy_to_warehouse(local_path, warehouse_path / file_path, file_path, dry_run)
+    if not dry_run:
+        _print_contribute_next_steps(warehouse_path, [file_path])
+
+
+def _contribute_all(
+    comparator: DeltaComparator,
+    beacon_settings: BeaconSettings,
+    warehouse_path: Path,
+    artifacts_dir: Path,
+    dry_run: bool,
+) -> None:
+    """Contribute all modified and added artifacts back to the warehouse."""
+    summary = comparator.compare_from_config(beacon_settings)
+    contributable = summary.modified + summary.added
+
+    if not contributable:
+        console.print(
+            "[green]Nothing to contribute.[/green] "
+            "All local artifacts match the warehouse."
+        )
+        return
+
+    contributed = []
+    for result in contributable:
+        local_path = artifacts_dir / result.path
+        if not local_path.exists():
+            console.print(
+                f"  [yellow]Skipping[/yellow] {result.path} (not found locally — run 'abc sync')"
+            )
+            continue
+        _copy_to_warehouse(
+            local_path, warehouse_path / result.path, result.path, dry_run
+        )
+        if not dry_run:
+            contributed.append(result.path)
+
+    if not dry_run and contributed:
+        _print_contribute_next_steps(warehouse_path, contributed)
+
+
+def _copy_to_warehouse(
+    local_path: Path, dest_path: Path, display_path: str, dry_run: bool
+) -> None:
+    """Copy a local artifact to the warehouse, creating parent dirs as needed."""
+    if dry_run:
+        console.print(f"  [dim]Would contribute:[/dim] {display_path}")
+        return
+    dest_path.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(local_path, dest_path)
+    console.print(f"  [green]✓[/green] {display_path}")
+
+
+def _print_contribute_next_steps(warehouse_path: Path, contributed: list[str]) -> None:
+    """Print post-contribute git workflow."""
+    count = len(contributed)
+    console.print(
+        f"\n[bold green]✓ Contributed {count} file{'s' if count != 1 else ''} to warehouse[/bold green]"
+    )
+    console.print(f"  Warehouse: [dim]{warehouse_path}[/dim]\n")
+    console.print("[bold]Next Steps — commit the changes in your warehouse:[/bold]")
+    console.print(f"\n  cd {warehouse_path}")
+    console.print("  git diff                    # Review what changed")
+    console.print("  git add .")
+    console.print('  git commit -m "feat: <describe your improvements>"')
+    console.print("  git push\n")
+    console.print("[dim]Teammates get the changes on their next:[/dim]")
+    console.print("  cd ~/team-warehouse && git pull")
+    console.print("  cd my-project && abc sync")
 
 
 # ========== Skill Commands ==========

--- a/libs/beacon/src/beacon/core/delta.py
+++ b/libs/beacon/src/beacon/core/delta.py
@@ -214,6 +214,9 @@ class DeltaComparator:
     def compare_from_config(self, beacon_settings) -> DeltaSummary:
         """Compare only artifacts listed in beacon.yaml.
 
+        Detects MODIFIED, IDENTICAL, and MISSING files (those in the warehouse)
+        as well as ADDED files (those that exist locally but not in the warehouse).
+
         Args:
             beacon_settings: Parsed BeaconSettings object
 
@@ -223,7 +226,8 @@ class DeltaComparator:
         from .sync import SyncEngine
 
         # Collect all artifact paths, expanding globs
-        artifact_paths = []
+        seen: set[str] = set()
+        artifact_paths: list[str] = []
         sync_engine = SyncEngine(
             warehouse_path=self.warehouse_path,
             artifacts_path=self.artifacts_path,
@@ -233,10 +237,25 @@ class DeltaComparator:
             patterns = getattr(beacon_settings.artifacts, artifact_type)
             for pattern in patterns:
                 if "*" in pattern or "?" in pattern or "[" in pattern:
-                    matches = sync_engine.expand_glob(pattern)
-                    artifact_paths.extend(matches)
+                    # Glob the warehouse — finds MODIFIED/IDENTICAL/MISSING candidates
+                    for rel_path in sync_engine.expand_glob(pattern):
+                        if rel_path not in seen:
+                            seen.add(rel_path)
+                            artifact_paths.append(rel_path)
+
+                    # Also glob the local artifacts dir — catches ADDED files that
+                    # only exist locally and would be invisible to a warehouse-only glob
+                    if self.artifacts_path.exists():
+                        for match in self.artifacts_path.glob(pattern):
+                            if match.is_file():
+                                rel_path = str(match.relative_to(self.artifacts_path))
+                                if rel_path not in seen:
+                                    seen.add(rel_path)
+                                    artifact_paths.append(rel_path)
                 else:
-                    artifact_paths.append(pattern)
+                    if pattern not in seen:
+                        seen.add(pattern)
+                        artifact_paths.append(pattern)
 
         return self.compare_all(artifact_paths)
 

--- a/libs/beacon/tests/cli/test_contribute_command.py
+++ b/libs/beacon/tests/cli/test_contribute_command.py
@@ -1,0 +1,266 @@
+"""Tests for abc contribute command."""
+
+import pytest
+from beacon.cli import main
+from click.testing import CliRunner
+
+KNOWLEDGE_CONTENT_ORIGINAL = "# Type Hints\n\nUse type hints.\n"
+KNOWLEDGE_CONTENT_MODIFIED = (
+    "# Type Hints\n\nUse type hints.\nPrefer `str | None` over `Optional[str]`.\n"
+)
+ADDED_CONTENT = "# New Lesson\n\nSomething new discovered locally.\n"
+
+BEACON_YAML = """\
+artifacts:
+  knowledge:
+    - knowledge/python/type-hints.md
+    - knowledge/python/new-lesson.md
+  skills: []
+  contexts: []
+"""
+
+
+@pytest.fixture
+def project_with_delta(tmp_path, monkeypatch):
+    """Project with a warehouse, beacon config, and local artifact changes."""
+    monkeypatch.chdir(tmp_path)
+
+    # Warehouse structure
+    warehouse = tmp_path / "warehouse"
+    warehouse.mkdir()
+    (warehouse / "contexts").mkdir()
+    (warehouse / "knowledge").mkdir()
+    (warehouse / "skills").mkdir()
+    (warehouse / "docs").mkdir()
+    (warehouse / "README.md").write_text("# Warehouse")
+
+    knowledge_dir = warehouse / "knowledge" / "python"
+    knowledge_dir.mkdir(parents=True)
+    (knowledge_dir / "type-hints.md").write_text(KNOWLEDGE_CONTENT_ORIGINAL)
+    # new-lesson.md does NOT exist in warehouse (ADDED case)
+
+    # Project .agentic-beacon
+    beacon_dir = tmp_path / ".agentic-beacon"
+    beacon_dir.mkdir()
+    (beacon_dir / "config.toml").write_text(
+        f'[warehouse]\nlocal_path = "{warehouse}"\n'
+    )
+    (beacon_dir / "beacon.yaml").write_text(BEACON_YAML)
+
+    # Local artifacts (modified + added)
+    artifacts_knowledge = beacon_dir / "artifacts" / "knowledge" / "python"
+    artifacts_knowledge.mkdir(parents=True)
+    (artifacts_knowledge / "type-hints.md").write_text(KNOWLEDGE_CONTENT_MODIFIED)
+    (artifacts_knowledge / "new-lesson.md").write_text(ADDED_CONTENT)
+
+    return tmp_path, warehouse
+
+
+# ---------------------------------------------------------------------------
+# Single file contribution
+# ---------------------------------------------------------------------------
+
+
+def test_contribute_single_modified_file(project_with_delta):
+    tmp_path, warehouse = project_with_delta
+    runner = CliRunner()
+
+    result = runner.invoke(main, ["contribute", "knowledge/python/type-hints.md"])
+
+    assert result.exit_code == 0, result.output
+    dest = warehouse / "knowledge" / "python" / "type-hints.md"
+    assert dest.read_text() == KNOWLEDGE_CONTENT_MODIFIED
+
+
+def test_contribute_single_added_file(project_with_delta):
+    """ADDED file (exists locally, not in warehouse) is copied to warehouse."""
+    tmp_path, warehouse = project_with_delta
+    runner = CliRunner()
+
+    result = runner.invoke(main, ["contribute", "knowledge/python/new-lesson.md"])
+
+    assert result.exit_code == 0, result.output
+    dest = warehouse / "knowledge" / "python" / "new-lesson.md"
+    assert dest.exists()
+    assert dest.read_text() == ADDED_CONTENT
+
+
+def test_contribute_identical_file_is_noop(project_with_delta):
+    """IDENTICAL file produces a friendly message and exit 0."""
+    tmp_path, warehouse = project_with_delta
+    runner = CliRunner()
+
+    # Make local match warehouse
+    local = (
+        tmp_path
+        / ".agentic-beacon"
+        / "artifacts"
+        / "knowledge"
+        / "python"
+        / "type-hints.md"
+    )
+    local.write_text(KNOWLEDGE_CONTENT_ORIGINAL)
+
+    result = runner.invoke(main, ["contribute", "knowledge/python/type-hints.md"])
+
+    assert result.exit_code == 0
+    assert "nothing to contribute" in result.output.lower()
+    # Warehouse unchanged
+    assert (
+        warehouse / "knowledge" / "python" / "type-hints.md"
+    ).read_text() == KNOWLEDGE_CONTENT_ORIGINAL
+
+
+# ---------------------------------------------------------------------------
+# --all flag
+# ---------------------------------------------------------------------------
+
+
+def test_contribute_all_copies_modified_and_added(project_with_delta):
+    tmp_path, warehouse = project_with_delta
+    runner = CliRunner()
+
+    result = runner.invoke(main, ["contribute", "--all"])
+
+    assert result.exit_code == 0, result.output
+    assert (
+        warehouse / "knowledge" / "python" / "type-hints.md"
+    ).read_text() == KNOWLEDGE_CONTENT_MODIFIED
+    assert (
+        warehouse / "knowledge" / "python" / "new-lesson.md"
+    ).read_text() == ADDED_CONTENT
+
+
+def test_contribute_all_nothing_to_contribute(project_with_delta):
+    """When all artifacts are identical, --all reports nothing to contribute."""
+    tmp_path, warehouse = project_with_delta
+    runner = CliRunner()
+
+    # Sync local back to original so nothing differs
+    local_hints = (
+        tmp_path
+        / ".agentic-beacon"
+        / "artifacts"
+        / "knowledge"
+        / "python"
+        / "type-hints.md"
+    )
+    local_hints.write_text(KNOWLEDGE_CONTENT_ORIGINAL)
+    # Remove added file to make both identical
+    local_new = (
+        tmp_path
+        / ".agentic-beacon"
+        / "artifacts"
+        / "knowledge"
+        / "python"
+        / "new-lesson.md"
+    )
+    local_new.unlink()
+    # Add new-lesson to warehouse so it's also "identical" (both absent from local)
+    # Actually MISSING means it's in beacon.yaml but not local — we just remove it
+
+    result = runner.invoke(main, ["contribute", "--all"])
+
+    assert result.exit_code == 0
+    assert "nothing to contribute" in result.output.lower()
+
+
+# ---------------------------------------------------------------------------
+# --dry-run flag
+# ---------------------------------------------------------------------------
+
+
+def test_contribute_dry_run_does_not_copy(project_with_delta):
+    tmp_path, warehouse = project_with_delta
+    runner = CliRunner()
+
+    result = runner.invoke(
+        main, ["contribute", "knowledge/python/type-hints.md", "--dry-run"]
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "dry" in result.output.lower() or "would" in result.output.lower()
+    # Warehouse NOT modified
+    assert (
+        warehouse / "knowledge" / "python" / "type-hints.md"
+    ).read_text() == KNOWLEDGE_CONTENT_ORIGINAL
+
+
+def test_contribute_all_dry_run_does_not_copy(project_with_delta):
+    tmp_path, warehouse = project_with_delta
+    runner = CliRunner()
+
+    result = runner.invoke(main, ["contribute", "--all", "--dry-run"])
+
+    assert result.exit_code == 0, result.output
+    # Warehouse files unchanged
+    assert (
+        warehouse / "knowledge" / "python" / "type-hints.md"
+    ).read_text() == KNOWLEDGE_CONTENT_ORIGINAL
+    assert not (warehouse / "knowledge" / "python" / "new-lesson.md").exists()
+
+
+# ---------------------------------------------------------------------------
+# Error cases
+# ---------------------------------------------------------------------------
+
+
+def test_contribute_errors_without_file_or_all(project_with_delta):
+    runner = CliRunner()
+    result = runner.invoke(main, ["contribute"])
+    assert result.exit_code != 0
+
+
+def test_contribute_errors_with_file_and_all(project_with_delta):
+    runner = CliRunner()
+    result = runner.invoke(
+        main, ["contribute", "knowledge/python/type-hints.md", "--all"]
+    )
+    assert result.exit_code != 0
+
+
+def test_contribute_errors_when_file_not_in_beacon_yaml(project_with_delta):
+    runner = CliRunner()
+    result = runner.invoke(main, ["contribute", "knowledge/unlisted/file.md"])
+    assert result.exit_code != 0
+    assert (
+        "beacon.yaml" in result.output.lower() or "not tracked" in result.output.lower()
+    )
+
+
+def test_contribute_errors_when_file_not_synced_locally(project_with_delta):
+    """File is in beacon.yaml but not downloaded yet."""
+    tmp_path, warehouse = project_with_delta
+    # Remove local artifact
+    local = (
+        tmp_path
+        / ".agentic-beacon"
+        / "artifacts"
+        / "knowledge"
+        / "python"
+        / "type-hints.md"
+    )
+    local.unlink()
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["contribute", "knowledge/python/type-hints.md"])
+    assert result.exit_code != 0
+    assert "sync" in result.output.lower() or "not" in result.output.lower()
+
+
+def test_contribute_errors_without_beacon_dir(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(main, ["contribute", "knowledge/python/type-hints.md"])
+    assert result.exit_code != 0
+    assert ".agentic-beacon" in result.output
+
+
+def test_contribute_errors_without_warehouse_connection(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".agentic-beacon").mkdir()
+    # No config.toml
+    runner = CliRunner()
+    result = runner.invoke(main, ["contribute", "knowledge/python/type-hints.md"])
+    assert result.exit_code != 0
+    assert "warehouse" in result.output.lower()

--- a/libs/beacon/tests/core/test_delta_comparator.py
+++ b/libs/beacon/tests/core/test_delta_comparator.py
@@ -337,3 +337,75 @@ def test_summary_filter_properties(valid_warehouse, temp_dir):
     assert len(summary.identical) == 1
     assert len(summary.modified) == 1
     assert len(summary.missing) == 1
+
+
+# ========== Bug fix: compare_from_config detects locally-added files ==========
+
+
+def test_compare_from_config_detects_added_file_via_glob(valid_warehouse, temp_dir):
+    """compare_from_config finds locally-added files that match a glob pattern
+    but don't exist in the warehouse (previously invisible to delta)."""
+    from beacon.core.settings import BeaconSettings
+
+    artifacts_dir = temp_dir / "artifacts"
+    (artifacts_dir / "knowledge").mkdir(parents=True)
+
+    # This file only exists locally — not in the warehouse
+    (artifacts_dir / "knowledge" / "new-lesson.md").write_text("# New Lesson\n")
+
+    beacon_yaml = temp_dir / "beacon.yaml"
+    beacon_yaml.write_text(
+        "artifacts:\n  knowledge:\n    - knowledge/**/*.md\n  skills: []\n  contexts: []\n"
+    )
+    settings = BeaconSettings.from_yaml(beacon_yaml)
+
+    comparator = DeltaComparator(valid_warehouse, artifacts_dir)
+    summary = comparator.compare_from_config(settings)
+
+    added_paths = [r.path for r in summary.added]
+    assert "knowledge/new-lesson.md" in added_paths
+
+
+def test_compare_from_config_detects_added_skill_via_glob(valid_warehouse, temp_dir):
+    """compare_from_config detects a locally-added skill file via glob."""
+    from beacon.core.settings import BeaconSettings
+
+    artifacts_dir = temp_dir / "artifacts"
+    skill_dir = artifacts_dir / "skills" / "my-skill"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("# Skill: My Skill\n")
+
+    beacon_yaml = temp_dir / "beacon.yaml"
+    beacon_yaml.write_text(
+        "artifacts:\n  knowledge: []\n  skills:\n    - skills/**/*\n  contexts: []\n"
+    )
+    settings = BeaconSettings.from_yaml(beacon_yaml)
+
+    comparator = DeltaComparator(valid_warehouse, artifacts_dir)
+    summary = comparator.compare_from_config(settings)
+
+    added_paths = [r.path for r in summary.added]
+    assert "skills/my-skill/SKILL.md" in added_paths
+
+
+def test_compare_from_config_no_duplicates_for_modified(valid_warehouse, temp_dir):
+    """A MODIFIED file present in both warehouse and local is not double-counted."""
+    from beacon.core.settings import BeaconSettings
+
+    artifacts_dir = temp_dir / "artifacts"
+    (artifacts_dir / "knowledge").mkdir(parents=True)
+    (valid_warehouse / "knowledge" / "shared.md").write_text("original")
+    (artifacts_dir / "knowledge" / "shared.md").write_text("modified")
+
+    beacon_yaml = temp_dir / "beacon.yaml"
+    beacon_yaml.write_text(
+        "artifacts:\n  knowledge:\n    - knowledge/**/*.md\n  skills: []\n  contexts: []\n"
+    )
+    settings = BeaconSettings.from_yaml(beacon_yaml)
+
+    comparator = DeltaComparator(valid_warehouse, artifacts_dir)
+    summary = comparator.compare_from_config(settings)
+
+    assert len(summary.results) == 1
+    assert summary.results[0].path == "knowledge/shared.md"
+    assert len(summary.modified) == 1


### PR DESCRIPTION
## Summary

- **New command: `abc contribute`** — copies local artifact changes back to the warehouse so the team benefits from agent-driven improvements
  - `abc contribute knowledge/python/type-hints.md` — single file
  - `abc contribute --all` — all MODIFIED and ADDED artifacts at once
  - `abc contribute --dry-run` — preview without copying
  - Prints the exact `git add / commit / push` commands after copying

- **Bug fix: `abc delta` was blind to locally-added files** — `compare_from_config` only globbed the warehouse, so files created locally by an agent (not yet in the warehouse) were invisible. Now also globs the local artifacts directory and merges both sets without duplicates. Covers knowledge, skills, and contexts equally.

- **Rewrote `guides/warehouse-contribution-guide.md`** — now leads with the `abc contribute` workflow as the primary path. Removed vim-centric manual editing instructions. Designed for the agent-edits-then-contribute flow.

- **Updated README** — `abc contribute` added to CLI reference table, For Teams workflow, Practical Guides list, and feature bullet points.

## Test plan

- [ ] 13 new tests for `abc contribute` — single file, --all, --dry-run, all error cases
- [ ] 3 new regression tests in `test_delta_comparator.py` — locally-added knowledge file via glob, locally-added skill via glob, no duplicates for MODIFIED files
- [ ] Full suite: 239 passed, 2 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)