### PR TITLE
feat!: redesign list operations — abc list <type> and abc warehouse list <type>

### DIFF
--- a/libs/beacon/src/beacon/cli.py
+++ b/libs/beacon/src/beacon/cli.py
@@ -22,28 +22,6 @@ from .warehouse import WarehouseValidator
 console = Console()
 
 
-def find_warehouse_root() -> Path | None:
-    """
-    Find warehouse root by looking for warehouse markers.
-
-    Returns:
-        Path to warehouse root or None if not found
-    """
-    current = Path.cwd()
-
-    # Check current directory and parents
-    for path in [current, *current.parents]:
-        # Check for warehouse markers
-        if (
-            (path / "contexts").exists()
-            and (path / "knowledge").exists()
-            and (path / "skills").exists()
-        ):
-            return path
-
-    return None
-
-
 def find_project_root() -> Path:
     """
     Find project root (current directory or first parent with .git).
@@ -80,7 +58,7 @@ def main(*, verbose: bool) -> None:
 
 @main.group()
 def warehouse() -> None:
-    """Warehouse management commands (init, connect)."""
+    """Warehouse management commands (init, connect, list)."""
     pass
 
 
@@ -334,6 +312,79 @@ def connect(*, path: Path | None) -> None:
         console.print(f"\n[red]Error:[/red] Failed to save connection: {e}")
         logger.exception("Connection failed")
         sys.exit(1)
+
+
+@warehouse.command(name="list")
+@click.argument(
+    "artifact_type",
+    required=False,
+    type=click.Choice(["knowledge", "skills", "contexts"], case_sensitive=False),
+    default=None,
+)
+def warehouse_list(*, artifact_type: str | None) -> None:
+    """List artifacts available in the connected warehouse.
+
+    ARTIFACT_TYPE filters output to a single type. Omit to show all.
+
+    Example:
+        abc warehouse list
+        abc warehouse list knowledge
+        abc warehouse list skills
+        abc warehouse list contexts
+    """
+    beacon_dir = Path.cwd() / ".agentic-beacon"
+    config_file = beacon_dir / "config.toml"
+
+    if not config_file.exists():
+        console.print("[red]Error:[/red] No warehouse connected.")
+        console.print("Run 'abc warehouse connect --path <warehouse>' first.")
+        sys.exit(1)
+
+    try:
+        warehouse_settings = WarehouseSettings()
+        warehouse_path = Path(warehouse_settings.warehouse.local_path)
+    except Exception as e:
+        console.print(f"[red]Error:[/red] Failed to read warehouse connection: {e}")
+        sys.exit(1)
+
+    if not warehouse_path.exists():
+        console.print(
+            f"[red]Error:[/red] Warehouse path no longer exists: {warehouse_path}"
+        )
+        console.print("Run 'abc warehouse connect --path <warehouse>' to reconnect.")
+        sys.exit(1)
+
+    distributor = WarehouseDistributor(
+        warehouse_root=warehouse_path, target_root=Path.cwd()
+    )
+    available = distributor.list_available()
+
+    types_to_show = (
+        [artifact_type] if artifact_type else ["contexts", "knowledge", "skills"]
+    )
+
+    section_config = {
+        "contexts": ("Available Contexts", "cyan", "Context"),
+        "knowledge": ("Available Knowledge", "green", "Scope"),
+        "skills": ("Available Skills", "yellow", "Skill"),
+    }
+
+    any_shown = False
+    for section in types_to_show:
+        items = available.get(section, [])
+        if items:
+            title, color, col_name = section_config[section]
+            table = Table(title=title)
+            table.add_column(col_name, style=color)
+            for item in items:
+                table.add_row(item)
+            console.print(table)
+            console.print()
+            any_shown = True
+
+    if not any_shown:
+        label = artifact_type or "artifacts"
+        console.print(f"[yellow]No {label} found in warehouse.[/yellow]")
 
 
 # ========== Client Commands (top-level) ==========
@@ -1806,50 +1857,71 @@ def update(*, project: Path | None) -> None:
 
 
 @main.command(name="list")
-@click.option(
-    "--warehouse",
-    type=click.Path(exists=True, file_okay=False, path_type=Path),
-    help="Path to warehouse repository (auto-detected if not provided)",
+@click.argument(
+    "artifact_type",
+    required=False,
+    type=click.Choice(["knowledge", "skills", "contexts"], case_sensitive=False),
+    default=None,
 )
-def list_cmd(*, warehouse: Path | None) -> None:
-    """List available warehouse content."""
-    warehouse_root = warehouse or find_warehouse_root()
-    if not warehouse_root:
-        console.print(
-            "[red]Error:[/red] Could not find warehouse root. Specify --warehouse."
-        )
+def list_cmd(*, artifact_type: str | None) -> None:
+    """List artifacts synced to the current project.
+
+    ARTIFACT_TYPE filters output to a single type. Omit to show all.
+
+    Reads from .agentic-beacon/artifacts/. Run 'abc sync' first to populate.
+
+    Example:
+        abc list
+        abc list knowledge
+        abc list skills
+        abc list contexts
+    """
+    beacon_dir = Path.cwd() / ".agentic-beacon"
+    artifacts_dir = beacon_dir / "artifacts"
+
+    if not artifacts_dir.exists():
+        console.print("[red]Error:[/red] No synced artifacts found.")
+        console.print("Run 'abc sync' to download artifacts from the warehouse.")
         sys.exit(1)
 
-    distributor = WarehouseDistributor(
-        warehouse_root=warehouse_root, target_root=Path.cwd()
+    types_to_show = (
+        [artifact_type] if artifact_type else ["contexts", "knowledge", "skills"]
     )
-    available = distributor.list_available()
 
-    # Display contexts
-    if available["contexts"]:
-        table = Table(title="Available Contexts")
-        table.add_column("Context", style="cyan")
-        for context in available["contexts"]:
-            table.add_row(context)
-        console.print(table)
-        console.print()
+    section_config = {
+        "contexts": ("Synced Contexts", "cyan", "Context"),
+        "knowledge": ("Synced Knowledge", "green", "File"),
+        "skills": ("Synced Skills", "yellow", "Skill"),
+    }
 
-    # Display knowledge
-    if available["knowledge"]:
-        table = Table(title="Available Knowledge Scopes")
-        table.add_column("Scope", style="green")
-        for scope in available["knowledge"]:
-            table.add_row(scope)
-        console.print(table)
-        console.print()
+    any_shown = False
+    for section in types_to_show:
+        section_dir = artifacts_dir / section
+        if not section_dir.exists():
+            continue
 
-    # Display skills
-    if available["skills"]:
-        table = Table(title="Available Skills")
-        table.add_column("Skill", style="yellow")
-        for skill in available["skills"]:
-            table.add_row(skill)
-        console.print(table)
+        files = sorted(
+            str(f.relative_to(artifacts_dir))
+            for f in section_dir.rglob("*")
+            if f.is_file() and not f.name.startswith(".")
+        )
+
+        if files:
+            title, color, col_name = section_config[section]
+            table = Table(title=title)
+            table.add_column(col_name, style=color)
+            for item in files:
+                table.add_row(item)
+            console.print(table)
+            console.print()
+            any_shown = True
+
+    if not any_shown:
+        label = artifact_type or "artifacts"
+        console.print(
+            f"[yellow]No {label} found in .agentic-beacon/artifacts/.[/yellow]"
+        )
+        console.print("Run 'abc sync' to download artifacts from the warehouse.")
 
 
 @main.command()

--- a/libs/beacon/tests/cli/test_e2e_happy_path.py
+++ b/libs/beacon/tests/cli/test_e2e_happy_path.py
@@ -98,14 +98,18 @@ def test_e2e_warehouse_init_installs_record_knowledge(e2e_warehouse):
 
 
 # ---------------------------------------------------------------------------
-# Step 2 — abc list shows all three sections including Contexts
+# Step 2 — abc warehouse list shows all three sections including Contexts
 # ---------------------------------------------------------------------------
 
 
-def test_e2e_list_shows_contexts(e2e_project):
+def test_e2e_warehouse_list_shows_contexts(e2e_project):
     project_dir, warehouse, runner = e2e_project
 
-    result = runner.invoke(main, ["list", "--warehouse", str(warehouse)])
+    # Connect first so warehouse list can read config.toml
+    connect = runner.invoke(main, ["warehouse", "connect", "--path", str(warehouse)])
+    assert connect.exit_code == 0, f"connect failed:\n{connect.output}"
+
+    result = runner.invoke(main, ["warehouse", "list"])
 
     assert result.exit_code == 0
     assert "Contexts" in result.output

--- a/libs/beacon/tests/cli/test_list_commands.py
+++ b/libs/beacon/tests/cli/test_list_commands.py
@@ -1,0 +1,305 @@
+"""Tests for abc list and abc warehouse list commands."""
+
+import pytest
+from beacon.cli import main
+from click.testing import CliRunner
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+@pytest.fixture
+def warehouse_with_artifacts(tmp_path):
+    """A valid warehouse with contexts, knowledge, and skills."""
+    wh = tmp_path / "warehouse"
+    wh.mkdir()
+    (wh / "README.md").write_text("# Warehouse")
+    (wh / "docs").mkdir()
+
+    (wh / "contexts").mkdir()
+    (wh / "contexts" / "AGENTS.md").write_text("# Context")
+
+    (wh / "knowledge").mkdir()
+    (wh / "knowledge" / "python").mkdir()
+    (wh / "knowledge" / "python" / "standards.md").write_text("# Python Standards")
+
+    (wh / "skills").mkdir()
+    skill_dir = wh / "skills" / "code-review"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text("# Skill: Code Review")
+
+    return wh
+
+
+@pytest.fixture
+def connected_project(tmp_path, warehouse_with_artifacts, monkeypatch):
+    """A project connected to warehouse_with_artifacts."""
+    project = tmp_path / "project"
+    project.mkdir()
+    monkeypatch.chdir(project)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main, ["warehouse", "connect", "--path", str(warehouse_with_artifacts)]
+    )
+    assert result.exit_code == 0, f"connect failed:\n{result.output}"
+
+    return project, warehouse_with_artifacts, runner
+
+
+@pytest.fixture
+def synced_project(connected_project):
+    """A connected project with artifacts synced from the warehouse."""
+    project, warehouse, runner = connected_project
+
+    # Write beacon.yaml
+    beacon_yaml = project / ".agentic-beacon" / "beacon.yaml"
+    beacon_yaml.write_text(
+        "artifacts:\n"
+        "  knowledge:\n"
+        "    - knowledge/python/standards.md\n"
+        "  skills:\n"
+        "    - skills/code-review/SKILL.md\n"
+        "  contexts:\n"
+        "    - contexts/AGENTS.md\n"
+    )
+
+    result = runner.invoke(main, ["sync"])
+    assert result.exit_code == 0, f"sync failed:\n{result.output}"
+
+    return project, warehouse, runner
+
+
+# ---------------------------------------------------------------------------
+# abc warehouse list — unit / isolated tests
+# ---------------------------------------------------------------------------
+
+
+def test_warehouse_list_requires_connected_project(runner, tmp_path, monkeypatch):
+    """abc warehouse list exits non-zero when no config.toml exists."""
+    project = tmp_path / "project"
+    project.mkdir()
+    monkeypatch.chdir(project)
+
+    result = runner.invoke(main, ["warehouse", "list"])
+
+    assert result.exit_code != 0
+    assert "No warehouse connected" in result.output
+
+
+def test_warehouse_list_all_types(connected_project):
+    """abc warehouse list shows all three sections."""
+    project, warehouse, runner = connected_project
+
+    result = runner.invoke(main, ["warehouse", "list"])
+
+    assert result.exit_code == 0
+    assert "Contexts" in result.output
+    assert "Knowledge" in result.output
+    assert "Skills" in result.output
+
+
+def test_warehouse_list_filter_knowledge(connected_project):
+    """abc warehouse list knowledge shows only knowledge section."""
+    project, warehouse, runner = connected_project
+
+    result = runner.invoke(main, ["warehouse", "list", "knowledge"])
+
+    assert result.exit_code == 0
+    assert "Knowledge" in result.output
+    assert "Contexts" not in result.output
+    assert "Skills" not in result.output
+
+
+def test_warehouse_list_filter_skills(connected_project):
+    """abc warehouse list skills shows only skills section."""
+    project, warehouse, runner = connected_project
+
+    result = runner.invoke(main, ["warehouse", "list", "skills"])
+
+    assert result.exit_code == 0
+    assert "Skills" in result.output
+    assert "Knowledge" not in result.output
+    assert "Contexts" not in result.output
+
+
+def test_warehouse_list_filter_contexts(connected_project):
+    """abc warehouse list contexts shows only contexts section."""
+    project, warehouse, runner = connected_project
+
+    result = runner.invoke(main, ["warehouse", "list", "contexts"])
+
+    assert result.exit_code == 0
+    assert "Contexts" in result.output
+    assert "Knowledge" not in result.output
+    assert "Skills" not in result.output
+
+
+def test_warehouse_list_shows_artifact_paths(connected_project):
+    """abc warehouse list shows actual artifact paths from the warehouse."""
+    project, warehouse, runner = connected_project
+
+    result = runner.invoke(main, ["warehouse", "list"])
+
+    assert result.exit_code == 0
+    assert "contexts/AGENTS.md" in result.output
+
+
+def test_warehouse_list_empty_warehouse(runner, tmp_path, monkeypatch):
+    """abc warehouse list handles empty warehouse sections gracefully."""
+    project = tmp_path / "project"
+    project.mkdir()
+    monkeypatch.chdir(project)
+
+    # Create an empty but valid warehouse
+    wh = tmp_path / "empty-warehouse"
+    wh.mkdir()
+    (wh / "README.md").write_text("# Empty Warehouse")
+    (wh / "docs").mkdir()
+    (wh / "contexts").mkdir()
+    (wh / "knowledge").mkdir()
+    (wh / "skills").mkdir()
+
+    connect_result = runner.invoke(main, ["warehouse", "connect", "--path", str(wh)])
+    assert connect_result.exit_code == 0
+
+    result = runner.invoke(main, ["warehouse", "list"])
+
+    assert result.exit_code == 0
+    assert "No artifacts found" in result.output or result.output.strip() != ""
+
+
+def test_warehouse_list_shown_in_warehouse_help(runner):
+    """abc warehouse --help lists the list subcommand."""
+    result = runner.invoke(main, ["warehouse", "--help"])
+
+    assert result.exit_code == 0
+    assert "list" in result.output
+
+
+# ---------------------------------------------------------------------------
+# abc list — unit / isolated tests
+# ---------------------------------------------------------------------------
+
+
+def test_list_project_no_artifacts_dir(runner, tmp_path, monkeypatch):
+    """abc list exits non-zero when .agentic-beacon/artifacts/ does not exist."""
+    project = tmp_path / "project"
+    project.mkdir()
+    monkeypatch.chdir(project)
+
+    result = runner.invoke(main, ["list"])
+
+    assert result.exit_code != 0
+    assert "No synced artifacts" in result.output
+
+
+def test_list_project_all_types(synced_project):
+    """abc list shows all three synced artifact sections."""
+    project, warehouse, runner = synced_project
+
+    result = runner.invoke(main, ["list"])
+
+    assert result.exit_code == 0
+    assert "Contexts" in result.output
+    assert "Knowledge" in result.output
+    assert "Skills" in result.output
+
+
+def test_list_project_filter_knowledge(synced_project):
+    """abc list knowledge shows only synced knowledge."""
+    project, warehouse, runner = synced_project
+
+    result = runner.invoke(main, ["list", "knowledge"])
+
+    assert result.exit_code == 0
+    assert "Knowledge" in result.output
+    assert "Contexts" not in result.output
+    assert "Skills" not in result.output
+
+
+def test_list_project_filter_skills(synced_project):
+    """abc list skills shows only synced skills."""
+    project, warehouse, runner = synced_project
+
+    result = runner.invoke(main, ["list", "skills"])
+
+    assert result.exit_code == 0
+    assert "Skills" in result.output
+    assert "Knowledge" not in result.output
+    assert "Contexts" not in result.output
+
+
+def test_list_project_filter_contexts(synced_project):
+    """abc list contexts shows only synced contexts."""
+    project, warehouse, runner = synced_project
+
+    result = runner.invoke(main, ["list", "contexts"])
+
+    assert result.exit_code == 0
+    assert "Contexts" in result.output
+    assert "Knowledge" not in result.output
+    assert "Skills" not in result.output
+
+
+def test_list_project_shows_artifact_paths(synced_project):
+    """abc list shows actual relative file paths under each section."""
+    project, warehouse, runner = synced_project
+
+    result = runner.invoke(main, ["list"])
+
+    assert result.exit_code == 0
+    assert "knowledge/python/standards.md" in result.output
+    assert "skills/code-review/SKILL.md" in result.output
+    assert "contexts/AGENTS.md" in result.output
+
+
+def test_list_project_empty_artifacts_dir(runner, tmp_path, monkeypatch):
+    """abc list shows helpful message when artifacts dir exists but is empty."""
+    project = tmp_path / "project"
+    project.mkdir()
+    monkeypatch.chdir(project)
+
+    # Create empty artifacts dir
+    (project / ".agentic-beacon" / "artifacts").mkdir(parents=True)
+
+    result = runner.invoke(main, ["list"])
+
+    assert result.exit_code == 0
+    assert "No artifacts found" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Integration: warehouse list end-to-end
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+def test_integration_warehouse_list_skills_filter(connected_project):
+    """Integration: abc warehouse list skills returns only skills after connection."""
+    project, warehouse, runner = connected_project
+
+    result = runner.invoke(main, ["warehouse", "list", "skills"])
+
+    assert result.exit_code == 0
+    assert "Skills" in result.output
+    assert "code-review" in result.output
+
+
+@pytest.mark.integration
+def test_integration_list_after_sync(synced_project):
+    """Integration: abc list shows all synced artifacts after abc sync."""
+    project, warehouse, runner = synced_project
+
+    result = runner.invoke(main, ["list"])
+
+    assert result.exit_code == 0
+    assert "knowledge/python/standards.md" in result.output
+    assert "skills/code-review/SKILL.md" in result.output
+    assert "contexts/AGENTS.md" in result.output


### PR DESCRIPTION
## Summary

Closes #26

- **Removes** the old `abc list --warehouse` command (breaking change — replaces with two focused commands)
- **Adds** `abc warehouse list [artifact_type]` — lists artifacts available in the connected warehouse, reads path from `.agentic-beacon/config.toml`, filtered by optional type (`knowledge` | `skills` | `contexts`)
- **Adds** `abc list [artifact_type]` — lists artifacts already synced to the project under `.agentic-beacon/artifacts/`, with same optional type filter
- Removes `find_warehouse_root()` heuristic (was only used by the old command)
- Skips the `~/.abc` global config as discussed in the issue — both commands remain project-scoped

## Test plan

- [x] New `libs/beacon/tests/cli/test_list_commands.py` with 17 tests (unit + 2 integration): guards, all-types, per-type filtering, path output, empty states
- [x] Updated `test_e2e_happy_path.py` — `test_e2e_list_shows_contexts` replaced with `test_e2e_warehouse_list_shows_contexts` using the new command
- [x] Full test suite passes: 302 passed, 2 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)