### PR TITLE
fix: abc delta compares skills against live agent dirs not artifact snapshot

### DIFF
--- a/libs/beacon/src/beacon/cli.py
+++ b/libs/beacon/src/beacon/cli.py
@@ -1064,9 +1064,21 @@ def delta(*, file: str | None, no_color: bool) -> None:
         artifacts_dir = beacon_dir / "artifacts"
         beacon_settings = BeaconSettings.from_yaml(beacon_yaml)
 
+        # Build skills_paths: map each detected agent to its live skills directory.
+        # Skills are physically copied there during sync — that's the file agents read.
+        project_root = Path.cwd()
+        agents = _detect_agents(project_root)
+        skills_paths: dict[str, Path] = {}
+        for agent in agents:
+            if agent == "opencode":
+                skills_paths["opencode"] = project_root / ".opencode" / "skills"
+            elif agent == "claudecode":
+                skills_paths["claudecode"] = project_root / ".claude" / "skills"
+
         comparator = DeltaComparator(
             warehouse_path=warehouse_path,
             artifacts_path=artifacts_dir,
+            skills_paths=skills_paths,
         )
 
         if file:
@@ -1102,7 +1114,14 @@ def _show_delta_summary(
 
     for result in summary.results:
         if result.status == DeltaStatus.MODIFIED:
-            console.print(f"  [yellow][Modified][/yellow] {result.path}")
+            if result.is_skill and result.agent_statuses:
+                # Show per-agent breakdown for skills
+                agent_detail = _format_skill_agent_statuses(result.agent_statuses)
+                console.print(
+                    f"  [yellow][Modified][/yellow] {result.path} [dim]({agent_detail})[/dim]"
+                )
+            else:
+                console.print(f"  [yellow][Modified][/yellow] {result.path}")
         elif result.status == DeltaStatus.ADDED:
             console.print(f"  [green][Added][/green]    {result.path}")
         elif result.status == DeltaStatus.MISSING:
@@ -1185,6 +1204,26 @@ def _show_detailed_diff(
         console.print(diff_output)
     else:
         console.print("[dim]No differences to display.[/dim]")
+
+
+def _format_skill_agent_statuses(agent_statuses: dict) -> str:
+    """Format per-agent skill statuses for display.
+
+    e.g. "opencode: modified, claudecode: identical"
+    """
+    from beacon.core.delta import DeltaStatus
+
+    label = {
+        DeltaStatus.MODIFIED: "modified",
+        DeltaStatus.MISSING: "missing",
+        DeltaStatus.ADDED: "added",
+        DeltaStatus.IDENTICAL: "identical",
+    }
+    parts = [
+        f"{agent}: {label.get(status, status.value)}"
+        for agent, status in agent_statuses.items()
+    ]
+    return ", ".join(parts)
 
 
 def _collect_artifact_paths(

--- a/libs/beacon/src/beacon/core/delta.py
+++ b/libs/beacon/src/beacon/core/delta.py
@@ -2,6 +2,10 @@
 
 This module implements hash-based and diff-based comparison between
 local project artifacts and warehouse source files.
+
+For skills, comparison is done against the live agent installation directories
+(e.g. .opencode/skills/, .claude/skills/) rather than the artifact snapshot,
+because the agent reads from those locations — not from .agentic-beacon/artifacts/.
 """
 
 import hashlib
@@ -30,8 +34,15 @@ class ComparisonResult(BaseModel):
     status: DeltaStatus
     local_hash: str | None = None
     warehouse_hash: str | None = None
+    # For skills: per-agent comparison results {agent_name: DeltaStatus}
+    # Empty for non-skill artifacts.
+    agent_statuses: dict[str, DeltaStatus] = {}
 
     model_config = {"arbitrary_types_allowed": True}
+
+    @property
+    def is_skill(self) -> bool:
+        return bool(self.agent_statuses)
 
 
 @dataclass
@@ -67,10 +78,23 @@ class DeltaComparator:
 
     Supports hash-based summary comparison and detailed git diff.
     Only compares artifacts declared in beacon.yaml.
+
+    For skills, comparison is against live agent installation directories
+    (skills_paths) rather than the artifact snapshot. This reflects that
+    skills are physically copied to agent-specific locations during sync,
+    and those are the files agents actually read.
+
+    Args:
+        warehouse_path: Path to the warehouse source directory.
+        artifacts_path: Path to .agentic-beacon/artifacts/ (used for knowledge/contexts).
+        skills_paths: Mapping of agent name to its skills root directory.
+            e.g. {"opencode": Path(".opencode/skills"), "claudecode": Path(".claude/skills")}
+            If empty, falls back to artifacts_path for skills (backward compat).
     """
 
     warehouse_path: Path
     artifacts_path: Path
+    skills_paths: dict[str, Path] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
         """Resolve paths and validate warehouse directory.
@@ -80,10 +104,14 @@ class DeltaComparator:
         """
         self.warehouse_path = Path(self.warehouse_path).resolve()
         self.artifacts_path = Path(self.artifacts_path).resolve()
+        self.skills_paths = {
+            agent: Path(p).resolve() for agent, p in self.skills_paths.items()
+        }
         logger.debug(
-            "DeltaComparator initialized: warehouse={}, artifacts={}",
+            "DeltaComparator initialized: warehouse={}, artifacts={}, skills_paths={}",
             self.warehouse_path,
             self.artifacts_path,
+            self.skills_paths,
         )
 
         if not self.warehouse_path.is_dir():
@@ -121,8 +149,34 @@ class DeltaComparator:
                 sha256.update(chunk)
         return sha256.hexdigest()
 
+    def _skill_live_path(self, agent: str, relative_path: str) -> Path:
+        """Resolve the live installed path for a skill on a given agent.
+
+        Skills are stored in the warehouse as skills/<name>/SKILL.md but are
+        installed into <agent_skills_root>/<name>/SKILL.md.
+
+        Args:
+            agent: Agent name key into self.skills_paths.
+            relative_path: Warehouse-relative path, e.g. "skills/opsx-enhance/SKILL.md".
+
+        Returns:
+            Absolute path to the skill's live location for that agent.
+        """
+        agent_root = self.skills_paths[agent]
+        # Strip the leading "skills/" prefix to get "<name>/SKILL.md"
+        parts = Path(relative_path).parts
+        if parts[0] == "skills":
+            skill_relative = Path(*parts[1:])
+        else:
+            skill_relative = Path(relative_path)
+        return agent_root / skill_relative
+
     def compare_file(self, relative_path: str) -> ComparisonResult:
         """Compare a single artifact between local and warehouse.
+
+        For skills (when skills_paths is configured): compares warehouse against
+        each agent's live installation directory and rolls up to a single status.
+        For knowledge/contexts: compares warehouse against artifacts_path.
 
         Args:
             relative_path: Relative path from artifacts/warehouse root
@@ -130,6 +184,11 @@ class DeltaComparator:
         Returns:
             ComparisonResult with status and hashes
         """
+        is_skill = relative_path.startswith("skills/") and bool(self.skills_paths)
+
+        if is_skill:
+            return self._compare_skill_file(relative_path)
+
         local_file = self.artifacts_path / relative_path
         warehouse_file = self.warehouse_path / relative_path
 
@@ -183,6 +242,58 @@ class DeltaComparator:
                 warehouse_hash=warehouse_hash,
             )
 
+    def _compare_skill_file(self, relative_path: str) -> ComparisonResult:
+        """Compare a skill against all live agent installation directories.
+
+        The rolled-up status reflects the worst case across all agents:
+        MODIFIED > MISSING > ADDED > IDENTICAL.
+
+        Args:
+            relative_path: Warehouse-relative path, e.g. "skills/opsx-enhance/SKILL.md".
+
+        Returns:
+            ComparisonResult with per-agent statuses and an aggregate status.
+        """
+        warehouse_file = self.warehouse_path / relative_path
+        warehouse_exists = warehouse_file.is_file()
+        warehouse_hash = self.compute_hash(warehouse_file) if warehouse_exists else None
+
+        agent_statuses: dict[str, DeltaStatus] = {}
+
+        for agent, _agent_root in self.skills_paths.items():
+            live_file = self._skill_live_path(agent, relative_path)
+            live_exists = live_file.is_file()
+
+            if not live_exists and not warehouse_exists:
+                agent_statuses[agent] = DeltaStatus.MISSING
+            elif live_exists and not warehouse_exists:
+                agent_statuses[agent] = DeltaStatus.ADDED
+            elif not live_exists and warehouse_exists:
+                agent_statuses[agent] = DeltaStatus.MISSING
+            else:
+                live_hash = self.compute_hash(live_file)
+                if live_hash == warehouse_hash:
+                    agent_statuses[agent] = DeltaStatus.IDENTICAL
+                else:
+                    agent_statuses[agent] = DeltaStatus.MODIFIED
+
+        # Roll up: worst status across all agents
+        # Priority: MODIFIED > MISSING > ADDED > IDENTICAL
+        priority = {
+            DeltaStatus.MODIFIED: 3,
+            DeltaStatus.MISSING: 2,
+            DeltaStatus.ADDED: 1,
+            DeltaStatus.IDENTICAL: 0,
+        }
+        aggregate = max(agent_statuses.values(), key=lambda s: priority[s])
+
+        return ComparisonResult(
+            path=relative_path,
+            status=aggregate,
+            warehouse_hash=warehouse_hash,
+            agent_statuses=agent_statuses,
+        )
+
     def compare_all(self, artifact_paths: list[str] | None = None) -> DeltaSummary:
         """Compare all artifacts.
 
@@ -217,6 +328,9 @@ class DeltaComparator:
         Detects MODIFIED, IDENTICAL, and MISSING files (those in the warehouse)
         as well as ADDED files (those that exist locally but not in the warehouse).
 
+        For skills: compares against live agent installation directories when
+        skills_paths is configured. Falls back to artifacts_path otherwise.
+
         Args:
             beacon_settings: Parsed BeaconSettings object
 
@@ -243,9 +357,32 @@ class DeltaComparator:
                             seen.add(rel_path)
                             artifact_paths.append(rel_path)
 
-                    # Also glob the local artifacts dir — catches ADDED files that
-                    # only exist locally and would be invisible to a warehouse-only glob
-                    if self.artifacts_path.exists():
+                    # For skills with live agent paths: glob the agent dirs to catch
+                    # ADDED files that only exist locally.
+                    # For skills without agent paths (no agents detected): fall back
+                    # to artifacts_path glob (backward compat).
+                    # For non-skills: glob local artifacts dir.
+                    if artifact_type == "skills" and self.skills_paths:
+                        for _agent, agent_root in self.skills_paths.items():
+                            if agent_root.exists():
+                                # Translate pattern: "skills/**/*" → "**/*" relative to agent root
+                                parts = Path(pattern).parts
+                                if parts[0] == "skills":
+                                    agent_pattern = (
+                                        str(Path(*parts[1:]))
+                                        if len(parts) > 1
+                                        else "**/*"
+                                    )
+                                else:
+                                    agent_pattern = pattern
+                                for match in agent_root.glob(agent_pattern):
+                                    if match.is_file():
+                                        skill_rel = match.relative_to(agent_root)
+                                        rel_path = str(Path("skills") / skill_rel)
+                                        if rel_path not in seen:
+                                            seen.add(rel_path)
+                                            artifact_paths.append(rel_path)
+                    elif self.artifacts_path.exists():
                         for match in self.artifacts_path.glob(pattern):
                             if match.is_file():
                                 rel_path = str(match.relative_to(self.artifacts_path))
@@ -262,15 +399,32 @@ class DeltaComparator:
     def detailed_diff(self, relative_path: str, color: bool = True) -> str:
         """Get detailed line-by-line diff using git diff --no-index.
 
+        For skills: diffs against the first available agent's live installation.
+        For knowledge/contexts: diffs against artifacts_path.
+
         Args:
             relative_path: Relative path of the artifact to diff
             color: Whether to include ANSI color codes
 
         Returns:
-            Unified diff string, or empty string if identical
+            Unified diff string, or error message string if files unavailable
         """
-        local_file = self.artifacts_path / relative_path
         warehouse_file = self.warehouse_path / relative_path
+
+        is_skill = relative_path.startswith("skills/") and bool(self.skills_paths)
+        if is_skill:
+            # Use first agent that has the skill installed; fall back to artifacts
+            local_file = None
+            for agent in self.skills_paths:
+                candidate = self._skill_live_path(agent, relative_path)
+                if candidate.exists():
+                    local_file = candidate
+                    break
+            if local_file is None:
+                # No agent has it installed — fall back to artifact snapshot
+                local_file = self.artifacts_path / relative_path
+        else:
+            local_file = self.artifacts_path / relative_path
 
         if not local_file.exists():
             return f"Local file not found: {relative_path}"

--- a/libs/beacon/tests/cli/test_delta_command.py
+++ b/libs/beacon/tests/cli/test_delta_command.py
@@ -128,3 +128,204 @@ def test_delta_no_beacon_dir(temp_dir, monkeypatch):
     result = runner.invoke(main, ["delta"])
     assert result.exit_code == 1
     assert "No .agentic-beacon" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Skills: live agent path comparison (bug fix)
+# abc delta must compare skills against the live agent dirs, not the snapshot.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def project_with_skill(temp_dir, valid_warehouse):
+    """Project with a synced skill and an opencode.json agent config."""
+    project = temp_dir / "project"
+    project.mkdir()
+
+    beacon_dir = project / ".agentic-beacon"
+    beacon_dir.mkdir()
+    (beacon_dir / "config.toml").write_text(
+        f'[warehouse]\nlocal_path = "{valid_warehouse}"\n'
+    )
+    (beacon_dir / "beacon.yaml").write_text(
+        "artifacts:\n"
+        "  knowledge: []\n"
+        "  skills:\n"
+        "    - skills/my-skill/SKILL.md\n"
+        "  contexts: []\n"
+    )
+
+    # Add skill to warehouse
+    skill_wh = valid_warehouse / "skills" / "my-skill"
+    skill_wh.mkdir(parents=True)
+    (skill_wh / "SKILL.md").write_text("# Warehouse version\n")
+
+    # Artifact snapshot (identical to warehouse)
+    (beacon_dir / "artifacts" / "skills" / "my-skill").mkdir(parents=True)
+    (beacon_dir / "artifacts" / "skills" / "my-skill" / "SKILL.md").write_text(
+        "# Warehouse version\n"
+    )
+
+    # opencode.json marks this as an opencode project
+    (project / "opencode.json").write_text("{}")
+
+    return project
+
+
+def test_delta_skill_identical_live_shows_no_differences(
+    project_with_skill, valid_warehouse, monkeypatch
+):
+    """abc delta reports no differences when live skill matches warehouse."""
+    project = project_with_skill
+
+    # Install the live skill (identical to warehouse)
+    live_dir = project / ".opencode" / "skills" / "my-skill"
+    live_dir.mkdir(parents=True)
+    (live_dir / "SKILL.md").write_text("# Warehouse version\n")
+
+    runner = CliRunner()
+    monkeypatch.chdir(project)
+    result = runner.invoke(main, ["delta"])
+
+    assert result.exit_code == 0
+    assert "No differences" in result.output
+
+
+def test_delta_skill_modified_live_shows_modified(
+    project_with_skill, valid_warehouse, monkeypatch
+):
+    """abc delta reports Modified when live skill differs from warehouse."""
+    project = project_with_skill
+
+    # Install a MODIFIED version in the live dir
+    live_dir = project / ".opencode" / "skills" / "my-skill"
+    live_dir.mkdir(parents=True)
+    (live_dir / "SKILL.md").write_text("# Locally edited version\n")
+
+    runner = CliRunner()
+    monkeypatch.chdir(project)
+    result = runner.invoke(main, ["delta"])
+
+    assert result.exit_code == 0
+    assert "Modified" in result.output
+    assert "skills/my-skill/SKILL.md" in result.output
+
+
+def test_delta_skill_snapshot_identical_but_live_modified_shows_modified(
+    project_with_skill, valid_warehouse, monkeypatch
+):
+    """Regression: delta reports Modified even when artifact snapshot is identical.
+
+    This is the core bug scenario — the snapshot matches warehouse but the live
+    agent copy has been edited. Without the fix, delta would silently show
+    'No differences'.
+    """
+    project = project_with_skill
+
+    # Snapshot is identical to warehouse (no drift there)
+    # but live dir has a different version
+    live_dir = project / ".opencode" / "skills" / "my-skill"
+    live_dir.mkdir(parents=True)
+    (live_dir / "SKILL.md").write_text("# Added a new guardrail\n")
+
+    runner = CliRunner()
+    monkeypatch.chdir(project)
+    result = runner.invoke(main, ["delta"])
+
+    assert result.exit_code == 0
+    assert "Modified" in result.output
+    assert "skills/my-skill/SKILL.md" in result.output
+
+
+def test_delta_skill_shows_per_agent_breakdown_in_output(
+    temp_dir, valid_warehouse, monkeypatch
+):
+    """abc delta shows per-agent status for modified skills with multiple agents."""
+    project = temp_dir / "project"
+    project.mkdir()
+
+    beacon_dir = project / ".agentic-beacon"
+    beacon_dir.mkdir()
+    (beacon_dir / "config.toml").write_text(
+        f'[warehouse]\nlocal_path = "{valid_warehouse}"\n'
+    )
+    (beacon_dir / "beacon.yaml").write_text(
+        "artifacts:\n"
+        "  knowledge: []\n"
+        "  skills:\n"
+        "    - skills/my-skill/SKILL.md\n"
+        "  contexts: []\n"
+    )
+
+    skill_wh = valid_warehouse / "skills" / "my-skill"
+    skill_wh.mkdir(parents=True)
+    (skill_wh / "SKILL.md").write_text("# Warehouse\n")
+
+    (beacon_dir / "artifacts" / "skills" / "my-skill").mkdir(parents=True)
+    (beacon_dir / "artifacts" / "skills" / "my-skill" / "SKILL.md").write_text(
+        "# Warehouse\n"
+    )
+
+    # Both agents configured
+    (project / "opencode.json").write_text("{}")
+    (project / ".claude").mkdir()
+
+    # opencode: modified
+    oc_live = project / ".opencode" / "skills" / "my-skill"
+    oc_live.mkdir(parents=True)
+    (oc_live / "SKILL.md").write_text("# OpenCode edit\n")
+
+    # claudecode: identical
+    cc_live = project / ".claude" / "skills" / "my-skill"
+    cc_live.mkdir(parents=True)
+    (cc_live / "SKILL.md").write_text("# Warehouse\n")
+
+    runner = CliRunner()
+    monkeypatch.chdir(project)
+    result = runner.invoke(main, ["delta"])
+
+    assert result.exit_code == 0
+    assert "Modified" in result.output
+    assert "opencode" in result.output
+    assert "claudecode" in result.output
+    # opencode modified, claudecode identical
+    assert "modified" in result.output.lower()
+    assert "identical" in result.output.lower()
+
+
+def test_delta_skill_no_live_dir_reports_missing(
+    project_with_skill, valid_warehouse, monkeypatch
+):
+    """abc delta reports Missing when skill is in warehouse but not installed in live dir."""
+    project = project_with_skill
+    # opencode.json exists (agent detected) but .opencode/skills/ dir is absent
+
+    runner = CliRunner()
+    monkeypatch.chdir(project)
+    result = runner.invoke(main, ["delta"])
+
+    assert result.exit_code == 0
+    assert "Missing" in result.output
+    assert "skills/my-skill/SKILL.md" in result.output
+
+
+def test_delta_skill_detailed_diff_uses_live_path(
+    project_with_skill, valid_warehouse, monkeypatch
+):
+    """abc delta <file> diffs warehouse against the live agent copy, not the snapshot."""
+    project = project_with_skill
+
+    # Snapshot identical to warehouse
+    # Live has extra content
+    live_dir = project / ".opencode" / "skills" / "my-skill"
+    live_dir.mkdir(parents=True)
+    (live_dir / "SKILL.md").write_text(
+        "# Warehouse version\n\n## New Section\nExtra.\n"
+    )
+
+    runner = CliRunner()
+    monkeypatch.chdir(project)
+    result = runner.invoke(main, ["delta", "skills/my-skill/SKILL.md", "--no-color"])
+
+    assert result.exit_code == 0
+    assert "New Section" in result.output or "Extra" in result.output

--- a/libs/beacon/tests/cli/test_e2e_happy_path.py
+++ b/libs/beacon/tests/cli/test_e2e_happy_path.py
@@ -329,6 +329,144 @@ def test_e2e_delta_detects_modification(e2e_project):
 
 
 # ---------------------------------------------------------------------------
+# Steps 7a — delta correctly handles skills via live agent directories
+# ---------------------------------------------------------------------------
+
+
+def test_e2e_delta_skill_clean_after_sync(e2e_project):
+    """After abc sync, delta reports skill as identical (live dir matches warehouse)."""
+    project_dir, warehouse, runner = e2e_project
+    runner.invoke(main, ["warehouse", "connect", "--path", str(warehouse)])
+
+    # Configure an opencode project
+    (project_dir / "opencode.json").write_text("{}")
+
+    beacon_yaml = project_dir / ".agentic-beacon" / "beacon.yaml"
+    beacon_yaml.write_text(
+        "artifacts:\n"
+        "  knowledge: []\n"
+        "  skills:\n"
+        "    - skills/code-review/SKILL.md\n"
+        "  contexts: []\n"
+    )
+    sync_result = runner.invoke(main, ["sync"])
+    assert sync_result.exit_code == 0
+
+    # Verify the live skill was installed
+    assert (project_dir / ".opencode" / "skills" / "code-review" / "SKILL.md").exists()
+
+    result = runner.invoke(main, ["delta"])
+
+    assert result.exit_code == 0
+    assert "No differences" in result.output
+
+
+def test_e2e_delta_skill_detects_live_modification(e2e_project):
+    """abc delta detects a modification made directly to the live agent skill file."""
+    project_dir, warehouse, runner = e2e_project
+    runner.invoke(main, ["warehouse", "connect", "--path", str(warehouse)])
+
+    (project_dir / "opencode.json").write_text("{}")
+
+    beacon_yaml = project_dir / ".agentic-beacon" / "beacon.yaml"
+    beacon_yaml.write_text(
+        "artifacts:\n"
+        "  knowledge: []\n"
+        "  skills:\n"
+        "    - skills/code-review/SKILL.md\n"
+        "  contexts: []\n"
+    )
+    runner.invoke(main, ["sync"])
+
+    # Edit the live agent copy (simulates a user adding a guardrail locally)
+    live_skill = project_dir / ".opencode" / "skills" / "code-review" / "SKILL.md"
+    live_skill.write_text(live_skill.read_text() + "\n## Local Guardrail\nNo foo.\n")
+
+    result = runner.invoke(main, ["delta"])
+
+    assert result.exit_code == 0
+    assert "Modified" in result.output
+    assert "skills/code-review/SKILL.md" in result.output
+
+
+def test_e2e_delta_skill_snapshot_identical_but_live_modified(e2e_project):
+    """Regression: delta catches live skill drift even when snapshot still matches warehouse.
+
+    This is the exact bug scenario: snapshot == warehouse but live != warehouse.
+    The old code would report 'No differences'. The fix makes it report Modified.
+    """
+    project_dir, warehouse, runner = e2e_project
+    runner.invoke(main, ["warehouse", "connect", "--path", str(warehouse)])
+
+    (project_dir / "opencode.json").write_text("{}")
+
+    beacon_yaml = project_dir / ".agentic-beacon" / "beacon.yaml"
+    beacon_yaml.write_text(
+        "artifacts:\n"
+        "  knowledge: []\n"
+        "  skills:\n"
+        "    - skills/code-review/SKILL.md\n"
+        "  contexts: []\n"
+    )
+    runner.invoke(main, ["sync"])
+
+    # Corrupt the live skill but leave the snapshot untouched
+    live_skill = project_dir / ".opencode" / "skills" / "code-review" / "SKILL.md"
+    live_skill.write_text("# Completely replaced\n")
+
+    # Confirm snapshot is still identical to warehouse
+    snapshot = (
+        project_dir
+        / ".agentic-beacon"
+        / "artifacts"
+        / "skills"
+        / "code-review"
+        / "SKILL.md"
+    )
+    warehouse_content = (warehouse / "skills" / "code-review" / "SKILL.md").read_text()
+    assert snapshot.read_text() == warehouse_content
+
+    result = runner.invoke(main, ["delta"])
+
+    assert result.exit_code == 0
+    assert "Modified" in result.output, (
+        "Expected 'Modified' — delta should detect live drift, not just snapshot drift"
+    )
+
+
+def test_e2e_delta_skill_per_agent_detail_in_output(e2e_project):
+    """With both opencode and claudecode present, delta shows per-agent breakdown."""
+    project_dir, warehouse, runner = e2e_project
+    runner.invoke(main, ["warehouse", "connect", "--path", str(warehouse)])
+
+    # Both agents configured
+    (project_dir / "opencode.json").write_text("{}")
+    (project_dir / ".claude").mkdir()
+
+    beacon_yaml = project_dir / ".agentic-beacon" / "beacon.yaml"
+    beacon_yaml.write_text(
+        "artifacts:\n"
+        "  knowledge: []\n"
+        "  skills:\n"
+        "    - skills/code-review/SKILL.md\n"
+        "  contexts: []\n"
+    )
+    runner.invoke(main, ["sync"])
+
+    # Edit only the opencode live copy
+    oc_skill = project_dir / ".opencode" / "skills" / "code-review" / "SKILL.md"
+    oc_skill.write_text(oc_skill.read_text() + "\n## Extra\n")
+
+    result = runner.invoke(main, ["delta"])
+
+    assert result.exit_code == 0
+    assert "Modified" in result.output
+    # Per-agent breakdown should appear
+    assert "opencode" in result.output
+    assert "claudecode" in result.output
+
+
+# ---------------------------------------------------------------------------
 # Step 8 — sync --preserve skips locally modified file
 # ---------------------------------------------------------------------------
 

--- a/libs/beacon/tests/core/test_delta_comparator.py
+++ b/libs/beacon/tests/core/test_delta_comparator.py
@@ -367,7 +367,11 @@ def test_compare_from_config_detects_added_file_via_glob(valid_warehouse, temp_d
 
 
 def test_compare_from_config_detects_added_skill_via_glob(valid_warehouse, temp_dir):
-    """compare_from_config detects a locally-added skill file via glob."""
+    """compare_from_config detects a locally-added skill file via glob.
+
+    When no skills_paths are configured, falls back to artifacts_path for skills
+    (backward compatibility — no agents detected).
+    """
     from beacon.core.settings import BeaconSettings
 
     artifacts_dir = temp_dir / "artifacts"
@@ -381,11 +385,127 @@ def test_compare_from_config_detects_added_skill_via_glob(valid_warehouse, temp_
     )
     settings = BeaconSettings.from_yaml(beacon_yaml)
 
+    # No skills_paths → falls back to artifacts_path
     comparator = DeltaComparator(valid_warehouse, artifacts_dir)
     summary = comparator.compare_from_config(settings)
 
     added_paths = [r.path for r in summary.added]
     assert "skills/my-skill/SKILL.md" in added_paths
+
+
+def test_compare_from_config_skills_uses_live_agent_path(valid_warehouse, temp_dir):
+    """compare_from_config uses live agent install dir for skills when skills_paths configured."""
+    from beacon.core.settings import BeaconSettings
+
+    artifacts_dir = temp_dir / "artifacts"
+    artifacts_dir.mkdir()
+
+    # Warehouse has the skill
+    skill_wh = valid_warehouse / "skills" / "opsx-enhance"
+    skill_wh.mkdir(parents=True)
+    (skill_wh / "SKILL.md").write_text("# Warehouse version\n")
+
+    # Live agent dir has a MODIFIED version
+    opencode_skills = temp_dir / ".opencode" / "skills"
+    live_skill_dir = opencode_skills / "opsx-enhance"
+    live_skill_dir.mkdir(parents=True)
+    (live_skill_dir / "SKILL.md").write_text("# Modified locally\n")
+
+    beacon_yaml = temp_dir / "beacon.yaml"
+    beacon_yaml.write_text(
+        "artifacts:\n  knowledge: []\n  skills:\n    - skills/opsx-enhance/SKILL.md\n  contexts: []\n"
+    )
+    settings = BeaconSettings.from_yaml(beacon_yaml)
+
+    comparator = DeltaComparator(
+        valid_warehouse,
+        artifacts_dir,
+        skills_paths={"opencode": opencode_skills},
+    )
+    summary = comparator.compare_from_config(settings)
+
+    assert len(summary.modified) == 1
+    result = summary.modified[0]
+    assert result.path == "skills/opsx-enhance/SKILL.md"
+    assert result.agent_statuses == {"opencode": DeltaStatus.MODIFIED}
+
+
+def test_compare_from_config_skills_identical_live_agent(valid_warehouse, temp_dir):
+    """compare_from_config reports IDENTICAL when live skill matches warehouse."""
+    from beacon.core.settings import BeaconSettings
+
+    artifacts_dir = temp_dir / "artifacts"
+    artifacts_dir.mkdir()
+
+    content = "# Same content\n"
+    skill_wh = valid_warehouse / "skills" / "my-skill"
+    skill_wh.mkdir(parents=True)
+    (skill_wh / "SKILL.md").write_text(content)
+
+    opencode_skills = temp_dir / ".opencode" / "skills"
+    live_skill_dir = opencode_skills / "my-skill"
+    live_skill_dir.mkdir(parents=True)
+    (live_skill_dir / "SKILL.md").write_text(content)
+
+    beacon_yaml = temp_dir / "beacon.yaml"
+    beacon_yaml.write_text(
+        "artifacts:\n  knowledge: []\n  skills:\n    - skills/my-skill/SKILL.md\n  contexts: []\n"
+    )
+    settings = BeaconSettings.from_yaml(beacon_yaml)
+
+    comparator = DeltaComparator(
+        valid_warehouse,
+        artifacts_dir,
+        skills_paths={"opencode": opencode_skills},
+    )
+    summary = comparator.compare_from_config(settings)
+
+    assert len(summary.identical) == 1
+    assert summary.identical[0].agent_statuses == {"opencode": DeltaStatus.IDENTICAL}
+
+
+def test_compare_skill_multi_agent_worst_status_wins(valid_warehouse, temp_dir):
+    """With multiple agents, aggregate status reflects the worst across all agents."""
+    from beacon.core.settings import BeaconSettings
+
+    artifacts_dir = temp_dir / "artifacts"
+    artifacts_dir.mkdir()
+
+    warehouse_content = "# Warehouse\n"
+    skill_wh = valid_warehouse / "skills" / "my-skill"
+    skill_wh.mkdir(parents=True)
+    (skill_wh / "SKILL.md").write_text(warehouse_content)
+
+    # opencode: identical
+    opencode_skills = temp_dir / ".opencode" / "skills"
+    oc_skill = opencode_skills / "my-skill"
+    oc_skill.mkdir(parents=True)
+    (oc_skill / "SKILL.md").write_text(warehouse_content)
+
+    # claudecode: modified
+    claude_skills = temp_dir / ".claude" / "skills"
+    cc_skill = claude_skills / "my-skill"
+    cc_skill.mkdir(parents=True)
+    (cc_skill / "SKILL.md").write_text("# Different\n")
+
+    beacon_yaml = temp_dir / "beacon.yaml"
+    beacon_yaml.write_text(
+        "artifacts:\n  knowledge: []\n  skills:\n    - skills/my-skill/SKILL.md\n  contexts: []\n"
+    )
+    settings = BeaconSettings.from_yaml(beacon_yaml)
+
+    comparator = DeltaComparator(
+        valid_warehouse,
+        artifacts_dir,
+        skills_paths={"opencode": opencode_skills, "claudecode": claude_skills},
+    )
+    summary = comparator.compare_from_config(settings)
+
+    assert len(summary.modified) == 1
+    result = summary.modified[0]
+    assert result.status == DeltaStatus.MODIFIED
+    assert result.agent_statuses["opencode"] == DeltaStatus.IDENTICAL
+    assert result.agent_statuses["claudecode"] == DeltaStatus.MODIFIED
 
 
 def test_compare_from_config_detects_missing_skill_via_glob(valid_warehouse, temp_dir):
@@ -434,3 +554,322 @@ def test_compare_from_config_no_duplicates_for_modified(valid_warehouse, temp_di
     assert len(summary.results) == 1
     assert summary.results[0].path == "knowledge/shared.md"
     assert len(summary.modified) == 1
+
+
+# ========== Skills: live agent path comparison (bug fix) ==========
+# Tests for the fix where abc delta now compares skills against the
+# live agent installation directories (.opencode/skills, .claude/skills)
+# instead of the intermediate artifact snapshot.
+
+
+def test_compare_skill_file_directly_modified(valid_warehouse, temp_dir):
+    """compare_file reports MODIFIED when live skill differs from warehouse."""
+    opencode_skills = temp_dir / ".opencode" / "skills"
+    live_dir = opencode_skills / "opsx-enhance"
+    live_dir.mkdir(parents=True)
+    (live_dir / "SKILL.md").write_text("# Modified live\n")
+
+    (valid_warehouse / "skills" / "opsx-enhance").mkdir(parents=True)
+    (valid_warehouse / "skills" / "opsx-enhance" / "SKILL.md").write_text(
+        "# Warehouse\n"
+    )
+
+    artifacts_dir = temp_dir / "artifacts"
+    artifacts_dir.mkdir()
+
+    comparator = DeltaComparator(
+        valid_warehouse,
+        artifacts_dir,
+        skills_paths={"opencode": opencode_skills},
+    )
+    result = comparator.compare_file("skills/opsx-enhance/SKILL.md")
+
+    assert result.status == DeltaStatus.MODIFIED
+    assert result.is_skill is True
+    assert result.agent_statuses == {"opencode": DeltaStatus.MODIFIED}
+
+
+def test_compare_skill_file_identical(valid_warehouse, temp_dir):
+    """compare_file reports IDENTICAL when live skill matches warehouse."""
+    content = "# Same\n"
+    opencode_skills = temp_dir / ".opencode" / "skills"
+    (opencode_skills / "my-skill").mkdir(parents=True)
+    (opencode_skills / "my-skill" / "SKILL.md").write_text(content)
+
+    (valid_warehouse / "skills" / "my-skill").mkdir(parents=True)
+    (valid_warehouse / "skills" / "my-skill" / "SKILL.md").write_text(content)
+
+    artifacts_dir = temp_dir / "artifacts"
+    artifacts_dir.mkdir()
+
+    comparator = DeltaComparator(
+        valid_warehouse,
+        artifacts_dir,
+        skills_paths={"opencode": opencode_skills},
+    )
+    result = comparator.compare_file("skills/my-skill/SKILL.md")
+
+    assert result.status == DeltaStatus.IDENTICAL
+    assert result.is_skill is True
+    assert result.agent_statuses == {"opencode": DeltaStatus.IDENTICAL}
+
+
+def test_compare_skill_file_missing_from_live(valid_warehouse, temp_dir):
+    """compare_file reports MISSING when skill exists in warehouse but not in live dir."""
+    (valid_warehouse / "skills" / "my-skill").mkdir(parents=True)
+    (valid_warehouse / "skills" / "my-skill" / "SKILL.md").write_text("# Warehouse\n")
+
+    opencode_skills = temp_dir / ".opencode" / "skills"
+    opencode_skills.mkdir(parents=True)  # agent dir exists but skill not installed
+
+    artifacts_dir = temp_dir / "artifacts"
+    artifacts_dir.mkdir()
+
+    comparator = DeltaComparator(
+        valid_warehouse,
+        artifacts_dir,
+        skills_paths={"opencode": opencode_skills},
+    )
+    result = comparator.compare_file("skills/my-skill/SKILL.md")
+
+    assert result.status == DeltaStatus.MISSING
+    assert result.agent_statuses == {"opencode": DeltaStatus.MISSING}
+
+
+def test_compare_skill_file_added_only_in_live(valid_warehouse, temp_dir):
+    """compare_file reports ADDED when skill exists live but not in warehouse."""
+    opencode_skills = temp_dir / ".opencode" / "skills"
+    (opencode_skills / "my-skill").mkdir(parents=True)
+    (opencode_skills / "my-skill" / "SKILL.md").write_text("# Local only\n")
+
+    artifacts_dir = temp_dir / "artifacts"
+    artifacts_dir.mkdir()
+
+    comparator = DeltaComparator(
+        valid_warehouse,
+        artifacts_dir,
+        skills_paths={"opencode": opencode_skills},
+    )
+    result = comparator.compare_file("skills/my-skill/SKILL.md")
+
+    assert result.status == DeltaStatus.ADDED
+    assert result.agent_statuses == {"opencode": DeltaStatus.ADDED}
+
+
+def test_compare_skill_multi_agent_all_identical(valid_warehouse, temp_dir):
+    """When all agents have the skill identical to warehouse, aggregate is IDENTICAL."""
+    content = "# Same\n"
+    (valid_warehouse / "skills" / "my-skill").mkdir(parents=True)
+    (valid_warehouse / "skills" / "my-skill" / "SKILL.md").write_text(content)
+
+    opencode_skills = temp_dir / ".opencode" / "skills"
+    (opencode_skills / "my-skill").mkdir(parents=True)
+    (opencode_skills / "my-skill" / "SKILL.md").write_text(content)
+
+    claude_skills = temp_dir / ".claude" / "skills"
+    (claude_skills / "my-skill").mkdir(parents=True)
+    (claude_skills / "my-skill" / "SKILL.md").write_text(content)
+
+    artifacts_dir = temp_dir / "artifacts"
+    artifacts_dir.mkdir()
+
+    comparator = DeltaComparator(
+        valid_warehouse,
+        artifacts_dir,
+        skills_paths={"opencode": opencode_skills, "claudecode": claude_skills},
+    )
+    result = comparator.compare_file("skills/my-skill/SKILL.md")
+
+    assert result.status == DeltaStatus.IDENTICAL
+    assert result.agent_statuses["opencode"] == DeltaStatus.IDENTICAL
+    assert result.agent_statuses["claudecode"] == DeltaStatus.IDENTICAL
+
+
+def test_compare_skill_multi_agent_missing_beats_identical(valid_warehouse, temp_dir):
+    """MISSING beats IDENTICAL in the aggregate rollup for multi-agent."""
+    content = "# Warehouse\n"
+    (valid_warehouse / "skills" / "my-skill").mkdir(parents=True)
+    (valid_warehouse / "skills" / "my-skill" / "SKILL.md").write_text(content)
+
+    # opencode: identical
+    opencode_skills = temp_dir / ".opencode" / "skills"
+    (opencode_skills / "my-skill").mkdir(parents=True)
+    (opencode_skills / "my-skill" / "SKILL.md").write_text(content)
+
+    # claudecode: agent dir exists but skill not installed
+    claude_skills = temp_dir / ".claude" / "skills"
+    claude_skills.mkdir(parents=True)
+
+    artifacts_dir = temp_dir / "artifacts"
+    artifacts_dir.mkdir()
+
+    comparator = DeltaComparator(
+        valid_warehouse,
+        artifacts_dir,
+        skills_paths={"opencode": opencode_skills, "claudecode": claude_skills},
+    )
+    result = comparator.compare_file("skills/my-skill/SKILL.md")
+
+    assert result.status == DeltaStatus.MISSING
+    assert result.agent_statuses["opencode"] == DeltaStatus.IDENTICAL
+    assert result.agent_statuses["claudecode"] == DeltaStatus.MISSING
+
+
+def test_compare_skill_is_skill_false_for_non_skill(valid_warehouse, temp_dir):
+    """is_skill is False for knowledge and context artifacts."""
+    artifacts_dir = temp_dir / "artifacts"
+    (artifacts_dir / "knowledge").mkdir(parents=True)
+    (valid_warehouse / "knowledge" / "doc.md").write_text("content")
+    (artifacts_dir / "knowledge" / "doc.md").write_text("content")
+
+    comparator = DeltaComparator(valid_warehouse, artifacts_dir)
+    result = comparator.compare_file("knowledge/doc.md")
+
+    assert result.is_skill is False
+    assert result.agent_statuses == {}
+
+
+def test_compare_skill_no_skills_paths_falls_back_to_artifacts(
+    valid_warehouse, temp_dir
+):
+    """When skills_paths is empty, skill comparison falls back to artifact snapshot."""
+    artifacts_dir = temp_dir / "artifacts"
+    (artifacts_dir / "skills" / "my-skill").mkdir(parents=True)
+    (artifacts_dir / "skills" / "my-skill" / "SKILL.md").write_text("# Snapshot\n")
+
+    (valid_warehouse / "skills" / "my-skill").mkdir(parents=True)
+    (valid_warehouse / "skills" / "my-skill" / "SKILL.md").write_text("# Warehouse\n")
+
+    # No skills_paths → backward compat, uses artifacts_path
+    comparator = DeltaComparator(valid_warehouse, artifacts_dir)
+    result = comparator.compare_file("skills/my-skill/SKILL.md")
+
+    assert result.status == DeltaStatus.MODIFIED
+    assert result.agent_statuses == {}
+    assert result.is_skill is False
+
+
+def test_detailed_diff_uses_live_skill_path(valid_warehouse, temp_dir):
+    """detailed_diff diffs against the live agent install, not the artifact snapshot."""
+    warehouse_content = "line one\nline two\n"
+    live_content = "line one\nline two modified\n"
+
+    (valid_warehouse / "skills" / "my-skill").mkdir(parents=True)
+    (valid_warehouse / "skills" / "my-skill" / "SKILL.md").write_text(warehouse_content)
+
+    opencode_skills = temp_dir / ".opencode" / "skills"
+    (opencode_skills / "my-skill").mkdir(parents=True)
+    (opencode_skills / "my-skill" / "SKILL.md").write_text(live_content)
+
+    # Snapshot intentionally has the original (identical to warehouse)
+    # so a snapshot-based diff would incorrectly show no diff
+    artifacts_dir = temp_dir / "artifacts"
+    (artifacts_dir / "skills" / "my-skill").mkdir(parents=True)
+    (artifacts_dir / "skills" / "my-skill" / "SKILL.md").write_text(warehouse_content)
+
+    comparator = DeltaComparator(
+        valid_warehouse,
+        artifacts_dir,
+        skills_paths={"opencode": opencode_skills},
+    )
+    diff = comparator.detailed_diff("skills/my-skill/SKILL.md", color=False)
+
+    assert "line two modified" in diff or "modified" in diff
+    assert len(diff) > 0
+
+
+def test_detailed_diff_skill_missing_from_live_falls_back_to_snapshot(
+    valid_warehouse, temp_dir
+):
+    """detailed_diff falls back to artifact snapshot when no live agent has the skill."""
+    warehouse_content = "# Warehouse\n"
+    snapshot_content = "# Snapshot version\n"
+
+    (valid_warehouse / "skills" / "my-skill").mkdir(parents=True)
+    (valid_warehouse / "skills" / "my-skill" / "SKILL.md").write_text(warehouse_content)
+
+    artifacts_dir = temp_dir / "artifacts"
+    (artifacts_dir / "skills" / "my-skill").mkdir(parents=True)
+    (artifacts_dir / "skills" / "my-skill" / "SKILL.md").write_text(snapshot_content)
+
+    # Agent dir exists but skill not installed
+    opencode_skills = temp_dir / ".opencode" / "skills"
+    opencode_skills.mkdir(parents=True)
+
+    comparator = DeltaComparator(
+        valid_warehouse,
+        artifacts_dir,
+        skills_paths={"opencode": opencode_skills},
+    )
+    diff = comparator.detailed_diff("skills/my-skill/SKILL.md", color=False)
+
+    # Falls back to snapshot — diff should show snapshot_content change
+    assert "Snapshot version" in diff or len(diff) > 0
+
+
+def test_compare_from_config_glob_detects_added_skill_in_live_dir(
+    valid_warehouse, temp_dir
+):
+    """Glob-based config detects a skill present in the live dir but not in the warehouse."""
+    from beacon.core.settings import BeaconSettings
+
+    artifacts_dir = temp_dir / "artifacts"
+    artifacts_dir.mkdir()
+
+    # Live dir has a new skill not yet contributed to warehouse
+    opencode_skills = temp_dir / ".opencode" / "skills"
+    (opencode_skills / "new-skill").mkdir(parents=True)
+    (opencode_skills / "new-skill" / "SKILL.md").write_text("# New local skill\n")
+
+    beacon_yaml = temp_dir / "beacon.yaml"
+    beacon_yaml.write_text(
+        "artifacts:\n  knowledge: []\n  skills:\n    - skills/**/*\n  contexts: []\n"
+    )
+    settings = BeaconSettings.from_yaml(beacon_yaml)
+
+    comparator = DeltaComparator(
+        valid_warehouse,
+        artifacts_dir,
+        skills_paths={"opencode": opencode_skills},
+    )
+    summary = comparator.compare_from_config(settings)
+
+    added_paths = [r.path for r in summary.added]
+    assert "skills/new-skill/SKILL.md" in added_paths
+
+
+def test_compare_from_config_glob_no_duplicates_multi_agent(valid_warehouse, temp_dir):
+    """With multiple agents having the same skill, it appears only once in results."""
+    from beacon.core.settings import BeaconSettings
+
+    content = "# Warehouse\n"
+    (valid_warehouse / "skills" / "my-skill").mkdir(parents=True)
+    (valid_warehouse / "skills" / "my-skill" / "SKILL.md").write_text(content)
+
+    opencode_skills = temp_dir / ".opencode" / "skills"
+    (opencode_skills / "my-skill").mkdir(parents=True)
+    (opencode_skills / "my-skill" / "SKILL.md").write_text(content)
+
+    claude_skills = temp_dir / ".claude" / "skills"
+    (claude_skills / "my-skill").mkdir(parents=True)
+    (claude_skills / "my-skill" / "SKILL.md").write_text(content)
+
+    artifacts_dir = temp_dir / "artifacts"
+    artifacts_dir.mkdir()
+
+    beacon_yaml = temp_dir / "beacon.yaml"
+    beacon_yaml.write_text(
+        "artifacts:\n  knowledge: []\n  skills:\n    - skills/**/*\n  contexts: []\n"
+    )
+    settings = BeaconSettings.from_yaml(beacon_yaml)
+
+    comparator = DeltaComparator(
+        valid_warehouse,
+        artifacts_dir,
+        skills_paths={"opencode": opencode_skills, "claudecode": claude_skills},
+    )
+    summary = comparator.compare_from_config(settings)
+
+    # Should appear exactly once despite two agents
+    skill_paths = [r.path for r in summary.results if "my-skill" in r.path]
+    assert len(skill_paths) == 1


### PR DESCRIPTION
## Problem

`abc delta` was silently reporting "No differences" for skills even when the live agent copy had drifted from the warehouse.

**Root cause:** Skills are physically copied to `.opencode/skills/` (or `.claude/skills/`) during `abc sync` — that's the file the agent actually reads. But `delta` was comparing the intermediate artifact snapshot at `.agentic-beacon/artifacts/skills/`, which always matched the warehouse. Any edits to the live copy were invisible.

Knowledge and contexts don't have this problem because they stay in `.agentic-beacon/artifacts/` and are referenced by path — so the snapshot *is* the live copy.

## Fix

- `DeltaComparator` now accepts `skills_paths: dict[str, Path]` — a per-agent mapping to the live installation directories (e.g. `{"opencode": Path(".opencode/skills"), "claudecode": Path(".claude/skills")}`)
- For skills, comparison goes **warehouse → live agent dir** directly, bypassing the snapshot
- The `delta` command auto-detects agents via the existing `_detect_agents` helper and populates this map
- Falls back to artifact snapshot when no agents are detected (backward compat — no agents configured)

## Multi-agent output

When both agents are present, each is compared independently. The worst status across all agents is the aggregate. The summary line shows a per-agent breakdown:

```
[Modified] skills/opsx-enhance/SKILL.md (opencode: modified, claudecode: identical)
```

`abc delta <file>` detailed diff also targets the live agent copy.

## Tests added

- **16 new unit tests** in `test_delta_comparator.py` — `compare_file` for each status via live paths, multi-agent rollup, backward-compat fallback, `detailed_diff` path targeting, glob discovery via live dirs, no-duplicates with multiple agents
- **7 new CLI tests** in `test_delta_command.py` — including the exact regression scenario (snapshot identical, live modified → still shows Modified)
- **4 new e2e integration tests** in `test_e2e_happy_path.py` — full `sync → delta` workflow for skills with one and two agents