### PR TITLE
feat: prompt to initialise agent config during abc sync

### DIFF
--- a/libs/beacon/src/beacon/cli.py
+++ b/libs/beacon/src/beacon/cli.py
@@ -895,13 +895,39 @@ def sync(*, preserve: bool, prune: bool, verbose_flag: bool, dry_run: bool) -> N
             if not has_opencode and not has_claude:
                 contexts_dir = artifacts_dir / "contexts"
                 if contexts_dir.exists() and any(contexts_dir.rglob("*.md")):
-                    wiring_notes.append(
-                        "  Contexts synced — wire them into your agent config:\n"
-                        '  [bold]opencode.json[/bold] → add to "instructions" array:\n'
-                        '    ".agentic-beacon/artifacts/contexts/<name>.md"\n'
-                        "  [bold]CLAUDE.md[/bold] → add a line per context:\n"
-                        "    @.agentic-beacon/artifacts/contexts/<name>.md"
-                    )
+                    if not dry_run and _is_interactive():
+                        console.print(
+                            "\n[yellow]No agent config detected.[/yellow] "
+                            "Set one up to wire contexts automatically."
+                        )
+                        if click.confirm("  Initialize opencode.json?", default=False):
+                            _init_opencode_json(project_root)
+                            oc_init = _wire_contexts_opencode(
+                                project_root, artifacts_dir
+                            )
+                            if oc_init:
+                                console.print(
+                                    f"[green]✓[/green] Created opencode.json and "
+                                    f"wired {len(oc_init)} context(s)"
+                                )
+                        if click.confirm("  Initialize CLAUDE.md?", default=False):
+                            _init_claude_md(project_root)
+                            cc_init = _wire_contexts_claudecode(
+                                project_root, artifacts_dir
+                            )
+                            if cc_init:
+                                console.print(
+                                    f"[green]✓[/green] Created CLAUDE.md and "
+                                    f"wired {len(cc_init)} context(s)"
+                                )
+                    else:
+                        wiring_notes.append(
+                            "  Contexts synced — wire them into your agent config:\n"
+                            '  [bold]opencode.json[/bold] → add to "instructions" array:\n'
+                            '    ".agentic-beacon/artifacts/contexts/<name>.md"\n'
+                            "  [bold]CLAUDE.md[/bold] → add a line per context:\n"
+                            "    @.agentic-beacon/artifacts/contexts/<name>.md"
+                        )
 
         if beacon_settings.artifacts.skills:
             wired_skills, wire_errors = _wire_skills_post_sync(
@@ -1770,6 +1796,11 @@ def _update_beacon_yaml(beacon_dir: Path, files: list[str]) -> None:
     settings.to_yaml(beacon_yaml)
 
 
+def _is_interactive() -> bool:
+    """Return True if running in an interactive terminal."""
+    return sys.stdin.isatty()
+
+
 def _wire_contexts_opencode(project_root: Path, artifacts_dir: Path) -> list[str]:
     """Append synced context paths to opencode.json instructions.
 
@@ -1856,6 +1887,21 @@ def _wire_contexts_claudecode(project_root: Path, artifacts_dir: Path) -> list[s
         )
 
     return added
+
+
+def _init_opencode_json(project_root: Path) -> None:
+    """Create a minimal opencode.json if one does not already exist."""
+    opencode_json = project_root / "opencode.json"
+    if not opencode_json.exists():
+        data = {"$schema": "https://opencode.ai/config.json", "instructions": []}
+        opencode_json.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+
+def _init_claude_md(project_root: Path) -> None:
+    """Create an empty CLAUDE.md at the project root if none exists."""
+    claude_md = project_root / "CLAUDE.md"
+    if not claude_md.exists():
+        claude_md.write_text("", encoding="utf-8")
 
 
 def _wire_skills_post_sync(

--- a/libs/beacon/tests/cli/test_sync_wiring.py
+++ b/libs/beacon/tests/cli/test_sync_wiring.py
@@ -9,6 +9,7 @@ And integration tests through the full `abc sync` CLI command.
 """
 
 import json
+from unittest.mock import patch
 
 import pytest
 from beacon.cli import (
@@ -338,14 +339,47 @@ def test_sync_wiring_is_idempotent(full_sync_project, monkeypatch):
     assert instructions.count(".agentic-beacon/artifacts/contexts/global.md") == 1
 
 
-def test_sync_prints_manual_instructions_when_no_agent_config(
+def test_sync_prints_manual_instructions_when_no_agent_config_non_interactive(
     full_sync_project, monkeypatch
 ):
     project, runner = full_sync_project
     monkeypatch.chdir(project)
-    # No opencode.json, no CLAUDE.md
+    # No opencode.json, no CLAUDE.md; simulate non-interactive (CI) environment
 
-    result = runner.invoke(main, ["sync"])
+    with patch("beacon.cli._is_interactive", return_value=False):
+        result = runner.invoke(main, ["sync"])
 
     assert result.exit_code == 0
     assert "manual" in result.output.lower() or "wire" in result.output.lower()
+
+
+def test_sync_interactive_init_opencode_json(full_sync_project, monkeypatch):
+    project, runner = full_sync_project
+    monkeypatch.chdir(project)
+    # No opencode.json, no CLAUDE.md; user answers yes/no to prompts
+
+    with patch("beacon.cli._is_interactive", return_value=True):
+        # "y" for opencode.json prompt, "n" for CLAUDE.md prompt
+        result = runner.invoke(main, ["sync"], input="y\nn\n")
+
+    assert result.exit_code == 0
+    assert (project / "opencode.json").exists()
+    data = json.loads((project / "opencode.json").read_text())
+    assert ".agentic-beacon/artifacts/contexts/global.md" in data["instructions"]
+    assert not (project / "CLAUDE.md").exists()
+
+
+def test_sync_interactive_init_claude_md(full_sync_project, monkeypatch):
+    project, runner = full_sync_project
+    monkeypatch.chdir(project)
+    # No opencode.json, no CLAUDE.md; user answers no/yes to prompts
+
+    with patch("beacon.cli._is_interactive", return_value=True):
+        # "n" for opencode.json prompt, "y" for CLAUDE.md prompt
+        result = runner.invoke(main, ["sync"], input="n\ny\n")
+
+    assert result.exit_code == 0
+    assert not (project / "opencode.json").exists()
+    assert (project / "CLAUDE.md").exists()
+    content = (project / "CLAUDE.md").read_text()
+    assert "@.agentic-beacon/artifacts/contexts/global.md" in content


### PR DESCRIPTION
## Summary

- When `abc sync` finds contexts but no `opencode.json` or `CLAUDE.md`, prompt the user interactively to create one or both config files and wire contexts in immediately
- Non-interactive environments (CI, piped stdin) retain the existing manual instructions output
- Extracts `_is_interactive()` helper and adds `_init_opencode_json()` / `_init_claude_md()` helpers

## Test plan

- [ ] Existing 18 wiring tests still pass
- [ ] New test: non-interactive path still shows manual instructions (`_is_interactive` patched to `False`)
- [ ] New test: interactive `y/n` → creates `opencode.json` and wires contexts
- [ ] New test: interactive `n/y` → creates `CLAUDE.md` and wires contexts

🤖 Generated with [Claude Code](https://claude.com/claude-code)