### PR TITLE
fix: update agent sync-state HEAD even when content is unchanged

### DIFF
--- a/libs/beacon/src/beacon/cli.py
+++ b/libs/beacon/src/beacon/cli.py
@@ -655,6 +655,11 @@ def connect(*, path: Path | None) -> None:
             console.print("[green]✓[/green] Updated .gitignore")
         _update_agent_gitignores(Path.cwd())
 
+        # Relink agent sync-state if the warehouse was moved/renamed.
+        # This migrates tracking entries from the old path key to the new one
+        # so that 'abc delta' does not report agents as stale after a move.
+        _relink_global_sync_state(warehouse_path)
+
         # Success message
         console.print("\n[bold green]✓ Connected to warehouse[/bold green]")
         console.print(f"  [blue]Location:[/blue] {warehouse_path}")
@@ -1736,9 +1741,12 @@ def _sync_agents_from_warehouse(
                 continue
 
             written = _install_agent_global(tool, agent_name, content)
+            # Always update sync-state HEAD, even when content is unchanged.
+            # Without this, 'abc delta' keeps reporting agents as stale after a
+            # sync that found nothing to write (warehouse advanced, content same).
+            _write_agent_sync_state(warehouse_path, rel, _hash_content(content))
             if written:
                 installed.append(agent_name)
-                _write_agent_sync_state(warehouse_path, rel, _hash_content(content))
 
     if installed:
         unique = sorted(set(installed))
@@ -1819,9 +1827,12 @@ def _handle_install_agent(
             continue
 
         written = _install_agent_global(tool, agent_name, content)
+        # Always update sync-state HEAD, even when content is unchanged.
+        # Without this, 'abc delta' keeps reporting the agent as stale after
+        # install finds nothing to write (warehouse advanced, content same).
+        _write_agent_sync_state(warehouse_path, artifact, _hash_content(content))
         if written:
             console.print(f"[green]Installed[/green] {artifact} → {dest}")
-            _write_agent_sync_state(warehouse_path, artifact, _hash_content(content))
             written_any = True
         else:
             console.print(f"[dim]Up to date[/dim] {dest}")

--- a/libs/beacon/tests/cli/test_agents_sync_command.py
+++ b/libs/beacon/tests/cli/test_agents_sync_command.py
@@ -15,7 +15,11 @@ Test Cases:
 - TC8: Non-interactive mode with conflict → skipped automatically
 - TC9: No .agentic-beacon → error
 - TC10: --force and --preserve are mutually exclusive
+- TC11: Sync updates sync-state HEAD even when agent content is already identical
 """
+
+import json
+import subprocess
 
 import pytest
 from beacon.cli import main
@@ -239,6 +243,87 @@ def test_agents_sync_no_beacon_dir_errors(tmp_path, monkeypatch, isolated_home):
 
     assert result.exit_code != 0
     assert "No .agentic-beacon directory found" in result.output
+
+
+# ---------------------------------------------------------------------------
+# TC11: Sync updates sync-state HEAD even when agent content is already identical
+# ---------------------------------------------------------------------------
+
+
+def test_agents_sync_updates_sync_state_when_content_unchanged(
+    connected_project, isolated_home
+):
+    """TC11: sync updates sync-state HEAD even when agent file is already up-to-date.
+
+    Regression test for: warehouse advances (e.g. a commit that doesn't touch agents),
+    content stays identical, but 'abc delta' keeps reporting agents as stale because
+    agents sync skipped writing the file and never bumped the recorded HEAD.
+    """
+
+    project, wh = connected_project
+
+    # Make wh a real git repo so we can get a HEAD SHA
+    subprocess.run(["git", "init", str(wh)], check=True, capture_output=True)
+    subprocess.run(
+        ["git", "-C", str(wh), "config", "user.email", "test@test.com"],
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(wh), "config", "user.name", "Test"],
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(["git", "-C", str(wh), "add", "."], check=True, capture_output=True)
+    subprocess.run(
+        ["git", "-C", str(wh), "commit", "-m", "init"],
+        check=True,
+        capture_output=True,
+    )
+    current_head = subprocess.run(
+        ["git", "-C", str(wh), "rev-parse", "HEAD"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+
+    # Pre-install the agent with the correct content (no write needed on sync)
+    opencode_agents = isolated_home / ".config" / "opencode" / "agents"
+    opencode_agents.mkdir(parents=True)
+    (opencode_agents / "code-reviewer.md").write_text(SAMPLE_AGENT_MD)
+
+    # Pre-populate sync-state with a stale (old) warehouse HEAD
+    state_file = isolated_home / ".config" / "agentic-beacon" / "sync-state.json"
+    state_file.parent.mkdir(parents=True, exist_ok=True)
+    state_file.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "warehouses": {
+                    str(wh): {
+                        "agents/code-reviewer.md": {
+                            "content_hash": "oldhash",
+                            "warehouse_head": "old_sha_before_advance",
+                            "installed_at": "2026-01-01T00:00:00+00:00",
+                        }
+                    }
+                },
+            }
+        )
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["agents", "sync", "--skip-git-check"])
+    assert result.exit_code == 0, result.output
+
+    # Sync-state HEAD must be updated to the current warehouse HEAD
+    updated_state = json.loads(state_file.read_text())
+    entry = updated_state["warehouses"][str(wh)]["agents/code-reviewer.md"]
+    assert entry["warehouse_head"] == current_head, (
+        f"Expected sync-state HEAD to be updated to {current_head!r}, "
+        f"got {entry['warehouse_head']!r}. "
+        "'abc delta' would still report this agent as stale."
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/libs/beacon/tests/cli/test_install_agent_integration.py
+++ b/libs/beacon/tests/cli/test_install_agent_integration.py
@@ -142,8 +142,13 @@ def test_tc3_beacon_yaml_unchanged(connected_project):
         assert not beacon_yaml.exists() or "agents" not in beacon_yaml.read_text()
 
 
-def test_tc4_identical_content_noop(connected_project):
-    """TC4: Content identical → no-op, sync-state NOT updated, exit 0."""
+def test_tc4_identical_content_updates_sync_state_head(connected_project):
+    """TC4: Content identical → no file write, but sync-state HEAD is still updated.
+
+    Even when the agent file content hasn't changed, install must bump the recorded
+    warehouse_head so that 'abc delta' does not keep reporting the agent as stale
+    after the warehouse advances past commits that don't touch agent files.
+    """
     project, warehouse, runner, fake_home = connected_project
     opencode_dir, claude_dir = _make_tool_dirs(fake_home)
 
@@ -157,17 +162,19 @@ def test_tc4_identical_content_noop(connected_project):
 
     assert result.exit_code == 0
 
-    # Sync-state should NOT be updated (no-op)
+    # Sync-state SHOULD be updated even though no file write happened
     state_file = _global_sync_state_file()
-    if state_file.exists():
-        state = json.loads(state_file.read_text())
-        warehouse_key = str(warehouse)
-        warehouses = state.get("warehouses", {})
-        # Either no state for this warehouse, or no entry for this file
-        agent_state = warehouses.get(warehouse_key, {}).get(
-            "agents/code-reviewer.md", {}
-        )
-        assert agent_state == {}
+    assert state_file.exists(), "sync-state file should exist after install"
+    state = json.loads(state_file.read_text())
+    agent_state = (
+        state.get("warehouses", {})
+        .get(str(warehouse), {})
+        .get("agents/code-reviewer.md", {})
+    )
+    assert agent_state != {}, (
+        "sync-state entry should be written even for identical content"
+    )
+    assert "warehouse_head" in agent_state
 
 
 def test_tc6_force_overwrites_without_prompt(connected_project):

--- a/libs/beacon/tests/cli/test_warehouse_connect.py
+++ b/libs/beacon/tests/cli/test_warehouse_connect.py
@@ -10,6 +10,9 @@ Following TDD workflow for tasks 3.1-3.7:
 - Task 3.7: Progress indicators
 """
 
+import json
+from pathlib import Path
+
 import pytest
 from beacon.cli import main
 from click.testing import CliRunner
@@ -428,3 +431,67 @@ def test_connect_progress_indicators_appear_in_order(
     connected_pos = output.find("✓ Connected to warehouse")
 
     assert validating_pos < validated_pos < saved_pos < connected_pos
+
+
+def test_connect_relinks_agent_sync_state_on_warehouse_move(
+    valid_warehouse, temp_dir, monkeypatch
+):
+    """TC: connect relinks agent sync-state when warehouse path changes.
+
+    When a warehouse is moved to a new path and the user re-runs
+    'abc warehouse connect --path /new/path', the global sync-state
+    (keyed by warehouse path) should be migrated from the old key to the
+    new one so that 'abc delta' no longer reports agents as stale.
+    """
+    fake_home = temp_dir / "home"
+    fake_home.mkdir()
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: fake_home))
+
+    # Pre-populate sync-state with entries under the old warehouse path.
+    # The new warehouse has the same directory name ("valid_warehouse" here
+    # won't match by name, so we rename to match the relink heuristic).
+    new_name = valid_warehouse.name  # use whatever name valid_warehouse has
+    old_path_key = str(temp_dir / "old_location" / new_name)
+
+    state_file = fake_home / ".config" / "agentic-beacon" / "sync-state.json"
+    state_file.parent.mkdir(parents=True, exist_ok=True)
+    state_file.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "warehouses": {
+                    old_path_key: {
+                        "agents/code-reviewer.md": {
+                            "content_hash": "abc123",
+                            "warehouse_head": "deadbeef",
+                            "installed_at": "2026-01-01T00:00:00+00:00",
+                        }
+                    }
+                },
+            }
+        )
+    )
+
+    project_dir = temp_dir / "project"
+    project_dir.mkdir()
+    monkeypatch.chdir(project_dir)
+
+    runner = CliRunner()
+    # Simulate reconnecting after a warehouse move — user says "y" to relink prompt
+    result = runner.invoke(
+        main,
+        ["warehouse", "connect", "--path", str(valid_warehouse)],
+        input="y\n",
+    )
+
+    assert result.exit_code == 0
+
+    updated_state = json.loads(state_file.read_text())
+    # Resolve both to handle macOS /var → /private/var symlinks
+    new_key = str(valid_warehouse.resolve())
+    assert new_key in updated_state["warehouses"], (
+        "sync-state should be relinked to the new warehouse path after connect"
+    )
+    assert old_path_key not in updated_state["warehouses"], (
+        "old warehouse path key should be removed after relink"
+    )


### PR DESCRIPTION
## Summary

- Moves `_write_agent_sync_state` outside the `if written:` block in both `_sync_agents_from_warehouse` and `_handle_install_agent` so the warehouse HEAD is always recorded, even when file content is identical
- Adds `_relink_global_sync_state` call during `abc warehouse connect` to migrate stale sync-state keys after a warehouse move/rename
- Adds regression tests: TC11 in `test_agents_sync_command.py`, updated TC4 in `test_install_agent_integration.py`, and a new connect relink test

## Test plan

- [x] All 39 tests in the affected test files pass
- [x] `abc delta` no longer reports agents as stale after a sync/install where content was already up-to-date
- [x] `abc warehouse connect` relinks sync-state when warehouse path changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)