### PR TITLE
fix(delta): show untracked local skills in abc delta output

### DIFF
--- a/libs/beacon/src/beacon/cli.py
+++ b/libs/beacon/src/beacon/cli.py
@@ -842,8 +842,11 @@ def _show_delta_summary(
 ) -> None:
     """Show summary of all artifact differences."""
     summary = comparator.compare_from_config(beacon_settings)
+    untracked = _find_untracked_local_files(
+        comparator, beacon_settings, comparator.artifacts_path
+    )
 
-    if not summary.has_differences:
+    if not summary.has_differences and not untracked:
         console.print(
             "[green]No differences found. Local artifacts match warehouse.[/green]"
         )
@@ -860,12 +863,18 @@ def _show_delta_summary(
         elif result.status == DeltaStatus.MISSING:
             console.print(f"  [red][Missing][/red]  {result.path}")
 
+    for rel_path in untracked:
+        console.print(
+            f"  [green][Added][/green]    {rel_path} [dim](not in beacon.yaml)[/dim]"
+        )
+
     # Summary counts
     console.print("\n[bold]Summary:[/bold]")
     if summary.modified:
         console.print(f"  [yellow]Modified:[/yellow] {len(summary.modified)} files")
-    if summary.added:
-        console.print(f"  [green]Added:[/green] {len(summary.added)} files")
+    total_added = len(summary.added) + len(untracked)
+    if total_added:
+        console.print(f"  [green]Added:[/green] {total_added} files")
     if summary.missing:
         console.print(f"  [red]Missing:[/red] {len(summary.missing)} files")
     if summary.identical:
@@ -879,6 +888,10 @@ def _show_delta_summary(
     if summary.modified:
         console.print(
             "[dim]Tip: Run 'abc delta <file>' to see detailed diff for a modified file.[/dim]"
+        )
+    if untracked:
+        console.print(
+            "[dim]Tip: Run 'abc contribute --all' to push untracked local artifacts to the warehouse.[/dim]"
         )
 
 

--- a/libs/beacon/tests/cli/test_delta_command.py
+++ b/libs/beacon/tests/cli/test_delta_command.py
@@ -90,6 +90,34 @@ def test_delta_no_beacon_yaml(temp_dir, valid_warehouse, monkeypatch):
     assert "No beacon.yaml found" in result.output
 
 
+def test_delta_shows_untracked_local_skill(temp_dir, valid_warehouse, monkeypatch):
+    """abc delta shows a locally-present skill not registered in beacon.yaml as Added."""
+    project = temp_dir / "project"
+    project.mkdir()
+    beacon_dir = project / ".agentic-beacon"
+    beacon_dir.mkdir()
+    (beacon_dir / "config.toml").write_text(
+        f'[warehouse]\nlocal_path = "{valid_warehouse}"\n'
+    )
+    # beacon.yaml has NO skills entries
+    (beacon_dir / "beacon.yaml").write_text(
+        "artifacts:\n  knowledge: []\n  skills: []\n  contexts: []\n"
+    )
+
+    # Create opsx-handoff skill locally (untracked — not in beacon.yaml, not in warehouse)
+    skill_dir = beacon_dir / "artifacts" / "skills" / "opsx-handoff"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("# opsx-handoff\n")
+
+    runner = CliRunner()
+    monkeypatch.chdir(project)
+    result = runner.invoke(main, ["delta"])
+
+    assert result.exit_code == 0
+    assert "opsx-handoff" in result.output
+    assert "Added" in result.output
+
+
 def test_delta_no_beacon_dir(temp_dir, monkeypatch):
     """No .agentic-beacon directory → Error."""
     project = temp_dir / "project"

--- a/libs/beacon/tests/core/test_delta_comparator.py
+++ b/libs/beacon/tests/core/test_delta_comparator.py
@@ -388,6 +388,31 @@ def test_compare_from_config_detects_added_skill_via_glob(valid_warehouse, temp_
     assert "skills/my-skill/SKILL.md" in added_paths
 
 
+def test_compare_from_config_detects_missing_skill_via_glob(valid_warehouse, temp_dir):
+    """compare_from_config detects a warehouse skill not yet synced locally via glob."""
+    from beacon.core.settings import BeaconSettings
+
+    # Skill exists in warehouse but not in local artifacts
+    skill_dir = valid_warehouse / "skills" / "opsx-handoff"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("# Skill: opsx-handoff\n")
+
+    artifacts_dir = temp_dir / "artifacts"
+    artifacts_dir.mkdir()
+
+    beacon_yaml = temp_dir / "beacon.yaml"
+    beacon_yaml.write_text(
+        "artifacts:\n  knowledge: []\n  skills:\n    - skills/**/*\n  contexts: []\n"
+    )
+    settings = BeaconSettings.from_yaml(beacon_yaml)
+
+    comparator = DeltaComparator(valid_warehouse, artifacts_dir)
+    summary = comparator.compare_from_config(settings)
+
+    missing_paths = [r.path for r in summary.missing]
+    assert "skills/opsx-handoff/SKILL.md" in missing_paths
+
+
 def test_compare_from_config_no_duplicates_for_modified(valid_warehouse, temp_dir):
     """A MODIFIED file present in both warehouse and local is not double-counted."""
     from beacon.core.settings import BeaconSettings


### PR DESCRIPTION
## Summary

- `abc delta` was silently ignoring locally-present artifacts not registered in `beacon.yaml` — skills created in `.agentic-beacon/artifacts/` without a matching beacon.yaml entry were invisible, so `delta` would report "No differences found" even when skills like `opsx-handoff` existed locally but not in the warehouse
- Fixed `_show_delta_summary` to also call `_find_untracked_local_files` and display those as `[Added] (not in beacon.yaml)` with a tip pointing to `abc contribute --all`

## Test plan

- [x] All 249 existing tests pass
- [x] New core test: `test_compare_from_config_detects_missing_skill_via_glob` — verifies a warehouse-only skill shows as MISSING when `skills/**/*` is the beacon.yaml pattern (regression guard)
- [x] New CLI test: `test_delta_shows_untracked_local_skill` — verifies `abc delta` surfaces an `opsx-handoff` skill that exists locally but isn't in `beacon.yaml` or the warehouse

🤖 Generated with [Claude Code](https://claude.com/claude-code)