### PR TITLE
feat: add abc agents sync command and include agents in abc sync

### DIFF
--- a/libs/beacon/src/beacon/cli.py
+++ b/libs/beacon/src/beacon/cli.py
@@ -1414,8 +1414,9 @@ def sync(
             console.print(
                 "[yellow]No artifacts configured in beacon.yaml. Nothing to sync.[/yellow]"
             )
-            # Still install bundled skills even when no warehouse artifacts are configured
+            # Still install bundled skills and sync agents even when no warehouse artifacts configured
             _print_bundled_install_result(*_install_bundled_skills_globally())
+            _sync_agents_from_warehouse(warehouse_path, force=force, preserve=preserve)
             sys.exit(0)
 
         # Create artifacts directory
@@ -1621,10 +1622,113 @@ def sync(
         # Install abc-bundled skills directly from data/skills/ (no beacon.yaml entry needed)
         _print_bundled_install_result(*_install_bundled_skills_globally())
 
+        # Sync global agents from warehouse
+        _sync_agents_from_warehouse(warehouse_path, force=force, preserve=preserve)
+
     except Exception as e:
         console.print(f"\n[red]Error:[/red] Sync failed: {e}")
         logger.exception("Sync failed")
         sys.exit(1)
+
+
+def _sync_agents_from_warehouse(
+    warehouse_path: Path,
+    *,
+    force: bool = False,
+    preserve: bool = False,
+) -> None:
+    """Sync all agent definition files from the warehouse into global tool directories.
+
+    Called as part of `abc sync`. Finds every *.md under warehouse/agents/,
+    compares each against the global agent dirs for detected tools, and installs
+    any that are out-of-date.  A single Y/N prompt is shown when conflicts exist
+    (unless --force or --preserve are supplied).
+
+    Args:
+        warehouse_path: Absolute path to the connected warehouse root.
+        force: Overwrite conflicting files without prompting.
+        preserve: Skip conflicting files without prompting.
+    """
+    agents_dir = warehouse_path / "agents"
+    if not agents_dir.is_dir():
+        return
+
+    agent_files = sorted(agents_dir.rglob("*.md"))
+    if not agent_files:
+        return
+
+    tools = _detect_agents_global()
+    if not tools:
+        return
+
+    agent_dirs = _global_agent_dirs()
+
+    # Build list of (relative_path, content, agent_name) tuples
+    entries: list[tuple[str, str, str]] = []
+    for af in agent_files:
+        rel = str(af.relative_to(warehouse_path))  # e.g. "agents/code-reviewer.md"
+        content = af.read_text(encoding="utf-8")
+        agent_name = af.name
+        entries.append((rel, content, agent_name))
+
+    # Detect conflicts: files that exist in global dirs but differ from warehouse
+    conflicts: list[str] = []
+    for _rel, content, agent_name in entries:
+        for tool in tools:
+            dest = agent_dirs[tool] / agent_name
+            if dest.exists() and dest.read_text(encoding="utf-8") != content:
+                conflicts.append(str(dest))
+
+    # Single Y/N prompt for all conflicts together
+    effective_preserve = preserve
+    if conflicts and not force and not preserve:
+        conflict_list = "\n".join(f"  • {p}" for p in conflicts)
+        console.print(
+            f"\n[yellow]Warning:[/yellow] {len(conflicts)} global agent file(s) "
+            f"differ from the warehouse and will be overwritten:\n{conflict_list}\n"
+        )
+        is_interactive = sys.stdin.isatty()
+        if is_interactive:
+            if not click.confirm(
+                "Overwrite local agent files with warehouse versions?", default=False
+            ):
+                effective_preserve = True
+        else:
+            console.print(
+                "[dim]Non-interactive mode — skipping agent overwrite. "
+                "Use --force to overwrite or --preserve to suppress this warning.[/dim]"
+            )
+            effective_preserve = True
+
+    # Install
+    installed: list[str] = []
+    skipped: list[str] = []
+    for rel, content, agent_name in entries:
+        for tool in tools:
+            dest = agent_dirs[tool] / agent_name
+            is_conflict = str(dest) in conflicts
+
+            if effective_preserve and is_conflict:
+                skipped.append(agent_name)
+                continue
+
+            written = _install_agent_global(tool, agent_name, content)
+            if written:
+                installed.append(agent_name)
+                _write_agent_sync_state(warehouse_path, rel, _hash_content(content))
+
+    if installed:
+        unique = sorted(set(installed))
+        console.print(
+            f"\n[green]✓[/green] Synced {len(unique)} global agent(s) from warehouse "
+            f"({', '.join(unique)})"
+        )
+    if skipped:
+        unique_skipped = sorted(set(skipped))
+        console.print(
+            f"  [yellow]Skipped {len(unique_skipped)} agent(s) with local changes "
+            f"(use --force to overwrite): {', '.join(unique_skipped)}[/yellow]"
+        )
 
 
 def _handle_install_agent(
@@ -1710,6 +1814,64 @@ def _hash_content(content: str) -> str:
     import hashlib
 
     return hashlib.sha256(content.encode("utf-8")).hexdigest()
+
+
+@main.group()
+def agents() -> None:
+    """Agent definition commands (sync)."""
+    pass
+
+
+@agents.command(name="sync")
+@click.option("--preserve", is_flag=True, help="Skip files with local modifications")
+@click.option(
+    "--force", is_flag=True, help="Overwrite conflicting files without prompting"
+)
+@click.option(
+    "--skip-git-check",
+    is_flag=True,
+    help="Skip warehouse uncommitted-changes check",
+)
+def agents_sync(*, preserve: bool, force: bool, skip_git_check: bool) -> None:
+    """Sync all agent definitions from warehouse into global tool directories.
+
+    Reads the connected warehouse, finds every agent definition under agents/,
+    and installs them into the global directories for all detected tools
+    (~/.config/opencode/agents/ and/or ~/.claude/agents/).
+
+    A confirmation prompt is shown when local agent files differ from the
+    warehouse version. Use --force to overwrite without prompting, or
+    --preserve to skip conflicts silently.
+
+    Example:
+        abc agents sync            # Sync all agents, prompt on conflicts
+        abc agents sync --force    # Overwrite all conflicts without prompting
+        abc agents sync --preserve # Skip conflicting agents
+    """
+    if force and preserve:
+        console.print(
+            "[red]Error:[/red] --force and --preserve are mutually exclusive."
+        )
+        sys.exit(1)
+
+    beacon_dir = Path.cwd() / ".agentic-beacon"
+    if not beacon_dir.exists():
+        console.print("[red]Error:[/red] No .agentic-beacon directory found.")
+        console.print("Run 'abc warehouse connect' to connect to a warehouse first.")
+        sys.exit(1)
+
+    try:
+        warehouse_settings = WarehouseSettings()
+        warehouse_path = Path(warehouse_settings.warehouse.local_path)
+    except Exception as e:
+        console.print(f"[red]Error:[/red] Could not load warehouse settings: {e}")
+        sys.exit(1)
+
+    if not skip_git_check:
+        _check_warehouse_git_clean(warehouse_path)
+        _check_warehouse_on_main_branch(warehouse_path)
+
+    _sync_agents_from_warehouse(warehouse_path, force=force, preserve=preserve)
 
 
 @main.command(name="install")

--- a/libs/beacon/tests/cli/test_agents_sync_command.py
+++ b/libs/beacon/tests/cli/test_agents_sync_command.py
@@ -1,0 +1,258 @@
+"""Tests for abc agents sync command.
+
+abc agents sync reads the connected warehouse, finds every agent definition
+under agents/, and installs them into global tool directories. It operates
+at the user level (global agent dirs), not the project level.
+
+Test Cases:
+- TC1: Installs agent to opencode global dir
+- TC2: Installs agent to claudecode global dir
+- TC3: Both tools present → both get the agent
+- TC4: No agents/ dir in warehouse → silent no-op
+- TC5: Already up-to-date → idempotent
+- TC6: --force overwrites conflicting agent without prompting
+- TC7: --preserve skips conflicting agent
+- TC8: Non-interactive mode with conflict → skipped automatically
+- TC9: No .agentic-beacon → error
+- TC10: --force and --preserve are mutually exclusive
+"""
+
+import pytest
+from beacon.cli import main
+from click.testing import CliRunner
+
+SAMPLE_AGENT_MD = "You are a helpful assistant specialized in Python.\n"
+SAMPLE_AGENT_MD_LOCAL = "You are a local version of the assistant.\n"
+
+
+@pytest.fixture
+def warehouse_with_agents(tmp_path):
+    """Warehouse with one agent definition."""
+    wh = tmp_path / "warehouse"
+    for d in ("agents", "knowledge", "skills", "contexts", "docs"):
+        (wh / d).mkdir(parents=True)
+    (wh / "README.md").write_text("# WH")
+    (wh / "agents" / "code-reviewer.md").write_text(SAMPLE_AGENT_MD)
+    return wh
+
+
+@pytest.fixture
+def connected_project(tmp_path, warehouse_with_agents, monkeypatch):
+    """Project connected to the warehouse."""
+    project = tmp_path / "project"
+    project.mkdir()
+    beacon_dir = project / ".agentic-beacon"
+    beacon_dir.mkdir()
+    (beacon_dir / "config.toml").write_text(
+        f'[warehouse]\nlocal_path = "{warehouse_with_agents}"\n'
+    )
+    (beacon_dir / "beacon.yaml").write_text(
+        "artifacts:\n  knowledge: []\n  skills: []\n  contexts: []\n"
+    )
+    monkeypatch.chdir(project)
+    return project, warehouse_with_agents
+
+
+# ---------------------------------------------------------------------------
+# TC1: Installs agent to opencode global dir
+# ---------------------------------------------------------------------------
+
+
+def test_agents_sync_installs_to_opencode(connected_project, isolated_home):
+    """TC1: abc agents sync writes agent to ~/.config/opencode/agents/."""
+    (isolated_home / ".config" / "opencode").mkdir(parents=True)
+    project, wh = connected_project
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["agents", "sync", "--skip-git-check"])
+
+    assert result.exit_code == 0, result.output
+    dest = isolated_home / ".config" / "opencode" / "agents" / "code-reviewer.md"
+    assert dest.exists()
+    assert dest.read_text() == SAMPLE_AGENT_MD
+
+
+# ---------------------------------------------------------------------------
+# TC2: Installs agent to claudecode global dir
+# ---------------------------------------------------------------------------
+
+
+def test_agents_sync_installs_to_claudecode(connected_project, isolated_home):
+    """TC2: abc agents sync writes agent to ~/.claude/agents/."""
+    (isolated_home / ".claude").mkdir(parents=True)
+    project, wh = connected_project
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["agents", "sync", "--skip-git-check"])
+
+    assert result.exit_code == 0, result.output
+    dest = isolated_home / ".claude" / "agents" / "code-reviewer.md"
+    assert dest.exists()
+    assert dest.read_text() == SAMPLE_AGENT_MD
+
+
+# ---------------------------------------------------------------------------
+# TC3: Both tools present → both get the agent
+# ---------------------------------------------------------------------------
+
+
+def test_agents_sync_installs_to_both_tools(connected_project, isolated_home):
+    """TC3: When both tools are installed, both get the agent."""
+    (isolated_home / ".config" / "opencode").mkdir(parents=True)
+    (isolated_home / ".claude").mkdir(parents=True)
+    project, wh = connected_project
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["agents", "sync", "--skip-git-check"])
+
+    assert result.exit_code == 0, result.output
+    assert (
+        isolated_home / ".config" / "opencode" / "agents" / "code-reviewer.md"
+    ).exists()
+    assert (isolated_home / ".claude" / "agents" / "code-reviewer.md").exists()
+    assert "code-reviewer" in result.output
+
+
+# ---------------------------------------------------------------------------
+# TC4: No agents/ dir in warehouse → silent no-op
+# ---------------------------------------------------------------------------
+
+
+def test_agents_sync_no_agents_dir_is_noop(tmp_path, monkeypatch, isolated_home):
+    """TC4: Warehouse without agents/ dir completes silently without error."""
+    (isolated_home / ".config" / "opencode").mkdir(parents=True)
+
+    wh = tmp_path / "warehouse"
+    for d in ("knowledge", "skills", "contexts", "docs"):
+        (wh / d).mkdir(parents=True)
+    (wh / "README.md").write_text("# WH")
+
+    project = tmp_path / "project"
+    project.mkdir()
+    beacon_dir = project / ".agentic-beacon"
+    beacon_dir.mkdir()
+    (beacon_dir / "config.toml").write_text(f'[warehouse]\nlocal_path = "{wh}"\n')
+    (beacon_dir / "beacon.yaml").write_text(
+        "artifacts:\n  knowledge: []\n  skills: []\n  contexts: []\n"
+    )
+    monkeypatch.chdir(project)
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["agents", "sync", "--skip-git-check"])
+
+    assert result.exit_code == 0, result.output
+    assert not (isolated_home / ".config" / "opencode" / "agents").exists()
+
+
+# ---------------------------------------------------------------------------
+# TC5: Already up-to-date → idempotent
+# ---------------------------------------------------------------------------
+
+
+def test_agents_sync_idempotent(connected_project, isolated_home):
+    """TC5: Running agents sync twice does not re-write already-current agent files."""
+    opencode_agents = isolated_home / ".config" / "opencode" / "agents"
+    opencode_agents.mkdir(parents=True)
+    (opencode_agents / "code-reviewer.md").write_text(SAMPLE_AGENT_MD)
+    mtime_before = (opencode_agents / "code-reviewer.md").stat().st_mtime
+
+    project, wh = connected_project
+    runner = CliRunner()
+    runner.invoke(main, ["agents", "sync", "--skip-git-check"])
+
+    mtime_after = (opencode_agents / "code-reviewer.md").stat().st_mtime
+    assert mtime_before == mtime_after
+
+
+# ---------------------------------------------------------------------------
+# TC6: --force overwrites conflicting agent without prompting
+# ---------------------------------------------------------------------------
+
+
+def test_agents_sync_force_overwrites_conflict(connected_project, isolated_home):
+    """TC6: --force overwrites a diverged local agent without a prompt."""
+    opencode_agents = isolated_home / ".config" / "opencode" / "agents"
+    opencode_agents.mkdir(parents=True)
+    (opencode_agents / "code-reviewer.md").write_text(SAMPLE_AGENT_MD_LOCAL)
+
+    project, wh = connected_project
+    runner = CliRunner()
+    result = runner.invoke(main, ["agents", "sync", "--force", "--skip-git-check"])
+
+    assert result.exit_code == 0, result.output
+    assert (opencode_agents / "code-reviewer.md").read_text() == SAMPLE_AGENT_MD
+
+
+# ---------------------------------------------------------------------------
+# TC7: --preserve skips conflicting agent
+# ---------------------------------------------------------------------------
+
+
+def test_agents_sync_preserve_skips_conflict(connected_project, isolated_home):
+    """TC7: --preserve leaves diverged local agent files untouched."""
+    opencode_agents = isolated_home / ".config" / "opencode" / "agents"
+    opencode_agents.mkdir(parents=True)
+    (opencode_agents / "code-reviewer.md").write_text(SAMPLE_AGENT_MD_LOCAL)
+
+    project, wh = connected_project
+    runner = CliRunner()
+    result = runner.invoke(main, ["agents", "sync", "--preserve", "--skip-git-check"])
+
+    assert result.exit_code == 0, result.output
+    assert (opencode_agents / "code-reviewer.md").read_text() == SAMPLE_AGENT_MD_LOCAL
+    assert "Skipped" in result.output
+
+
+# ---------------------------------------------------------------------------
+# TC8: Non-interactive mode with conflict → skipped automatically
+# ---------------------------------------------------------------------------
+
+
+def test_agents_sync_non_interactive_skips_conflict(connected_project, isolated_home):
+    """TC8: In non-interactive mode, conflicts are skipped without prompting."""
+    opencode_agents = isolated_home / ".config" / "opencode" / "agents"
+    opencode_agents.mkdir(parents=True)
+    (opencode_agents / "code-reviewer.md").write_text(SAMPLE_AGENT_MD_LOCAL)
+
+    project, wh = connected_project
+    runner = CliRunner()
+    # CliRunner uses non-interactive stdin by default
+    result = runner.invoke(main, ["agents", "sync", "--skip-git-check"])
+
+    assert result.exit_code == 0, result.output
+    assert (opencode_agents / "code-reviewer.md").read_text() == SAMPLE_AGENT_MD_LOCAL
+
+
+# ---------------------------------------------------------------------------
+# TC9: No .agentic-beacon → error
+# ---------------------------------------------------------------------------
+
+
+def test_agents_sync_no_beacon_dir_errors(tmp_path, monkeypatch, isolated_home):
+    """TC9: Running agents sync outside a connected project exits with an error."""
+    project = tmp_path / "project"
+    project.mkdir()
+    monkeypatch.chdir(project)
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["agents", "sync", "--skip-git-check"])
+
+    assert result.exit_code != 0
+    assert "No .agentic-beacon directory found" in result.output
+
+
+# ---------------------------------------------------------------------------
+# TC10: --force and --preserve are mutually exclusive
+# ---------------------------------------------------------------------------
+
+
+def test_agents_sync_force_and_preserve_are_exclusive(connected_project, isolated_home):
+    """TC10: Passing both --force and --preserve is rejected."""
+    project, wh = connected_project
+    runner = CliRunner()
+    result = runner.invoke(
+        main, ["agents", "sync", "--force", "--preserve", "--skip-git-check"]
+    )
+
+    assert result.exit_code != 0
+    assert "mutually exclusive" in result.output

--- a/libs/beacon/tests/cli/test_contribute_agents.py
+++ b/libs/beacon/tests/cli/test_contribute_agents.py
@@ -72,7 +72,7 @@ def test_contribute_single_modified_agent(project, fake_home):
 
     # Globally modified agent
     oc_agents = fake_home / ".config" / "opencode" / "agents"
-    oc_agents.mkdir(parents=True)
+    oc_agents.mkdir(parents=True, exist_ok=True)
     (oc_agents / "reviewer.md").write_text("# Reviewer\nImproved version.\n")
 
     result = runner.invoke(
@@ -95,7 +95,7 @@ def test_contribute_all_includes_modified_agent(project, fake_home):
     proj, warehouse, runner = project
 
     oc_agents = fake_home / ".config" / "opencode" / "agents"
-    oc_agents.mkdir(parents=True)
+    oc_agents.mkdir(parents=True, exist_ok=True)
     (oc_agents / "reviewer.md").write_text("# Reviewer\nImproved version.\n")
 
     result = runner.invoke(main, ["contribute"], input="y\n")
@@ -114,7 +114,7 @@ def test_contribute_agent_dry_run(project, fake_home):
     proj, warehouse, runner = project
 
     oc_agents = fake_home / ".config" / "opencode" / "agents"
-    oc_agents.mkdir(parents=True)
+    oc_agents.mkdir(parents=True, exist_ok=True)
     (oc_agents / "reviewer.md").write_text("# Reviewer\nImproved version.\n")
 
     result = runner.invoke(
@@ -138,7 +138,7 @@ def test_contribute_agent_identical_is_noop(project, fake_home):
 
     # Install identical copy globally
     oc_agents = fake_home / ".config" / "opencode" / "agents"
-    oc_agents.mkdir(parents=True)
+    oc_agents.mkdir(parents=True, exist_ok=True)
     (oc_agents / "reviewer.md").write_text("# Reviewer\nWarehouse version.\n")
 
     result = runner.invoke(
@@ -163,7 +163,7 @@ def test_contribute_new_agent_added_to_warehouse(project, fake_home):
     proj, warehouse, runner = project
 
     oc_agents = fake_home / ".config" / "opencode" / "agents"
-    oc_agents.mkdir(parents=True)
+    oc_agents.mkdir(parents=True, exist_ok=True)
     (oc_agents / "new-agent.md").write_text("# New Agent\nBrand new.\n")
     # Add to warehouse agents dir so comparator finds it
     (warehouse / "agents" / "new-agent.md").write_text("# New Agent\nOld.\n")
@@ -190,11 +190,11 @@ def test_contribute_agent_two_identical_tools_no_prompt(project, fake_home):
     content = "# Reviewer\nSame improvement everywhere.\n"
 
     oc_agents = fake_home / ".config" / "opencode" / "agents"
-    oc_agents.mkdir(parents=True)
+    oc_agents.mkdir(parents=True, exist_ok=True)
     (oc_agents / "reviewer.md").write_text(content)
 
     cc_agents = fake_home / ".claude" / "agents"
-    cc_agents.mkdir(parents=True)
+    cc_agents.mkdir(parents=True, exist_ok=True)
     (cc_agents / "reviewer.md").write_text(content)
 
     # input only has the confirm "y" — no conflict choice prompt expected

--- a/libs/beacon/tests/cli/test_sync_wiring.py
+++ b/libs/beacon/tests/cli/test_sync_wiring.py
@@ -909,3 +909,169 @@ def test_sync_fallback_wires_for_both_even_when_one_config_exists(
     assert (project / ".opencode" / "skills" / "my-skill" / "SKILL.md").exists()
     # claudecode NOT wired — detection found opencode, fallback not triggered
     assert not (project / ".claude" / "skills" / "my-skill" / "SKILL.md").exists()
+
+
+# ---------------------------------------------------------------------------
+# Agent sync: _sync_agents_from_warehouse via abc sync
+# ---------------------------------------------------------------------------
+
+SAMPLE_AGENT_MD = "You are a helpful assistant specialized in Python.\n"
+
+
+def _make_agent_project(tmp_path, monkeypatch):
+    """Build a minimal connected project with an agents/ dir in the warehouse."""
+    wh = tmp_path / "warehouse"
+    for d in ("agents", "knowledge", "skills", "contexts", "docs"):
+        (wh / d).mkdir(parents=True)
+    (wh / "README.md").write_text("# WH")
+    (wh / "agents" / "code-reviewer.md").write_text(SAMPLE_AGENT_MD)
+
+    project = tmp_path / "project"
+    project.mkdir()
+    beacon_dir = project / ".agentic-beacon"
+    beacon_dir.mkdir()
+    (beacon_dir / "config.toml").write_text(f'[warehouse]\nlocal_path = "{wh}"\n')
+    (beacon_dir / "beacon.yaml").write_text(
+        "artifacts:\n  knowledge: []\n  skills: []\n  contexts: []\n"
+    )
+    monkeypatch.chdir(project)
+    return wh, project
+
+
+class TestSyncAgentsFromWarehouse:
+    def test_installs_agent_to_opencode_global_dir(
+        self, tmp_path, monkeypatch, isolated_home
+    ):
+        """abc sync installs warehouse agents into ~/.config/opencode/agents/."""
+        (isolated_home / ".config" / "opencode").mkdir(parents=True)
+        wh, project = _make_agent_project(tmp_path, monkeypatch)
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["sync", "--skip-git-check"])
+
+        assert result.exit_code == 0, result.output
+        dest = isolated_home / ".config" / "opencode" / "agents" / "code-reviewer.md"
+        assert dest.exists()
+        assert dest.read_text() == SAMPLE_AGENT_MD
+
+    def test_installs_agent_to_claudecode_global_dir(
+        self, tmp_path, monkeypatch, isolated_home
+    ):
+        """abc sync installs warehouse agents into ~/.claude/agents/."""
+        (isolated_home / ".claude").mkdir(parents=True)
+        wh, project = _make_agent_project(tmp_path, monkeypatch)
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["sync", "--skip-git-check"])
+
+        assert result.exit_code == 0, result.output
+        dest = isolated_home / ".claude" / "agents" / "code-reviewer.md"
+        assert dest.exists()
+        assert dest.read_text() == SAMPLE_AGENT_MD
+
+    def test_installs_to_both_tools_when_both_present(
+        self, tmp_path, monkeypatch, isolated_home
+    ):
+        """When both opencode and claudecode are installed, both get the agent."""
+        (isolated_home / ".config" / "opencode").mkdir(parents=True)
+        (isolated_home / ".claude").mkdir(parents=True)
+        wh, project = _make_agent_project(tmp_path, monkeypatch)
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["sync", "--skip-git-check"])
+
+        assert result.exit_code == 0, result.output
+        assert (
+            isolated_home / ".config" / "opencode" / "agents" / "code-reviewer.md"
+        ).exists()
+        assert (isolated_home / ".claude" / "agents" / "code-reviewer.md").exists()
+        assert "code-reviewer" in result.output
+
+    def test_skips_agents_when_warehouse_has_no_agents_dir(
+        self, tmp_path, monkeypatch, isolated_home
+    ):
+        """Warehouse without agents/ dir: sync completes without installing any agents."""
+        (isolated_home / ".config" / "opencode").mkdir(parents=True)
+
+        wh = tmp_path / "warehouse"
+        for d in ("knowledge", "skills", "contexts", "docs"):
+            (wh / d).mkdir(parents=True)
+        (wh / "README.md").write_text("# WH")
+
+        project = tmp_path / "project"
+        project.mkdir()
+        beacon_dir = project / ".agentic-beacon"
+        beacon_dir.mkdir()
+        (beacon_dir / "config.toml").write_text(f'[warehouse]\nlocal_path = "{wh}"\n')
+        (beacon_dir / "beacon.yaml").write_text(
+            "artifacts:\n  knowledge: []\n  skills: []\n  contexts: []\n"
+        )
+        monkeypatch.chdir(project)
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["sync", "--skip-git-check"])
+
+        assert result.exit_code == 0, result.output
+        assert not (isolated_home / ".config" / "opencode" / "agents").exists()
+
+    def test_idempotent_when_already_up_to_date(
+        self, tmp_path, monkeypatch, isolated_home
+    ):
+        """Running sync twice does not re-write agent files that are already current."""
+        agents_dir = isolated_home / ".config" / "opencode" / "agents"
+        agents_dir.mkdir(parents=True)
+        (agents_dir / "code-reviewer.md").write_text(SAMPLE_AGENT_MD)
+        mtime_before = (agents_dir / "code-reviewer.md").stat().st_mtime
+
+        wh, project = _make_agent_project(tmp_path, monkeypatch)
+        runner = CliRunner()
+        runner.invoke(main, ["sync", "--skip-git-check"])
+
+        mtime_after = (agents_dir / "code-reviewer.md").stat().st_mtime
+        assert mtime_before == mtime_after
+
+    def test_force_overwrites_conflicting_agent(
+        self, tmp_path, monkeypatch, isolated_home
+    ):
+        """--force overwrites a diverged local agent without prompting."""
+        agents_dir = isolated_home / ".config" / "opencode" / "agents"
+        agents_dir.mkdir(parents=True)
+        (agents_dir / "code-reviewer.md").write_text("old local content\n")
+
+        wh, project = _make_agent_project(tmp_path, monkeypatch)
+        runner = CliRunner()
+        result = runner.invoke(main, ["sync", "--force", "--skip-git-check"])
+
+        assert result.exit_code == 0, result.output
+        assert (agents_dir / "code-reviewer.md").read_text() == SAMPLE_AGENT_MD
+
+    def test_preserve_skips_conflicting_agent(
+        self, tmp_path, monkeypatch, isolated_home
+    ):
+        """--preserve leaves diverged local agent files untouched."""
+        agents_dir = isolated_home / ".config" / "opencode" / "agents"
+        agents_dir.mkdir(parents=True)
+        (agents_dir / "code-reviewer.md").write_text("old local content\n")
+
+        wh, project = _make_agent_project(tmp_path, monkeypatch)
+        runner = CliRunner()
+        result = runner.invoke(main, ["sync", "--preserve", "--skip-git-check"])
+
+        assert result.exit_code == 0, result.output
+        assert (agents_dir / "code-reviewer.md").read_text() == "old local content\n"
+        assert "Skipped" in result.output
+
+    def test_non_interactive_conflict_skips_without_prompt(
+        self, tmp_path, monkeypatch, isolated_home
+    ):
+        """In non-interactive mode, conflicting agents are skipped automatically."""
+        agents_dir = isolated_home / ".config" / "opencode" / "agents"
+        agents_dir.mkdir(parents=True)
+        (agents_dir / "code-reviewer.md").write_text("diverged content\n")
+
+        wh, project = _make_agent_project(tmp_path, monkeypatch)
+        runner = CliRunner()
+        result = runner.invoke(main, ["sync", "--skip-git-check"])
+
+        assert result.exit_code == 0, result.output
+        assert (agents_dir / "code-reviewer.md").read_text() == "diverged content\n"


### PR DESCRIPTION
## Summary

- Adds `abc agents sync` subcommand to bulk-pull all agent definitions from the warehouse into global tool directories (`~/.config/opencode/agents/` and/or `~/.claude/agents/`)
- Includes agent sync as part of `abc sync` so one command keeps all artifact types in sync — knowledge, skills, contexts, and agents
- Supports `--force` (overwrite without prompting), `--preserve` (skip conflicts silently), and `--skip-git-check` flags consistently across both commands
- Single Y/N prompt (default N) shown when local agent files diverge from the warehouse

## Behaviour

```
abc sync               # syncs project artifacts + agents globally
abc agents sync        # syncs agents only (useful standalone)
abc agents sync --force    # overwrite all without prompting
abc agents sync --preserve # skip all conflicts silently
```

## Tests

- `test_agents_sync_command.py` — 10 tests covering `abc agents sync` (install to opencode, claudecode, both, idempotency, --force, --preserve, non-interactive, no agents dir, no .agentic-beacon, mutual exclusion)
- `TestSyncAgentsFromWarehouse` in `test_sync_wiring.py` — 8 tests covering agent sync via `abc sync`
- Fixed `test_contribute_agents.py` mkdir calls to use `exist_ok=True` since `abc sync` now creates agent dirs as a side effect