### PR TITLE
feat: bundled skills with abc- prefixed command stubs and record-skill

### DIFF
--- a/examples/sample-warehouse/skills/record-skill/SKILL.md
+++ b/examples/sample-warehouse/skills/record-skill/SKILL.md
@@ -1,0 +1,211 @@
+---
+name: record-skill
+description: Pattern for extracting operational scripts from hosts/ into dedicated skills. Use when you encounter scripts embedded in infrastructure directories that should be reusable, atomic skill operations.
+---
+
+# SKILL: Record Skill — Extract Scripts into Dedicated Skills
+
+## Philosophy
+
+Operational scripts belong in **skills**, not in `hosts/<host>/services/<service>/scripts/`. Skills are:
+
+- **Atomic** — one concern per skill
+- **Reusable** — callable from any context without coupling to a specific host
+- **Self-contained** — dependencies declared inline (PEP 723 for Python) or clearly documented
+- **Versioned with intent** — the skill captures the *operation*, not the *location*
+
+## When to Apply This Pattern
+
+Apply when you find scripts in these locations:
+
+- `hosts/<host>/services/<service>/scripts/`
+- `hosts/<host>/scripts/`
+- Ad-hoc scripts committed next to docker-compose files
+
+**Do NOT extract:**
+- One-time migration scripts
+- Host-specific configuration files (SSH keys, systemd units)
+- Scripts that are literally part of the service image build
+
+## Decision Tree
+
+```
+Script found in hosts/
+    |
+    +-- Is it an operational tool? (create bucket, clean disk, manage user)
+    |       +-- YES → Extract to skill
+    |       +-- NO  → Leave in place
+    |
+    +-- Is it coupled to a specific host path?
+    |       +-- YES → Parameterize it, then extract
+    |       +-- NO  → Extract as-is
+    |
+    +-- Does it need to run as part of service startup?
+            +-- YES → Leave in hosts/ or move to image
+            +-- NO  → Extract to skill
+```
+
+## Workflow
+
+### Step 1: Identify the Script(s)
+
+```bash
+find hosts/ -name "*.sh" -o -name "*.py" | grep -E "scripts/|bin/"
+```
+
+### Step 2: Choose Skill Location
+
+| Scope | Location | Example |
+|-------|----------|---------|
+| Project-specific | `.opencode/skills/<skill-name>/` | `minio-ops`, `runner-disk-cleanup` |
+| Global (cross-project) | `~/.config/opencode/skills/<skill-name>/` | `record-knowledge` |
+
+Use **project-specific** when the script targets project infrastructure (e.g., homelab MinIO). Use **global** when the pattern itself is reusable.
+
+### Step 3: Create Skill Structure
+
+```bash
+mkdir -p <skill-dir>/scripts
+touch <skill-dir>/SKILL.md
+```
+
+For **Python scripts** — convert to PEP 723 inline scripts:
+
+```python
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#   "minio>=7.2.0",
+#   "click>=8.1.0",
+#   "loguru>=0.7.0",
+# ]
+# ///
+```
+
+For **bash scripts** — keep as `.sh` with clear headers:
+
+```bash
+#!/bin/bash
+# Script: <name>
+# Purpose: <one-line description>
+# Host: <target host>
+# Usage: <how to invoke>
+```
+
+### Step 4: Move and Adapt
+
+1. Copy script to `<skill-dir>/scripts/`
+2. Remove host-specific hardcoding (URLs, paths) if possible
+3. Parameterize via CLI flags or environment variables
+4. Update comments to reference `${SKILL_DIR}` instead of hard paths
+
+### Step 5: Write SKILL.md
+
+Template:
+
+```markdown
+---
+name: <skill-name>
+description: <one-line purpose>
+---
+
+# SKILL: <Skill Name>
+
+## Role & Purpose
+
+<what this skill does>
+
+## Scripts
+
+| Script | Purpose |
+|--------|---------|
+| `${SKILL_DIR}/scripts/<script>` | <description> |
+
+## Usage
+
+```bash
+<command examples using ${SKILL_DIR}>
+```
+
+## Prerequisites
+
+<env vars, ssh access, etc.>
+
+## Important Notes
+
+<critical warnings>
+```
+
+### Step 6: Update References
+
+Remove script from `hosts/` and update all references:
+
+```bash
+# Find references
+grep -r "hosts/.*/scripts/<script>" .
+
+# Update docs, READMEs, other skills
+grep -r "<old-path>" . --include="*.md" --include="*.sh"
+```
+
+### Step 7: Test
+
+For Python (PEP 723):
+```bash
+uv run ${SKILL_DIR}/scripts/script.py --help
+```
+
+For bash:
+```bash
+bash -n ${SKILL_DIR}/scripts/script.sh
+ssh root@<host> "bash -s" < ${SKILL_DIR}/scripts/script.sh
+```
+
+## Examples
+
+### Example 1: MinIO Operations (Python)
+
+**Before:** `hosts/truenas/services/minio/scripts/minio_admin.py`
+
+**After:** `.opencode/skills/minio-ops/scripts/minio_admin.py` (PEP 723 inline)
+
+**Usage change:**
+```bash
+# Before
+uv run --with "minio>=7.2.0,..." python hosts/truenas/services/minio/scripts/minio_admin.py ...
+
+# After
+uv run ${SKILL_DIR}/scripts/minio_admin.py ...
+```
+
+### Example 2: Runner Disk Cleanup (Bash)
+
+**Before:** `hosts/prod-github-runner/scripts/disk-cleanup.sh`
+
+**After:** `.opencode/skills/runner-disk-cleanup/scripts/disk-cleanup.sh`
+
+**Usage change:**
+```bash
+# Before
+ssh root@192.168.88.7 "bash -s" < hosts/prod-github-runner/scripts/setup-cleanup-cron.sh
+
+# After
+ssh root@192.168.88.7 "cat > /usr/local/bin/runner-disk-cleanup.sh" < ${SKILL_DIR}/scripts/disk-cleanup.sh
+ssh root@192.168.88.7 "bash -s" < ${SKILL_DIR}/scripts/setup-cleanup-cron.sh
+```
+
+## Anti-Patterns
+
+❌ **Leaving scripts in hosts/ because "that's where they run"** — Skills can target any host; the skill is the operation, the host is the parameter.
+
+❌ **Bundling unrelated operations into one skill** — Disk cleanup and runner setup are orthogonal; they deserve separate skills.
+
+❌ **Duplicating requirements.txt** — Use PEP 723 inline metadata for Python scripts instead.
+
+❌ **Hardcoding host paths in skills** — Use CLI args or env vars; document defaults in SKILL.md.
+
+## Related
+
+- `minio-ops` — Example of a Python PEP 723 skill
+- `runner-disk-cleanup` — Example of a bash skill
+- `record-knowledge` — Global skill for capturing decisions and lessons

--- a/examples/sample-warehouse/skills/record-skill/SKILL.md
+++ b/examples/sample-warehouse/skills/record-skill/SKILL.md
@@ -1,211 +1,194 @@
 ---
 name: record-skill
-description: Pattern for extracting operational scripts from hosts/ into dedicated skills. Use when you encounter scripts embedded in infrastructure directories that should be reusable, atomic skill operations.
+description: Scaffold new Beacon skills with proper frontmatter, section structure, and optional PEP 723 Python scripts.
+license: MIT
+compatibility: opencode
 ---
 
-# SKILL: Record Skill — Extract Scripts into Dedicated Skills
+# SKILL: Record Skill — Scaffold New Skills
 
-## Philosophy
+## Purpose
 
-Operational scripts belong in **skills**, not in `hosts/<host>/services/<service>/scripts/`. Skills are:
+Create properly structured Beacon skills from an interactive prompt. Generates:
 
-- **Atomic** — one concern per skill
-- **Reusable** — callable from any context without coupling to a specific host
-- **Self-contained** — dependencies declared inline (PEP 723 for Python) or clearly documented
-- **Versioned with intent** — the skill captures the *operation*, not the *location*
+- `SKILL.md` with frontmatter (`name`, `description`, `license`, `compatibility`)
+- Standard section structure (Purpose / When to Use / Invocation / Process / Examples / Checklist)
+- Optional PEP 723 Python script under `scripts/`
 
-## When to Apply This Pattern
+## When to Use
 
-Apply when you find scripts in these locations:
-
-- `hosts/<host>/services/<service>/scripts/`
-- `hosts/<host>/scripts/`
-- Ad-hoc scripts committed next to docker-compose files
-
-**Do NOT extract:**
-- One-time migration scripts
-- Host-specific configuration files (SSH keys, systemd units)
-- Scripts that are literally part of the service image build
-
-## Decision Tree
-
-```
-Script found in hosts/
-    |
-    +-- Is it an operational tool? (create bucket, clean disk, manage user)
-    |       +-- YES → Extract to skill
-    |       +-- NO  → Leave in place
-    |
-    +-- Is it coupled to a specific host path?
-    |       +-- YES → Parameterize it, then extract
-    |       +-- NO  → Extract as-is
-    |
-    +-- Does it need to run as part of service startup?
-            +-- YES → Leave in hosts/ or move to image
-            +-- NO  → Extract to skill
-```
-
-## Workflow
-
-### Step 1: Identify the Script(s)
-
-```bash
-find hosts/ -name "*.sh" -o -name "*.py" | grep -E "scripts/|bin/"
-```
-
-### Step 2: Choose Skill Location
-
-| Scope | Location | Example |
-|-------|----------|---------|
-| Project-specific | `.opencode/skills/<skill-name>/` | `minio-ops`, `runner-disk-cleanup` |
-| Global (cross-project) | `~/.config/opencode/skills/<skill-name>/` | `record-knowledge` |
-
-Use **project-specific** when the script targets project infrastructure (e.g., homelab MinIO). Use **global** when the pattern itself is reusable.
-
-### Step 3: Create Skill Structure
-
-```bash
-mkdir -p <skill-dir>/scripts
-touch <skill-dir>/SKILL.md
-```
-
-For **Python scripts** — convert to PEP 723 inline scripts:
-
-```python
-# /// script
-# requires-python = ">=3.11"
-# dependencies = [
-#   "minio>=7.2.0",
-#   "click>=8.1.0",
-#   "loguru>=0.7.0",
-# ]
-# ///
-```
-
-For **bash scripts** — keep as `.sh` with clear headers:
-
-```bash
-#!/bin/bash
-# Script: <name>
-# Purpose: <one-line description>
-# Host: <target host>
-# Usage: <how to invoke>
-```
-
-### Step 4: Move and Adapt
-
-1. Copy script to `<skill-dir>/scripts/`
-2. Remove host-specific hardcoding (URLs, paths) if possible
-3. Parameterize via CLI flags or environment variables
-4. Update comments to reference `${SKILL_DIR}` instead of hard paths
-
-### Step 5: Write SKILL.md
-
-Template:
-
-```markdown
----
-name: <skill-name>
-description: <one-line purpose>
----
-
-# SKILL: <Skill Name>
-
-## Role & Purpose
-
-<what this skill does>
+- You want to create a new skill for your team or project
+- You need a PEP 723-headed Python script as part of a skill
+- You want consistent skill structure across your warehouse
 
 ## Scripts
 
 | Script | Purpose |
 |--------|---------|
-| `${SKILL_DIR}/scripts/<script>` | <description> |
+| `${SKILL_DIR}/scripts/create_skill.py` | Interactive skill scaffolder |
 
 ## Usage
 
 ```bash
-<command examples using ${SKILL_DIR}>
+# Run the interactive scaffolder
+uv run ${SKILL_DIR}/scripts/create_skill.py
 ```
 
-## Prerequisites
+The tool prompts for:
 
-<env vars, ssh access, etc.>
+1. **Skill name** (auto-normalized to kebab-case)
+2. **One-line description** (→ frontmatter `description`)
+3. **Invocation form** (e.g. `/my-skill <args>`, defaults to `/<name>`)
+4. **Include Python script?** (yes/no — generates PEP 723 inline script)
 
-## Important Notes
+## Process
 
-<critical warnings>
-```
-
-### Step 6: Update References
-
-Remove script from `hosts/` and update all references:
+### Step 1: Run the Scaffolder
 
 ```bash
-# Find references
-grep -r "hosts/.*/scripts/<script>" .
-
-# Update docs, READMEs, other skills
-grep -r "<old-path>" . --include="*.md" --include="*.sh"
+uv run ${SKILL_DIR}/scripts/create_skill.py
 ```
 
-### Step 7: Test
+### Step 2: Fill in Generated Content
 
-For Python (PEP 723):
+The scaffolder creates `.agentic-beacon/artifacts/skills/<name>/` with:
+
+```
+skills/<name>/
+├── SKILL.md
+└── scripts/
+    └── <name>.py          # only if you requested a script
+```
+
+Edit `SKILL.md` to complete:
+- **When to Use** — specific situations
+- **Process** — step-by-step workflow
+- **Examples** — concrete usage
+
+### Step 3: Implement the Script (if included)
+
+The generated `.py` file has a PEP 723 header:
+
+```python
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
+```
+
+Add dependencies as you implement:
+
+```python
+# dependencies = [
+#   "requests>=2.31.0",
+#   "pydantic>=2.0.0",
+# ]
+```
+
+Test without any `pyproject.toml`:
+
 ```bash
-uv run ${SKILL_DIR}/scripts/script.py --help
+uv run .agentic-beacon/artifacts/skills/<name>/scripts/<name>.py
 ```
 
-For bash:
-```bash
-bash -n ${SKILL_DIR}/scripts/script.sh
-ssh root@<host> "bash -s" < ${SKILL_DIR}/scripts/script.sh
+### Step 4: Register and Sync
+
+Add to `beacon.yaml`:
+
+```yaml
+artifacts:
+  skills:
+    - skills/<name>/
 ```
+
+Run `abc sync` to distribute.
 
 ## Examples
 
-### Example 1: MinIO Operations (Python)
+### Example 1: Markdown-Only Skill
 
-**Before:** `hosts/truenas/services/minio/scripts/minio_admin.py`
-
-**After:** `.opencode/skills/minio-ops/scripts/minio_admin.py` (PEP 723 inline)
-
-**Usage change:**
 ```bash
-# Before
-uv run --with "minio>=7.2.0,..." python hosts/truenas/services/minio/scripts/minio_admin.py ...
+$ uv run ${SKILL_DIR}/scripts/create_skill.py
+============================================================
+Beacon Skill Scaffolder
+============================================================
 
-# After
-uv run ${SKILL_DIR}/scripts/minio_admin.py ...
+Skill name (kebab-case): deploy-check
+One-line description: Validate deployment readiness checklist
+Invocation form [/deploy-check]:
+Include PEP 723 Python script [y/N]: n
+
+Scaffolding...
+
+============================================================
+✓ Created skill: deploy-check
+============================================================
+
+  Location: /path/to/project/.agentic-beacon/artifacts/skills/deploy-check
+  SKILL.md: /path/to/project/.agentic-beacon/artifacts/skills/deploy-check/SKILL.md
+
+Next steps:
+  1. Edit .../SKILL.md to fill in Process and Examples
+  4. Add to beacon.yaml: skills/deploy-check/
+  5. Run 'abc sync' to distribute
 ```
 
-### Example 2: Runner Disk Cleanup (Bash)
+### Example 2: Skill with PEP 723 Script
 
-**Before:** `hosts/prod-github-runner/scripts/disk-cleanup.sh`
-
-**After:** `.opencode/skills/runner-disk-cleanup/scripts/disk-cleanup.sh`
-
-**Usage change:**
 ```bash
-# Before
-ssh root@192.168.88.7 "bash -s" < hosts/prod-github-runner/scripts/setup-cleanup-cron.sh
+$ uv run ${SKILL_DIR}/scripts/create_skill.py
+Skill name (kebab-case): s3-cleanup
+One-line description: Clean old S3 buckets with configurable retention
+Include PEP 723 Python script [y/N]: y
 
-# After
-ssh root@192.168.88.7 "cat > /usr/local/bin/runner-disk-cleanup.sh" < ${SKILL_DIR}/scripts/disk-cleanup.sh
-ssh root@192.168.88.7 "bash -s" < ${SKILL_DIR}/scripts/setup-cleanup-cron.sh
+Scaffolding...
+
+============================================================
+✓ Created skill: s3-cleanup
+============================================================
+
+  Location: .../.agentic-beacon/artifacts/skills/s3-cleanup
+  SKILL.md: .../.agentic-beacon/artifacts/skills/s3-cleanup/SKILL.md
+  Script:   .../.agentic-beacon/artifacts/skills/s3-cleanup/scripts/s3-cleanup.py
+
+Next steps:
+  1. Edit .../SKILL.md to fill in Process and Examples
+  2. Implement logic in .../scripts/s3-cleanup.py
+  3. Test: uv run .../scripts/s3-cleanup.py
+  4. Add to beacon.yaml: skills/s3-cleanup/
+  5. Run 'abc sync' to distribute
 ```
 
-## Anti-Patterns
+## Checklist
 
-❌ **Leaving scripts in hosts/ because "that's where they run"** — Skills can target any host; the skill is the operation, the host is the parameter.
+- [ ] Skill name is kebab-case and descriptive
+- [ ] Description is one line and clear
+- [ ] SKILL.md sections are filled in (not left as stubs)
+- [ ] Scripts run without errors (`uv run ...`)
+- [ ] beacon.yaml entry added before syncing
+- [ ] Skill tested in a real project before sharing
 
-❌ **Bundling unrelated operations into one skill** — Disk cleanup and runner setup are orthogonal; they deserve separate skills.
+## PEP 723 Pattern
 
-❌ **Duplicating requirements.txt** — Use PEP 723 inline metadata for Python scripts instead.
+PEP 723 (uv inline script metadata) lets Python scripts declare their own dependencies without a `pyproject.toml`:
 
-❌ **Hardcoding host paths in skills** — Use CLI args or env vars; document defaults in SKILL.md.
+```python
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#   "requests>=2.31.0",
+# ]
+# ///
+```
+
+**Benefits:**
+- No `venv/` or `pyproject.toml` needed per skill
+- Dependencies are version-pinned and explicit
+- Scripts are self-contained and portable
+- Runs with `uv run script.py` anywhere
+
+**Reference:** [PEP 723 – Inline script metadata](https://peps.python.org/pep-0723/)
 
 ## Related
 
-- `minio-ops` — Example of a Python PEP 723 skill
-- `runner-disk-cleanup` — Example of a bash skill
-- `record-knowledge` — Global skill for capturing decisions and lessons
+- `record-knowledge` — Capture decisions and lessons into the knowledge base

--- a/examples/sample-warehouse/skills/record-skill/scripts/create_skill.py
+++ b/examples/sample-warehouse/skills/record-skill/scripts/create_skill.py
@@ -1,0 +1,210 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
+
+"""Interactive scaffolding for new Beacon skills.
+
+Creates a new skill directory under .agentic-beacon/artifacts/skills/<name>/
+with proper frontmatter, section structure, and optional PEP 723 Python script.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+
+def prompt(text: str, default: str = "") -> str:
+    """Prompt user for input with optional default."""
+    if default:
+        raw = input(f"{text} [{default}]: ").strip()
+        return raw if raw else default
+    while True:
+        raw = input(f"{text}: ").strip()
+        if raw:
+            return raw
+        print("  (required)")
+
+
+def prompt_yes_no(text: str, default: bool = False) -> bool:
+    """Prompt for yes/no with optional default."""
+    suffix = " [Y/n]" if default else " [y/N]"
+    while True:
+        raw = input(f"{text}{suffix}: ").strip().lower()
+        if not raw:
+            return default
+        if raw in ("y", "yes"):
+            return True
+        if raw in ("n", "no"):
+            return False
+        print("  Please enter 'y' or 'n'")
+
+
+def validate_kebab_case(name: str) -> str:
+    """Validate and convert to kebab-case."""
+    # Replace underscores and spaces with hyphens
+    normalized = name.replace("_", "-").replace(" ", "-").lower()
+    # Remove any non-alphanumeric-non-hyphen characters
+    normalized = re.sub(r"[^a-z0-9-]", "", normalized)
+    # Collapse multiple hyphens
+    normalized = re.sub(r"-+", "-", normalized)
+    return normalized.strip("-")
+
+
+def scaffold_skill(
+    name: str,
+    description: str,
+    invocation: str,
+    include_scripts: bool,
+) -> Path:
+    """Scaffold a new skill directory and return its path."""
+    project_root = Path.cwd()
+    artifacts_dir = project_root / ".agentic-beacon" / "artifacts"
+    if not artifacts_dir.exists():
+        print("Error: No .agentic-beacon/artifacts/ directory found.")
+        print("Run 'abc sync' or 'abc setup' first.")
+        sys.exit(1)
+
+    skill_dir = artifacts_dir / "skills" / name
+    if skill_dir.exists():
+        print(f"Error: Skill directory already exists: {skill_dir}")
+        sys.exit(1)
+
+    skill_dir.mkdir(parents=True)
+
+    # Write SKILL.md
+    skill_md = skill_dir / "SKILL.md"
+    skill_md.write_text(_build_skill_md(name, description, invocation, include_scripts))
+
+    # Write optional PEP 723 script
+    if include_scripts:
+        scripts_dir = skill_dir / "scripts"
+        scripts_dir.mkdir()
+        script_file = scripts_dir / f"{name}.py"
+        script_file.write_text(_build_pep723_script(name, description))
+
+    return skill_dir
+
+
+def _build_skill_md(
+    name: str, description: str, invocation: str, include_scripts: bool
+) -> str:
+    """Build the SKILL.md content."""
+    scripts_section = ""
+    if include_scripts:
+        scripts_section = f"""
+## Scripts
+
+| Script | Purpose |
+|--------|---------|
+| `${{SKILL_DIR}}/scripts/{name}.py` | Main executable script |
+
+"""
+
+    return f"""---
+name: {name}
+description: {description}
+license: MIT
+compatibility: opencode
+---
+
+# SKILL: {name.replace("-", " ").title()}
+
+## Purpose
+
+{description}
+
+## When to Use
+
+<!-- Describe the specific situations where this skill applies -->
+
+## Invocation
+
+```
+{invocation}
+```
+
+{scripts_section}## Process
+
+<!-- Step-by-step workflow -->
+
+## Examples
+
+<!-- Concrete usage examples -->
+
+## Checklist
+
+- [ ] Skill files are complete and tested
+- [ ] All scripts run without errors (`uv run ${{SKILL_DIR}}/scripts/*.py`)
+- [ ] Documentation is accurate and up-to-date
+- [ ] Skill has been validated in a real project
+"""
+
+
+def _build_pep723_script(name: str, description: str) -> str:
+    """Build a PEP 723 inline script template."""
+    return f'''# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
+
+"""{description}"""
+
+import sys
+
+
+def main() -> None:
+    """Main entry point for {name}."""
+    print(f"Running {{name}}...")
+    # TODO: Implement your skill logic here
+    pass
+
+
+if __name__ == "__main__":
+    main()
+'''
+
+
+def main() -> None:
+    """Run interactive skill scaffolding."""
+    print("=" * 60)
+    print("Beacon Skill Scaffolder")
+    print("=" * 60)
+    print()
+
+    name_raw = prompt("Skill name (kebab-case)")
+    name = validate_kebab_case(name_raw)
+    if name != name_raw:
+        print(f"  → Normalized to: {name}")
+
+    description = prompt("One-line description")
+    invocation = prompt("Invocation form", default=f"/{name}")
+    include_scripts = prompt_yes_no("Include PEP 723 Python script", default=False)
+
+    print()
+    print("Scaffolding...")
+
+    skill_dir = scaffold_skill(name, description, invocation, include_scripts)
+
+    print()
+    print("=" * 60)
+    print(f"✓ Created skill: {name}")
+    print("=" * 60)
+    print()
+    print(f"  Location: {skill_dir}")
+    print(f"  SKILL.md: {skill_dir / 'SKILL.md'}")
+    if include_scripts:
+        print(f"  Script:   {skill_dir / 'scripts' / f'{name}.py'}")
+    print()
+    print("Next steps:")
+    print(f"  1. Edit {skill_dir / 'SKILL.md'} to fill in Process and Examples")
+    if include_scripts:
+        print(f"  2. Implement logic in {skill_dir / 'scripts' / f'{name}.py'}")
+        print(f"  3. Test: uv run {skill_dir / 'scripts' / f'{name}.py'}")
+    print(f"  4. Add to beacon.yaml: skills/{name}/")
+    print("  5. Run 'abc sync' to distribute")
+    print()
+
+
+if __name__ == "__main__":
+    main()

--- a/libs/beacon/src/beacon/data/skills/record-skill/SKILL.md
+++ b/libs/beacon/src/beacon/data/skills/record-skill/SKILL.md
@@ -1,0 +1,211 @@
+---
+name: record-skill
+description: Pattern for extracting operational scripts from hosts/ into dedicated skills. Use when you encounter scripts embedded in infrastructure directories that should be reusable, atomic skill operations.
+---
+
+# SKILL: Record Skill — Extract Scripts into Dedicated Skills
+
+## Philosophy
+
+Operational scripts belong in **skills**, not in `hosts/<host>/services/<service>/scripts/`. Skills are:
+
+- **Atomic** — one concern per skill
+- **Reusable** — callable from any context without coupling to a specific host
+- **Self-contained** — dependencies declared inline (PEP 723 for Python) or clearly documented
+- **Versioned with intent** — the skill captures the *operation*, not the *location*
+
+## When to Apply This Pattern
+
+Apply when you find scripts in these locations:
+
+- `hosts/<host>/services/<service>/scripts/`
+- `hosts/<host>/scripts/`
+- Ad-hoc scripts committed next to docker-compose files
+
+**Do NOT extract:**
+- One-time migration scripts
+- Host-specific configuration files (SSH keys, systemd units)
+- Scripts that are literally part of the service image build
+
+## Decision Tree
+
+```
+Script found in hosts/
+    |
+    +-- Is it an operational tool? (create bucket, clean disk, manage user)
+    |       +-- YES → Extract to skill
+    |       +-- NO  → Leave in place
+    |
+    +-- Is it coupled to a specific host path?
+    |       +-- YES → Parameterize it, then extract
+    |       +-- NO  → Extract as-is
+    |
+    +-- Does it need to run as part of service startup?
+            +-- YES → Leave in hosts/ or move to image
+            +-- NO  → Extract to skill
+```
+
+## Workflow
+
+### Step 1: Identify the Script(s)
+
+```bash
+find hosts/ -name "*.sh" -o -name "*.py" | grep -E "scripts/|bin/"
+```
+
+### Step 2: Choose Skill Location
+
+| Scope | Location | Example |
+|-------|----------|---------|
+| Project-specific | `.opencode/skills/<skill-name>/` | `minio-ops`, `runner-disk-cleanup` |
+| Global (cross-project) | `~/.config/opencode/skills/<skill-name>/` | `record-knowledge` |
+
+Use **project-specific** when the script targets project infrastructure (e.g., homelab MinIO). Use **global** when the pattern itself is reusable.
+
+### Step 3: Create Skill Structure
+
+```bash
+mkdir -p <skill-dir>/scripts
+touch <skill-dir>/SKILL.md
+```
+
+For **Python scripts** — convert to PEP 723 inline scripts:
+
+```python
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#   "minio>=7.2.0",
+#   "click>=8.1.0",
+#   "loguru>=0.7.0",
+# ]
+# ///
+```
+
+For **bash scripts** — keep as `.sh` with clear headers:
+
+```bash
+#!/bin/bash
+# Script: <name>
+# Purpose: <one-line description>
+# Host: <target host>
+# Usage: <how to invoke>
+```
+
+### Step 4: Move and Adapt
+
+1. Copy script to `<skill-dir>/scripts/`
+2. Remove host-specific hardcoding (URLs, paths) if possible
+3. Parameterize via CLI flags or environment variables
+4. Update comments to reference `${SKILL_DIR}` instead of hard paths
+
+### Step 5: Write SKILL.md
+
+Template:
+
+```markdown
+---
+name: <skill-name>
+description: <one-line purpose>
+---
+
+# SKILL: <Skill Name>
+
+## Role & Purpose
+
+<what this skill does>
+
+## Scripts
+
+| Script | Purpose |
+|--------|---------|
+| `${SKILL_DIR}/scripts/<script>` | <description> |
+
+## Usage
+
+```bash
+<command examples using ${SKILL_DIR}>
+```
+
+## Prerequisites
+
+<env vars, ssh access, etc.>
+
+## Important Notes
+
+<critical warnings>
+```
+
+### Step 6: Update References
+
+Remove script from `hosts/` and update all references:
+
+```bash
+# Find references
+grep -r "hosts/.*/scripts/<script>" .
+
+# Update docs, READMEs, other skills
+grep -r "<old-path>" . --include="*.md" --include="*.sh"
+```
+
+### Step 7: Test
+
+For Python (PEP 723):
+```bash
+uv run ${SKILL_DIR}/scripts/script.py --help
+```
+
+For bash:
+```bash
+bash -n ${SKILL_DIR}/scripts/script.sh
+ssh root@<host> "bash -s" < ${SKILL_DIR}/scripts/script.sh
+```
+
+## Examples
+
+### Example 1: MinIO Operations (Python)
+
+**Before:** `hosts/truenas/services/minio/scripts/minio_admin.py`
+
+**After:** `.opencode/skills/minio-ops/scripts/minio_admin.py` (PEP 723 inline)
+
+**Usage change:**
+```bash
+# Before
+uv run --with "minio>=7.2.0,..." python hosts/truenas/services/minio/scripts/minio_admin.py ...
+
+# After
+uv run ${SKILL_DIR}/scripts/minio_admin.py ...
+```
+
+### Example 2: Runner Disk Cleanup (Bash)
+
+**Before:** `hosts/prod-github-runner/scripts/disk-cleanup.sh`
+
+**After:** `.opencode/skills/runner-disk-cleanup/scripts/disk-cleanup.sh`
+
+**Usage change:**
+```bash
+# Before
+ssh root@192.168.88.7 "bash -s" < hosts/prod-github-runner/scripts/setup-cleanup-cron.sh
+
+# After
+ssh root@192.168.88.7 "cat > /usr/local/bin/runner-disk-cleanup.sh" < ${SKILL_DIR}/scripts/disk-cleanup.sh
+ssh root@192.168.88.7 "bash -s" < ${SKILL_DIR}/scripts/setup-cleanup-cron.sh
+```
+
+## Anti-Patterns
+
+❌ **Leaving scripts in hosts/ because "that's where they run"** — Skills can target any host; the skill is the operation, the host is the parameter.
+
+❌ **Bundling unrelated operations into one skill** — Disk cleanup and runner setup are orthogonal; they deserve separate skills.
+
+❌ **Duplicating requirements.txt** — Use PEP 723 inline metadata for Python scripts instead.
+
+❌ **Hardcoding host paths in skills** — Use CLI args or env vars; document defaults in SKILL.md.
+
+## Related
+
+- `minio-ops` — Example of a Python PEP 723 skill
+- `runner-disk-cleanup` — Example of a bash skill
+- `record-knowledge` — Global skill for capturing decisions and lessons

--- a/libs/beacon/src/beacon/data/skills/record-skill/SKILL.md
+++ b/libs/beacon/src/beacon/data/skills/record-skill/SKILL.md
@@ -1,211 +1,196 @@
 ---
 name: record-skill
-description: Pattern for extracting operational scripts from hosts/ into dedicated skills. Use when you encounter scripts embedded in infrastructure directories that should be reusable, atomic skill operations.
+description: Scaffold new Beacon skills with proper frontmatter, section structure, and optional PEP 723 Python scripts.
+license: MIT
+compatibility: opencode
 ---
 
-# SKILL: Record Skill — Extract Scripts into Dedicated Skills
+# SKILL: Record Skill — Scaffold New Skills
 
-## Philosophy
+## Purpose
 
-Operational scripts belong in **skills**, not in `hosts/<host>/services/<service>/scripts/`. Skills are:
+Create properly structured Beacon skills from an interactive prompt. Generates:
 
-- **Atomic** — one concern per skill
-- **Reusable** — callable from any context without coupling to a specific host
-- **Self-contained** — dependencies declared inline (PEP 723 for Python) or clearly documented
-- **Versioned with intent** — the skill captures the *operation*, not the *location*
+- `SKILL.md` with frontmatter (`name`, `description`, `license`, `compatibility`)
+- Standard section structure (Purpose / When to Use / Invocation / Process / Examples / Checklist)
+- Optional PEP 723 Python script under `scripts/`
 
-## When to Apply This Pattern
+## When to Use
 
-Apply when you find scripts in these locations:
-
-- `hosts/<host>/services/<service>/scripts/`
-- `hosts/<host>/scripts/`
-- Ad-hoc scripts committed next to docker-compose files
-
-**Do NOT extract:**
-- One-time migration scripts
-- Host-specific configuration files (SSH keys, systemd units)
-- Scripts that are literally part of the service image build
-
-## Decision Tree
-
-```
-Script found in hosts/
-    |
-    +-- Is it an operational tool? (create bucket, clean disk, manage user)
-    |       +-- YES → Extract to skill
-    |       +-- NO  → Leave in place
-    |
-    +-- Is it coupled to a specific host path?
-    |       +-- YES → Parameterize it, then extract
-    |       +-- NO  → Extract as-is
-    |
-    +-- Does it need to run as part of service startup?
-            +-- YES → Leave in hosts/ or move to image
-            +-- NO  → Extract to skill
-```
-
-## Workflow
-
-### Step 1: Identify the Script(s)
-
-```bash
-find hosts/ -name "*.sh" -o -name "*.py" | grep -E "scripts/|bin/"
-```
-
-### Step 2: Choose Skill Location
-
-| Scope | Location | Example |
-|-------|----------|---------|
-| Project-specific | `.opencode/skills/<skill-name>/` | `minio-ops`, `runner-disk-cleanup` |
-| Global (cross-project) | `~/.config/opencode/skills/<skill-name>/` | `record-knowledge` |
-
-Use **project-specific** when the script targets project infrastructure (e.g., homelab MinIO). Use **global** when the pattern itself is reusable.
-
-### Step 3: Create Skill Structure
-
-```bash
-mkdir -p <skill-dir>/scripts
-touch <skill-dir>/SKILL.md
-```
-
-For **Python scripts** — convert to PEP 723 inline scripts:
-
-```python
-# /// script
-# requires-python = ">=3.11"
-# dependencies = [
-#   "minio>=7.2.0",
-#   "click>=8.1.0",
-#   "loguru>=0.7.0",
-# ]
-# ///
-```
-
-For **bash scripts** — keep as `.sh` with clear headers:
-
-```bash
-#!/bin/bash
-# Script: <name>
-# Purpose: <one-line description>
-# Host: <target host>
-# Usage: <how to invoke>
-```
-
-### Step 4: Move and Adapt
-
-1. Copy script to `<skill-dir>/scripts/`
-2. Remove host-specific hardcoding (URLs, paths) if possible
-3. Parameterize via CLI flags or environment variables
-4. Update comments to reference `${SKILL_DIR}` instead of hard paths
-
-### Step 5: Write SKILL.md
-
-Template:
-
-```markdown
----
-name: <skill-name>
-description: <one-line purpose>
----
-
-# SKILL: <Skill Name>
-
-## Role & Purpose
-
-<what this skill does>
+- You want to create a new skill for your team or project
+- You need a PEP 723-headed Python script as part of a skill
+- You want consistent skill structure across your warehouse
 
 ## Scripts
 
 | Script | Purpose |
 |--------|---------|
-| `${SKILL_DIR}/scripts/<script>` | <description> |
+| `${SKILL_DIR}/scripts/create_skill.py` | Interactive skill scaffolder |
 
 ## Usage
 
 ```bash
-<command examples using ${SKILL_DIR}>
+# Run the interactive scaffolder
+uv run ${SKILL_DIR}/scripts/create_skill.py
 ```
 
-## Prerequisites
+The tool prompts for:
 
-<env vars, ssh access, etc.>
+1. **Skill name** (auto-normalized to kebab-case)
+2. **One-line description** (→ frontmatter `description`)
+3. **Invocation form** (e.g. `/my-skill <args>`, defaults to `/<name>`)
+4. **Include Python script?** (yes/no — generates PEP 723 inline script)
 
-## Important Notes
+## Process
 
-<critical warnings>
-```
-
-### Step 6: Update References
-
-Remove script from `hosts/` and update all references:
+### Step 1: Run the Scaffolder
 
 ```bash
-# Find references
-grep -r "hosts/.*/scripts/<script>" .
-
-# Update docs, READMEs, other skills
-grep -r "<old-path>" . --include="*.md" --include="*.sh"
+uv run ${SKILL_DIR}/scripts/create_skill.py
 ```
 
-### Step 7: Test
+### Step 2: Fill in Generated Content
 
-For Python (PEP 723):
+The scaffolder creates `.agentic-beacon/artifacts/skills/<name>/` with:
+
+```
+skills/<name>/
+├── SKILL.md
+└── scripts/
+    └── <name>.py          # only if you requested a script
+```
+
+Edit `SKILL.md` to complete:
+- **When to Use** — specific situations
+- **Process** — step-by-step workflow
+- **Examples** — concrete usage
+
+### Step 3: Implement the Script (if included)
+
+The generated `.py` file has a PEP 723 header:
+
+```python
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
+```
+
+Add dependencies as you implement:
+
+```python
+# dependencies = [
+#   "requests>=2.31.0",
+#   "pydantic>=2.0.0",
+# ]
+```
+
+Test without any `pyproject.toml`:
+
 ```bash
-uv run ${SKILL_DIR}/scripts/script.py --help
+uv run .agentic-beacon/artifacts/skills/<name>/scripts/<name>.py
 ```
 
-For bash:
-```bash
-bash -n ${SKILL_DIR}/scripts/script.sh
-ssh root@<host> "bash -s" < ${SKILL_DIR}/scripts/script.sh
+### Step 4: Register and Sync
+
+Add to `beacon.yaml`:
+
+```yaml
+artifacts:
+  skills:
+    - skills/<name>/
 ```
+
+Run `abc sync` to distribute.
 
 ## Examples
 
-### Example 1: MinIO Operations (Python)
+### Example 1: Markdown-Only Skill
 
-**Before:** `hosts/truenas/services/minio/scripts/minio_admin.py`
-
-**After:** `.opencode/skills/minio-ops/scripts/minio_admin.py` (PEP 723 inline)
-
-**Usage change:**
 ```bash
-# Before
-uv run --with "minio>=7.2.0,..." python hosts/truenas/services/minio/scripts/minio_admin.py ...
+$ uv run ${SKILL_DIR}/scripts/create_skill.py
+============================================================
+Beacon Skill Scaffolder
+============================================================
 
-# After
-uv run ${SKILL_DIR}/scripts/minio_admin.py ...
+Skill name (kebab-case): deploy-check
+One-line description: Validate deployment readiness checklist
+Invocation form [/deploy-check]:
+Include PEP 723 Python script [y/N]: n
+
+Scaffolding...
+
+============================================================
+✓ Created skill: deploy-check
+============================================================
+
+  Location: /path/to/project/.agentic-beacon/artifacts/skills/deploy-check
+  SKILL.md: /path/to/project/.agentic-beacon/artifacts/skills/deploy-check/SKILL.md
+
+Next steps:
+  1. Edit .../SKILL.md to fill in Process and Examples
+  4. Add to beacon.yaml: skills/deploy-check/
+  5. Run 'abc sync' to distribute
 ```
 
-### Example 2: Runner Disk Cleanup (Bash)
+### Example 2: Skill with PEP 723 Script
 
-**Before:** `hosts/prod-github-runner/scripts/disk-cleanup.sh`
-
-**After:** `.opencode/skills/runner-disk-cleanup/scripts/disk-cleanup.sh`
-
-**Usage change:**
 ```bash
-# Before
-ssh root@192.168.88.7 "bash -s" < hosts/prod-github-runner/scripts/setup-cleanup-cron.sh
+$ uv run ${SKILL_DIR}/scripts/create_skill.py
+Skill name (kebab-case): s3-cleanup
+One-line description: Clean old S3 buckets with configurable retention
+Include PEP 723 Python script [y/N]: y
 
-# After
-ssh root@192.168.88.7 "cat > /usr/local/bin/runner-disk-cleanup.sh" < ${SKILL_DIR}/scripts/disk-cleanup.sh
-ssh root@192.168.88.7 "bash -s" < ${SKILL_DIR}/scripts/setup-cleanup-cron.sh
+Scaffolding...
+
+============================================================
+✓ Created skill: s3-cleanup
+============================================================
+
+  Location: .../.agentic-beacon/artifacts/skills/s3-cleanup
+  SKILL.md: .../.agentic-beacon/artifacts/skills/s3-cleanup/SKILL.md
+  Script:   .../.agentic-beacon/artifacts/skills/s3-cleanup/scripts/s3-cleanup.py
+
+Next steps:
+  1. Edit .../SKILL.md to fill in Process and Examples
+  2. Implement logic in .../scripts/s3-cleanup.py
+  3. Test: uv run .../scripts/s3-cleanup.py
+  4. Add to beacon.yaml: skills/s3-cleanup/
+  5. Run 'abc sync' to distribute
 ```
 
-## Anti-Patterns
+## Checklist
 
-❌ **Leaving scripts in hosts/ because "that's where they run"** — Skills can target any host; the skill is the operation, the host is the parameter.
+- [ ] Skill name is kebab-case and descriptive
+- [ ] Description is one line and clear
+- [ ] SKILL.md sections are filled in (not left as stubs)
+- [ ] Scripts run without errors (`uv run ...`)
+- [ ] beacon.yaml entry added before syncing
+- [ ] Skill tested in a real project before sharing
 
-❌ **Bundling unrelated operations into one skill** — Disk cleanup and runner setup are orthogonal; they deserve separate skills.
+## PEP 723 Pattern
 
-❌ **Duplicating requirements.txt** — Use PEP 723 inline metadata for Python scripts instead.
+PEP 723 (uv inline script metadata) lets Python scripts declare their own dependencies without a `pyproject.toml`:
 
-❌ **Hardcoding host paths in skills** — Use CLI args or env vars; document defaults in SKILL.md.
+```python
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#   "requests>=2.31.0",
+# ]
+# ///
+```
+
+**Benefits:**
+- No `venv/` or `pyproject.toml` needed per skill
+- Dependencies are version-pinned and explicit
+- Scripts are self-contained and portable
+- Runs with `uv run script.py` anywhere
+
+**Reference:** [PEP 723 – Inline script metadata](https://peps.python.org/pep-0723/)
 
 ## Related
 
+- `record-knowledge` — Capture decisions and lessons into the knowledge base
 - `minio-ops` — Example of a Python PEP 723 skill
 - `runner-disk-cleanup` — Example of a bash skill
-- `record-knowledge` — Global skill for capturing decisions and lessons

--- a/libs/beacon/src/beacon/data/skills/record-skill/scripts/create_skill.py
+++ b/libs/beacon/src/beacon/data/skills/record-skill/scripts/create_skill.py
@@ -1,0 +1,210 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
+
+"""Interactive scaffolding for new Beacon skills.
+
+Creates a new skill directory under .agentic-beacon/artifacts/skills/<name>/
+with proper frontmatter, section structure, and optional PEP 723 Python script.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+
+def prompt(text: str, default: str = "") -> str:
+    """Prompt user for input with optional default."""
+    if default:
+        raw = input(f"{text} [{default}]: ").strip()
+        return raw if raw else default
+    while True:
+        raw = input(f"{text}: ").strip()
+        if raw:
+            return raw
+        print("  (required)")
+
+
+def prompt_yes_no(text: str, default: bool = False) -> bool:
+    """Prompt for yes/no with optional default."""
+    suffix = " [Y/n]" if default else " [y/N]"
+    while True:
+        raw = input(f"{text}{suffix}: ").strip().lower()
+        if not raw:
+            return default
+        if raw in ("y", "yes"):
+            return True
+        if raw in ("n", "no"):
+            return False
+        print("  Please enter 'y' or 'n'")
+
+
+def validate_kebab_case(name: str) -> str:
+    """Validate and convert to kebab-case."""
+    # Replace underscores and spaces with hyphens
+    normalized = name.replace("_", "-").replace(" ", "-").lower()
+    # Remove any non-alphanumeric-non-hyphen characters
+    normalized = re.sub(r"[^a-z0-9-]", "", normalized)
+    # Collapse multiple hyphens
+    normalized = re.sub(r"-+", "-", normalized)
+    return normalized.strip("-")
+
+
+def scaffold_skill(
+    name: str,
+    description: str,
+    invocation: str,
+    include_scripts: bool,
+) -> Path:
+    """Scaffold a new skill directory and return its path."""
+    project_root = Path.cwd()
+    artifacts_dir = project_root / ".agentic-beacon" / "artifacts"
+    if not artifacts_dir.exists():
+        print("Error: No .agentic-beacon/artifacts/ directory found.")
+        print("Run 'abc sync' or 'abc setup' first.")
+        sys.exit(1)
+
+    skill_dir = artifacts_dir / "skills" / name
+    if skill_dir.exists():
+        print(f"Error: Skill directory already exists: {skill_dir}")
+        sys.exit(1)
+
+    skill_dir.mkdir(parents=True)
+
+    # Write SKILL.md
+    skill_md = skill_dir / "SKILL.md"
+    skill_md.write_text(_build_skill_md(name, description, invocation, include_scripts))
+
+    # Write optional PEP 723 script
+    if include_scripts:
+        scripts_dir = skill_dir / "scripts"
+        scripts_dir.mkdir()
+        script_file = scripts_dir / f"{name}.py"
+        script_file.write_text(_build_pep723_script(name, description))
+
+    return skill_dir
+
+
+def _build_skill_md(
+    name: str, description: str, invocation: str, include_scripts: bool
+) -> str:
+    """Build the SKILL.md content."""
+    scripts_section = ""
+    if include_scripts:
+        scripts_section = f"""
+## Scripts
+
+| Script | Purpose |
+|--------|---------|
+| `${{SKILL_DIR}}/scripts/{name}.py` | Main executable script |
+
+"""
+
+    return f"""---
+name: {name}
+description: {description}
+license: MIT
+compatibility: opencode
+---
+
+# SKILL: {name.replace("-", " ").title()}
+
+## Purpose
+
+{description}
+
+## When to Use
+
+<!-- Describe the specific situations where this skill applies -->
+
+## Invocation
+
+```
+{invocation}
+```
+
+{scripts_section}## Process
+
+<!-- Step-by-step workflow -->
+
+## Examples
+
+<!-- Concrete usage examples -->
+
+## Checklist
+
+- [ ] Skill files are complete and tested
+- [ ] All scripts run without errors (`uv run ${{SKILL_DIR}}/scripts/*.py`)
+- [ ] Documentation is accurate and up-to-date
+- [ ] Skill has been validated in a real project
+"""
+
+
+def _build_pep723_script(name: str, description: str) -> str:
+    """Build a PEP 723 inline script template."""
+    return f'''# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
+
+"""{description}"""
+
+import sys
+
+
+def main() -> None:
+    """Main entry point for {name}."""
+    print(f"Running {{name}}...")
+    # TODO: Implement your skill logic here
+    pass
+
+
+if __name__ == "__main__":
+    main()
+'''
+
+
+def main() -> None:
+    """Run interactive skill scaffolding."""
+    print("=" * 60)
+    print("Beacon Skill Scaffolder")
+    print("=" * 60)
+    print()
+
+    name_raw = prompt("Skill name (kebab-case)")
+    name = validate_kebab_case(name_raw)
+    if name != name_raw:
+        print(f"  → Normalized to: {name}")
+
+    description = prompt("One-line description")
+    invocation = prompt("Invocation form", default=f"/{name}")
+    include_scripts = prompt_yes_no("Include PEP 723 Python script", default=False)
+
+    print()
+    print("Scaffolding...")
+
+    skill_dir = scaffold_skill(name, description, invocation, include_scripts)
+
+    print()
+    print("=" * 60)
+    print(f"✓ Created skill: {name}")
+    print("=" * 60)
+    print()
+    print(f"  Location: {skill_dir}")
+    print(f"  SKILL.md: {skill_dir / 'SKILL.md'}")
+    if include_scripts:
+        print(f"  Script:   {skill_dir / 'scripts' / f'{name}.py'}")
+    print()
+    print("Next steps:")
+    print(f"  1. Edit {skill_dir / 'SKILL.md'} to fill in Process and Examples")
+    if include_scripts:
+        print(f"  2. Implement logic in {skill_dir / 'scripts' / f'{name}.py'}")
+        print(f"  3. Test: uv run {skill_dir / 'scripts' / f'{name}.py'}")
+    print(f"  4. Add to beacon.yaml: skills/{name}/")
+    print("  5. Run 'abc sync' to distribute")
+    print()
+
+
+if __name__ == "__main__":
+    main()

--- a/libs/beacon/src/beacon/domains/artifact/skill.py
+++ b/libs/beacon/src/beacon/domains/artifact/skill.py
@@ -96,15 +96,14 @@ def install_bundled_skills_globally() -> tuple[list[str], list[str]]:
 
     Returns (installed, errors) where each entry is '<skill> (<agent>)'.
     """
-    bundled_skills_dir = BUNDLED_SKILLS_DIR
-    if not bundled_skills_dir.exists():
+    if not BUNDLED_SKILLS_DIR.exists():
         return [], []
 
     global_dirs = bundled_global_skill_dirs()
     installed: list[str] = []
     errors: list[str] = []
 
-    for skill_dir in sorted(bundled_skills_dir.iterdir()):
+    for skill_dir in sorted(BUNDLED_SKILLS_DIR.iterdir()):
         if not skill_dir.is_dir():
             continue
         skill_md = skill_dir / "SKILL.md"
@@ -138,19 +137,16 @@ def wire_bundled_skills_per_project(
 
     Returns (installed, errors) where each entry is '<skill> (<agent>)'.
     """
-    bundled_skills_dir = BUNDLED_SKILLS_DIR
-    if not bundled_skills_dir.exists():
+    if not BUNDLED_SKILLS_DIR.exists():
         return [], []
 
     if agents is None:
-        from beacon.domains.artifact.agent import detect_agents
-
         agents = detect_agents(project_root, fallback_to_all=True)
 
     installed: list[str] = []
     errors: list[str] = []
 
-    for skill_dir in sorted(bundled_skills_dir.iterdir()):
+    for skill_dir in sorted(BUNDLED_SKILLS_DIR.iterdir()):
         if not skill_dir.is_dir():
             continue
         if not (skill_dir / "SKILL.md").exists():
@@ -186,13 +182,12 @@ def show_bundled_skills_status() -> None:
     Checks global agent skill dirs — bundled skills are user-level,
     not per-project.
     """
-    bundled_skills_dir = BUNDLED_SKILLS_DIR
-    if not bundled_skills_dir.exists():
+    if not BUNDLED_SKILLS_DIR.exists():
         return
 
     skill_names = sorted(
         d.name
-        for d in bundled_skills_dir.iterdir()
+        for d in BUNDLED_SKILLS_DIR.iterdir()
         if d.is_dir() and (d / "SKILL.md").exists()
     )
     if not skill_names:
@@ -284,18 +279,29 @@ def skill_name_from_entry(entry: str) -> str:
     return Path(normalize_skill_entry(entry)).name
 
 
-def _extract_skill_description(content: str) -> str:
-    """Extract description value from SKILL.md YAML frontmatter."""
+def _extract_skill_description(content: str, skill_name: str = "") -> str:
+    """Extract description value from SKILL.md YAML frontmatter.
+
+    Falls back to a generic description using the skill name when frontmatter
+    is missing or the description field is empty.
+    """
     if not content.startswith("---"):
-        return ""
+        return f"Use the {skill_name} skill" if skill_name else ""
     try:
         end = content.index("---", 3)
         for line in content[3:end].splitlines():
             if line.startswith("description:"):
-                return line.split(":", 1)[1].strip()
+                desc = line.split(":", 1)[1].strip()
+                return (
+                    desc
+                    if desc
+                    else f"Use the {skill_name} skill"
+                    if skill_name
+                    else ""
+                )
     except ValueError:
         pass
-    return ""
+    return f"Use the {skill_name} skill" if skill_name else ""
 
 
 def wire_single_skill(
@@ -341,7 +347,7 @@ def wire_single_skill(
         skill_md = skill_src_dir / "SKILL.md"
         if skill_md.exists():
             description = _extract_skill_description(
-                skill_md.read_text(encoding="utf-8")
+                skill_md.read_text(encoding="utf-8"), skill_name
             )
             stub = (
                 f"---\ndescription: {description}\n---\n\n"

--- a/libs/beacon/src/beacon/domains/artifact/skill.py
+++ b/libs/beacon/src/beacon/domains/artifact/skill.py
@@ -127,6 +127,47 @@ def install_bundled_skills_globally() -> tuple[list[str], list[str]]:
     return installed, errors
 
 
+def wire_bundled_skills_per_project(
+    project_root: Path,
+    agents: list[str] | None = None,
+) -> tuple[list[str], list[str]]:
+    """Wire abc-bundled skills into the project's agent directories.
+
+    Creates per-project skill copies and OpenCode command stubs so bundled
+    skills are available as slash commands (e.g. /abc-record-knowledge).
+
+    Returns (installed, errors) where each entry is '<skill> (<agent>)'.
+    """
+    bundled_skills_dir = BUNDLED_SKILLS_DIR
+    if not bundled_skills_dir.exists():
+        return [], []
+
+    if agents is None:
+        from beacon.domains.artifact.agent import detect_agents
+
+        agents = detect_agents(project_root, fallback_to_all=True)
+
+    installed: list[str] = []
+    errors: list[str] = []
+
+    for skill_dir in sorted(bundled_skills_dir.iterdir()):
+        if not skill_dir.is_dir():
+            continue
+        if not (skill_dir / "SKILL.md").exists():
+            continue
+        name = skill_dir.name
+
+        for agent in agents:
+            try:
+                changed = wire_single_skill(project_root, name, skill_dir, agent)
+                if changed:
+                    installed.append(f"{name} ({agent})")
+            except Exception as e:
+                errors.append(f"{name} ({agent}): {e}")
+
+    return installed, errors
+
+
 def print_bundled_install_result(installed: list[str], errors: list[str]) -> None:
     """Print the result of a bundled skill install to the console."""
     if installed:
@@ -309,7 +350,7 @@ def wire_single_skill(
             )
             command_dir = project_root / ".opencode" / "command"
             command_dir.mkdir(parents=True, exist_ok=True)
-            stub_file = command_dir / f"{skill_name}.md"
+            stub_file = command_dir / f"abc-{skill_name}.md"
             if not stub_file.exists() or stub_file.read_text(encoding="utf-8") != stub:
                 stub_file.write_text(stub, encoding="utf-8")
 
@@ -440,7 +481,7 @@ def _install_skill_opencode(
     )
     command_dir = project_root / ".opencode" / "command"
     command_dir.mkdir(parents=True, exist_ok=True)
-    stub_file = command_dir / f"{skill_name}.md"
+    stub_file = command_dir / f"abc-{skill_name}.md"
 
     skill_unchanged = (
         skill_file.exists() and skill_file.read_text(encoding="utf-8") == content

--- a/libs/beacon/src/beacon/domains/contribution/contributor.py
+++ b/libs/beacon/src/beacon/domains/contribution/contributor.py
@@ -477,7 +477,6 @@ def contribute_all(
             continue
 
         dest_dir = warehouse_path / skill_dir
-        dest_existed = dest_dir.exists()
 
         if not dry_run:
             if dest_dir.exists():

--- a/libs/beacon/src/beacon/domains/contribution/contributor.py
+++ b/libs/beacon/src/beacon/domains/contribution/contributor.py
@@ -29,11 +29,10 @@ def resolve_skill_contribute_source(
 
     Rules:
     - No agents configured → fall back to artifact snapshot (backward compat).
-    - One agent modified → use that agent's copy.
-    - Multiple agents modified with identical content → use any (they agree).
-    - Multiple agents modified with different content → call ``chooser`` to pick.
-    - No agent has a modified copy (IDENTICAL/MISSING/ADDED) → return None,
-      letting the caller decide (IDENTICAL means nothing to contribute).
+    - One agent modified/added → use that agent's copy.
+    - Multiple agents modified/added with identical content → use any (they agree).
+    - Multiple agents modified/added with different content → call ``chooser`` to pick.
+    - No agent has a modified or added copy → return None.
 
     ``chooser`` receives a dict of {agent_name: path} and must return the chosen
     agent name. Defaults to picking the first candidate (non-interactive).
@@ -46,20 +45,20 @@ def resolve_skill_contribute_source(
 
     result = comparator.compare_file(relative_path)
 
-    # Collect agents whose live copy differs from warehouse
-    modified_agents = [
+    # Collect agents whose live copy differs from warehouse (modified or added)
+    changed_agents = [
         agent
         for agent, status in result.agent_statuses.items()
-        if status == DeltaStatus.MODIFIED
+        if status in (DeltaStatus.MODIFIED, DeltaStatus.ADDED)
     ]
 
-    if not modified_agents:
-        # Nothing modified in any live dir — nothing to contribute
+    if not changed_agents:
+        # Nothing changed in any live dir — nothing to contribute
         return None
 
-    # Build the candidate paths for modified agents
+    # Build the candidate paths for changed agents
     candidates: dict[str, Path] = {}
-    for agent in modified_agents:
+    for agent in changed_agents:
         live_path = comparator.skill_live_path(agent, relative_path)
         if live_path.exists():
             candidates[agent] = live_path
@@ -70,14 +69,14 @@ def resolve_skill_contribute_source(
     if len(candidates) == 1:
         return next(iter(candidates.values()))
 
-    # Multiple agents have modified versions — check if they are identical
+    # Multiple agents have changed versions — check if they are identical
     hashes = {
         agent: comparator.compute_hash(path) for agent, path in candidates.items()
     }
     unique_hashes = set(hashes.values())
 
     if len(unique_hashes) == 1:
-        # All modified copies are identical — pick the first one
+        # All changed copies are identical — pick the first one
         return next(iter(candidates.values()))
 
     # Genuinely different versions across agents.
@@ -104,6 +103,14 @@ def resolve_skill_contribute_source(
     chosen_agent = _chooser(candidates)
     console.print(f"  Using [bold]{chosen_agent}[/bold] version.\n")
     return candidates[chosen_agent]
+
+
+def _get_skill_dir_from_path(relative_path: str) -> str:
+    """Extract skill directory from a path like 'skills/foo/SKILL.md'."""
+    parts = Path(relative_path).parts
+    if len(parts) >= 2 and parts[0] == "skills":
+        return f"{parts[0]}/{parts[1]}"
+    return relative_path
 
 
 def propagate_skill_to_agents(
@@ -361,57 +368,136 @@ def contribute_all(
 
     contributed: list[tuple[str, str]] = []
 
+    # Separate skill and non-skill results
+    skill_results = []
+    non_skill_results = []
     for result in contributable:
-        is_skill = result.path.startswith("skills/") and bool(comparator.skills_paths)
-
-        if is_skill:
-            local_path = resolve_skill_contribute_source(
-                comparator, result.path, artifacts_dir, dry_run=dry_run, chooser=chooser
-            )
-            if local_path is None:
-                console.print(
-                    f"  [yellow]Skipping[/yellow] {result.path} "
-                    "(no modified live copy found)"
-                )
-                continue
+        if result.path.startswith("skills/") and comparator.skills_paths:
+            skill_results.append(result)
         else:
-            local_path = artifacts_dir / result.path
-            if not local_path.exists():
-                console.print(
-                    f"  [yellow]Skipping[/yellow] {result.path} (not found locally — run 'abc sync')"
+            non_skill_results.append(result)
+
+    # Group skill results by skill directory and contribute as whole units
+    skill_dirs: dict[str, list] = {}
+    for result in skill_results:
+        skill_dir = _get_skill_dir_from_path(result.path)
+        skill_dirs.setdefault(skill_dir, []).append(result)
+
+    for skill_dir, results in skill_dirs.items():
+        # Use the first file to resolve which agent to contribute from
+        first_file = results[0].path
+        local_path = resolve_skill_contribute_source(
+            comparator, first_file, artifacts_dir, dry_run=dry_run, chooser=chooser
+        )
+        if local_path is None:
+            console.print(
+                f"  [yellow]Skipping[/yellow] {skill_dir}/ "
+                "(no modified live copy found)"
+            )
+            continue
+
+        # Determine the source skill directory from the chosen file
+        skill_name = Path(skill_dir).name
+        source_dir = local_path.parent
+        # Walk up to find the skill root directory
+        while source_dir.name != skill_name and source_dir.parent != source_dir:
+            source_dir = source_dir.parent
+
+        if source_dir.name != skill_name:
+            console.print(
+                f"  [yellow]Skipping[/yellow] {skill_dir}/ "
+                "(could not find skill directory)"
+            )
+            continue
+
+        dest_dir = warehouse_path / skill_dir
+
+        # Determine if this is a modification or addition based on warehouse state
+        dest_existed = dest_dir.exists()
+        status_label = "modified" if dest_existed else "added"
+
+        # Copy entire skill directory
+        if not dry_run:
+            if dest_dir.exists():
+                shutil.rmtree(dest_dir)
+            shutil.copytree(source_dir, dest_dir)
+        else:
+            console.print(f"  Would contribute: {skill_dir}/ ({status_label})")
+
+        # Propagate to all agents
+        if not dry_run:
+            skill_md = dest_dir / "SKILL.md"
+            if skill_md.exists():
+                propagate_skill_to_agents(
+                    project_root, f"{skill_dir}/SKILL.md", skill_md
                 )
-                continue
+
+        contributed.append((f"{skill_dir}/", status_label))
+
+    # Handle non-skill results individually
+    for result in non_skill_results:
+        local_path = artifacts_dir / result.path
+        if not local_path.exists():
+            console.print(
+                f"  [yellow]Skipping[/yellow] {result.path} (not found locally — run 'abc sync')"
+            )
+            continue
 
         copy_to_warehouse(
             local_path, warehouse_path / result.path, result.path, dry_run
         )
-        if is_skill and not dry_run:
-            propagate_skill_to_agents(project_root, result.path, local_path)
         status_label = "modified" if result.status == DeltaStatus.MODIFIED else "added"
         contributed.append((result.path, status_label))
 
+    # Handle unregistered paths
+    unregistered_skill_dirs: set[str] = set()
+    unregistered_non_skill: list[str] = []
+
     for rel_path in unregistered_paths:
-        is_skill = rel_path.startswith("skills/") and bool(comparator.skills_paths)
-        if is_skill:
-            # Skills live in live agent dirs, not in artifacts_dir.
-            # Pick the first agent copy that exists on disk.
-            local_path = None
-            for _agent, skills_root in comparator.skills_paths.items():
-                parts = Path(rel_path).parts
-                skill_relative = (
-                    Path(*parts[1:]) if parts[0] == "skills" else Path(rel_path)
-                )
-                candidate = skills_root / skill_relative
-                if candidate.exists():
-                    local_path = candidate
-                    break
-            if local_path is None:
-                console.print(
-                    f"  [yellow]Skipping[/yellow] {rel_path} (not found in any agent dir)"
-                )
-                continue
+        if rel_path.startswith("skills/") and comparator.skills_paths:
+            skill_dir = _get_skill_dir_from_path(rel_path)
+            unregistered_skill_dirs.add(skill_dir)
         else:
-            local_path = artifacts_dir / rel_path
+            unregistered_non_skill.append(rel_path)
+
+    # Contribute unregistered skills as whole directories
+    for skill_dir in sorted(unregistered_skill_dirs):
+        skill_name = Path(skill_dir).name
+        # Pick the first agent that has this skill
+        source_dir = None
+        for _agent, skills_root in comparator.skills_paths.items():
+            candidate = skills_root / skill_name
+            if candidate.exists():
+                source_dir = candidate
+                break
+        if source_dir is None:
+            console.print(
+                f"  [yellow]Skipping[/yellow] {skill_dir}/ (not found in any agent dir)"
+            )
+            continue
+
+        dest_dir = warehouse_path / skill_dir
+        dest_existed = dest_dir.exists()
+
+        if not dry_run:
+            if dest_dir.exists():
+                shutil.rmtree(dest_dir)
+            shutil.copytree(source_dir, dest_dir)
+        else:
+            console.print(f"  Would contribute: {skill_dir}/ (added)")
+
+        if not dry_run:
+            skill_md = dest_dir / "SKILL.md"
+            if skill_md.exists():
+                propagate_skill_to_agents(
+                    project_root, f"{skill_dir}/SKILL.md", skill_md
+                )
+
+        contributed.append((f"{skill_dir}/", "added"))
+
+    # Contribute unregistered non-skill files individually
+    for rel_path in unregistered_non_skill:
+        local_path = artifacts_dir / rel_path
         copy_to_warehouse(local_path, warehouse_path / rel_path, rel_path, dry_run)
         contributed.append((rel_path, "added"))
 

--- a/libs/beacon/src/beacon/domains/contribution/delta_view.py
+++ b/libs/beacon/src/beacon/domains/contribution/delta_view.py
@@ -241,7 +241,7 @@ def show_delta_summary(
         if untracked_non_skill:
             rows = []
             for rel_path, agents in untracked_non_skill:
-                agent_cells = {a: "[green]added[/green]" for a in agents}
+                agent_cells = dict.fromkeys(agents, "[green]added[/green]")
                 rows.append(("[green]added[/green]", rel_path, agent_cells))
             console.print()
             console.print(render_delta_table(rows, "", untracked_agents))
@@ -876,6 +876,9 @@ def find_untracked_local_files(
     # Scan live agent skill directories — the canonical location for installed skills.
     # Group by rel_path so a skill present in multiple agent dirs is reported once
     # with all agents listed.
+    from beacon.domains.artifact.skill import bundled_skill_names
+
+    bundled = bundled_skill_names()
     skill_agents: dict[str, list[str]] = {}
     for agent, skills_root in comparator.skills_paths.items():
         if skills_root.exists():
@@ -888,6 +891,9 @@ def find_untracked_local_files(
                         skill_name = (
                             Path(rel).parts[1] if len(Path(rel).parts) > 1 else ""
                         )
+                        # Skip abc-bundled skills — they are package-managed, not user content
+                        if skill_name in bundled:
+                            continue
                         if patterns and any(
                             fnmatch.fnmatch(skill_name, p) for p in patterns
                         ):

--- a/libs/beacon/src/beacon/domains/distribution/orchestrator.py
+++ b/libs/beacon/src/beacon/domains/distribution/orchestrator.py
@@ -26,6 +26,7 @@ from beacon.domains.artifact.skill import (
     normalize_skill_entry,
     skill_name_from_entry,
     validate_skill_entries,
+    wire_bundled_skills_per_project,
     wire_skills_post_sync,
 )
 from beacon.domains.distribution.state import read_sync_sha, write_sync_state
@@ -147,6 +148,12 @@ def run_sync(
 
     if total_artifacts == 0:
         bundled_installed, bundled_skipped = install_bundled_skills_globally()
+        if not dry_run:
+            bundled_wired, bundled_wire_errors = wire_bundled_skills_per_project(
+                project_root
+            )
+        else:
+            bundled_wired, bundled_wire_errors = [], []
         sync_agents_from_warehouse(warehouse_path, force=force, preserve=preserve)
         return SyncOrchestrationResult(
             dry_run=dry_run,
@@ -157,8 +164,8 @@ def run_sync(
             confirmed_prune=[],
             oc_added=[],
             cc_added=[],
-            wired_skills=[],
-            wire_errors=[],
+            wired_skills=list(bundled_wired),
+            wire_errors=list(bundled_wire_errors),
             bundled_installed=list(bundled_installed),
             bundled_skipped=list(bundled_skipped),
             adoption_notification=None,
@@ -291,6 +298,12 @@ def run_sync(
             update_agent_gitignores(project_root)
 
     bundled_installed, bundled_skipped = install_bundled_skills_globally()
+    if not dry_run:
+        bundled_wired, bundled_wire_errors = wire_bundled_skills_per_project(
+            project_root
+        )
+        wired_skills = wired_skills + bundled_wired
+        wire_errors = wire_errors + bundled_wire_errors
 
     sync_agents_from_warehouse(warehouse_path, force=force, preserve=preserve)
 

--- a/libs/beacon/src/beacon/domains/setup/initializer.py
+++ b/libs/beacon/src/beacon/domains/setup/initializer.py
@@ -178,10 +178,17 @@ class WarehouseInitializer:
             skill_md = skill_dir / "SKILL.md"
             if not skill_md.exists():
                 continue
-            content = skill_md.read_text(encoding="utf-8")
             dest_dir = self.warehouse_path / "skills" / skill_dir.name
             dest_dir.mkdir(parents=True, exist_ok=True)
-            self._write_if_missing(dest_dir / "SKILL.md", content)
+            for src_file in sorted(skill_dir.rglob("*")):
+                if not src_file.is_file():
+                    continue
+                if "__pycache__" in src_file.parts:
+                    continue
+                rel = src_file.relative_to(skill_dir)
+                dest_file = dest_dir / rel
+                dest_file.parent.mkdir(parents=True, exist_ok=True)
+                self._write_if_missing(dest_file, src_file.read_text(encoding="utf-8"))
 
         logger.info("Bundled skills installed")
 

--- a/libs/beacon/src/beacon/domains/setup/initializer.py
+++ b/libs/beacon/src/beacon/domains/setup/initializer.py
@@ -23,6 +23,7 @@ TEMPLATE_FILES: list[str] = [
     "knowledge/README.md",
     "skills/README.md",
     "skills/record-knowledge/SKILL.md",
+    "skills/record-skill/SKILL.md",
 ]
 
 

--- a/libs/beacon/src/beacon/domains/setup/wiring.py
+++ b/libs/beacon/src/beacon/domains/setup/wiring.py
@@ -337,10 +337,12 @@ def unwire_skill(project_root: Path, skill_name: str) -> None:
         shutil.rmtree(opencode_skill, ignore_errors=True)
         logger.debug("Removed OpenCode skill dir: {}", opencode_skill)
 
-    opencode_cmd = project_root / ".opencode" / "command" / f"{skill_name}.md"
-    if opencode_cmd.exists():
-        opencode_cmd.unlink(missing_ok=True)
-        logger.debug("Removed OpenCode command stub: {}", opencode_cmd)
+    # Remove legacy command stub (without abc- prefix) and current stub (with prefix)
+    for cmd_name in (f"{skill_name}.md", f"abc-{skill_name}.md"):
+        opencode_cmd = project_root / ".opencode" / "command" / cmd_name
+        if opencode_cmd.exists():
+            opencode_cmd.unlink(missing_ok=True)
+            logger.debug("Removed OpenCode command stub: {}", opencode_cmd)
 
     claude_skill = project_root / ".claude" / "skills" / skill_name
     if claude_skill.exists():

--- a/libs/beacon/tests/integration/test_bundled_skills.py
+++ b/libs/beacon/tests/integration/test_bundled_skills.py
@@ -268,8 +268,10 @@ def test_sync_installs_bundled_skills_globally(valid_warehouse, temp_dir, monkey
     assert (fake_dirs["claudecode"] / BUNDLED_SKILL_NAME / "SKILL.md").exists()
 
 
-def test_sync_does_not_install_to_project_dir(valid_warehouse, temp_dir, monkeypatch):
-    """abc sync does NOT write bundled skills to per-project .opencode/skills/."""
+def test_sync_installs_bundled_skills_to_project_dir(
+    valid_warehouse, temp_dir, monkeypatch
+):
+    """abc sync writes bundled skills to per-project .opencode/skills/ with command stubs."""
     fake_dirs = _fake_global_dirs(temp_dir)
     runner = CliRunner()
 
@@ -290,8 +292,11 @@ def test_sync_does_not_install_to_project_dir(valid_warehouse, temp_dir, monkeyp
     ):
         runner.invoke(main, ["sync", "--skip-git-check"])
 
-    assert not (
+    assert (
         project_dir / ".opencode" / "skills" / BUNDLED_SKILL_NAME / "SKILL.md"
+    ).exists()
+    assert (
+        project_dir / ".opencode" / "command" / f"abc-{BUNDLED_SKILL_NAME}.md"
     ).exists()
 
 

--- a/libs/beacon/tests/integration/test_contribute_command.py
+++ b/libs/beacon/tests/integration/test_contribute_command.py
@@ -1083,6 +1083,41 @@ def test_contribute_all_skills_propagates_to_other_agents(
     )
 
 
+def test_contribute_skill_with_new_script_contributes_whole_directory(
+    project_with_skill_setup,
+):
+    """When a skill has a new script file, contributing the skill copies the entire directory."""
+    tmp_path, warehouse = project_with_skill_setup
+
+    # Set up claudecode agent with a new script file
+    (tmp_path / ".claude").mkdir()
+    cc_skill_dir = tmp_path / ".claude" / "skills" / "my-skill"
+    cc_skill_dir.mkdir(parents=True)
+    (cc_skill_dir / "SKILL.md").write_text(SKILL_MODIFIED_CONTENT)
+    (cc_skill_dir / "scripts").mkdir(parents=True)
+    (cc_skill_dir / "scripts" / "helper.py").write_text("# helper script\n")
+
+    # opencode live copy still has the old warehouse content
+    oc_skill_dir = tmp_path / ".opencode" / "skills" / "my-skill"
+    oc_skill_dir.mkdir(parents=True)
+    (oc_skill_dir / "SKILL.md").write_text(SKILL_WAREHOUSE_CONTENT)
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["contribute"], input="y\n")
+
+    assert result.exit_code == 0, result.output
+    # Warehouse updated with both SKILL.md and the new script
+    assert (
+        warehouse / "skills" / "my-skill" / "SKILL.md"
+    ).read_text() == SKILL_MODIFIED_CONTENT
+    assert (
+        warehouse / "skills" / "my-skill" / "scripts" / "helper.py"
+    ).read_text() == "# helper script\n"
+    # opencode live copy must also get the new script
+    assert (oc_skill_dir / "SKILL.md").read_text() == SKILL_MODIFIED_CONTENT
+    assert (oc_skill_dir / "scripts" / "helper.py").read_text() == "# helper script\n"
+
+
 # ---------------------------------------------------------------------------
 # --exclude-unregistered flag
 # ---------------------------------------------------------------------------

--- a/libs/beacon/tests/integration/test_e2e_happy_path.py
+++ b/libs/beacon/tests/integration/test_e2e_happy_path.py
@@ -100,6 +100,11 @@ def test_e2e_warehouse_init_installs_record_knowledge(e2e_warehouse):
     assert (e2e_warehouse / "skills" / "record-knowledge" / "SKILL.md").exists()
 
 
+def test_e2e_warehouse_init_installs_record_skill(e2e_warehouse):
+    """warehouse init bundles record-skill as a distributable warehouse skill."""
+    assert (e2e_warehouse / "skills" / "record-skill" / "SKILL.md").exists()
+
+
 # ---------------------------------------------------------------------------
 # Step 2 — abc warehouse list shows all three sections including Contexts
 # ---------------------------------------------------------------------------

--- a/libs/beacon/tests/integration/test_e2e_happy_path.py
+++ b/libs/beacon/tests/integration/test_e2e_happy_path.py
@@ -103,6 +103,9 @@ def test_e2e_warehouse_init_installs_record_knowledge(e2e_warehouse):
 def test_e2e_warehouse_init_installs_record_skill(e2e_warehouse):
     """warehouse init bundles record-skill as a distributable warehouse skill."""
     assert (e2e_warehouse / "skills" / "record-skill" / "SKILL.md").exists()
+    assert (
+        e2e_warehouse / "skills" / "record-skill" / "scripts" / "create_skill.py"
+    ).exists()
 
 
 # ---------------------------------------------------------------------------

--- a/libs/beacon/tests/integration/test_install_command.py
+++ b/libs/beacon/tests/integration/test_install_command.py
@@ -94,7 +94,9 @@ def test_install_skill_wires_opencode(connected_project):
     assert (
         connected_project / ".opencode" / "skills" / "code-reviewer" / "SKILL.md"
     ).exists()
-    assert (connected_project / ".opencode" / "command" / "code-reviewer.md").exists()
+    assert (
+        connected_project / ".opencode" / "command" / "abc-code-reviewer.md"
+    ).exists()
     opencode_gitignore = (connected_project / ".opencode" / ".gitignore").read_text()
     assert "skills/" in opencode_gitignore
     assert "command/" in opencode_gitignore

--- a/libs/beacon/tests/integration/test_sync_wiring.py
+++ b/libs/beacon/tests/integration/test_sync_wiring.py
@@ -216,7 +216,7 @@ def test_wire_skills_post_sync_installs_for_opencode(project_with_skill):
     assert errors == []
     assert any("test-skill" in entry and "opencode" in entry for entry in installed)
     assert (project / ".opencode" / "skills" / "test-skill" / "SKILL.md").exists()
-    assert (project / ".opencode" / "command" / "test-skill.md").exists()
+    assert (project / ".opencode" / "command" / "abc-test-skill.md").exists()
 
 
 def test_wire_skills_post_sync_installs_for_claudecode(project_with_skill):
@@ -365,7 +365,7 @@ def test_install_skill_opencode_returns_true_on_first_install(tmp_path):
 
     assert changed is True
     assert (tmp_path / ".opencode" / "skills" / "my-skill" / "SKILL.md").exists()
-    assert (tmp_path / ".opencode" / "command" / "my-skill.md").exists()
+    assert (tmp_path / ".opencode" / "command" / "abc-my-skill.md").exists()
 
 
 def test_install_skill_opencode_returns_false_when_unchanged(tmp_path):
@@ -500,7 +500,7 @@ def test_sync_installs_skills(full_sync_project, monkeypatch):
 
     assert result.exit_code == 0
     assert (project / ".opencode" / "skills" / "my-skill" / "SKILL.md").exists()
-    assert (project / ".opencode" / "command" / "my-skill.md").exists()
+    assert (project / ".opencode" / "command" / "abc-my-skill.md").exists()
     assert "installed" in result.output.lower()
     opencode_gitignore = (project / ".opencode" / ".gitignore").read_text()
     assert "skills/" in opencode_gitignore
@@ -1146,7 +1146,7 @@ class TestWireSingleSkill:
 
         wire_single_skill(tmp_path, "my-skill", skill_src, "opencode")
 
-        stub = tmp_path / ".opencode" / "command" / "my-skill.md"
+        stub = tmp_path / ".opencode" / "command" / "abc-my-skill.md"
         assert stub.exists()
         assert "Pipeline helper skill" in stub.read_text()
 

--- a/libs/beacon/tests/integration/test_warehouse_init.py
+++ b/libs/beacon/tests/integration/test_warehouse_init.py
@@ -27,6 +27,7 @@ EXPECTED_FILES = [
     "README.md",
     ".gitignore",
     "skills/record-knowledge/SKILL.md",
+    "skills/record-skill/SKILL.md",
 ]
 
 

--- a/libs/beacon/tests/unit/test_create_skill_script.py
+++ b/libs/beacon/tests/unit/test_create_skill_script.py
@@ -1,0 +1,361 @@
+"""Unit tests for record-skill's create_skill.py scaffolding script (PER-65).
+
+Tests cover:
+- validate_kebab_case: name normalisation
+- _build_skill_md: generated SKILL.md content for both paths
+- _build_pep723_script: PEP 723 header and template structure
+- scaffold_skill: end-to-end file creation for markdown-only and markdown+scripts paths
+"""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Load the script as a module (it is a PEP 723 standalone script, not a
+# package, so we import it via importlib rather than a normal import).
+# ---------------------------------------------------------------------------
+
+_SCRIPT_PATH = (
+    Path(__file__).parent.parent.parent.parent
+    / "beacon"
+    / "src"
+    / "beacon"
+    / "data"
+    / "skills"
+    / "record-skill"
+    / "scripts"
+    / "create_skill.py"
+)
+
+
+def _load_create_skill():
+    """Load create_skill.py as a module and return it."""
+    spec = importlib.util.spec_from_file_location("create_skill", _SCRIPT_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def cs():
+    """Return the loaded create_skill module."""
+    return _load_create_skill()
+
+
+# ---------------------------------------------------------------------------
+# validate_kebab_case
+# ---------------------------------------------------------------------------
+
+
+class TestValidateKebabCase:
+    def test_already_kebab(self, cs):
+        assert cs.validate_kebab_case("my-skill") == "my-skill"
+
+    def test_spaces_become_hyphens(self, cs):
+        assert cs.validate_kebab_case("my skill") == "my-skill"
+
+    def test_underscores_become_hyphens(self, cs):
+        assert cs.validate_kebab_case("my_skill") == "my-skill"
+
+    def test_uppercase_lowercased(self, cs):
+        assert cs.validate_kebab_case("MySkill") == "myskill"
+
+    def test_special_chars_removed(self, cs):
+        assert cs.validate_kebab_case("my@skill!") == "myskill"
+
+    def test_multiple_hyphens_collapsed(self, cs):
+        assert cs.validate_kebab_case("my--skill") == "my-skill"
+
+    def test_leading_trailing_hyphens_stripped(self, cs):
+        assert cs.validate_kebab_case("-my-skill-") == "my-skill"
+
+    def test_mixed_normalisation(self, cs):
+        assert cs.validate_kebab_case("My_Cool Skill!") == "my-cool-skill"
+
+
+# ---------------------------------------------------------------------------
+# _build_skill_md
+# ---------------------------------------------------------------------------
+
+
+class TestBuildSkillMd:
+    def test_contains_frontmatter_name(self, cs):
+        content = cs._build_skill_md(
+            "deploy-check", "Validate deployment", "/deploy-check", False
+        )
+        assert "name: deploy-check" in content
+
+    def test_contains_frontmatter_description(self, cs):
+        content = cs._build_skill_md(
+            "deploy-check", "Validate deployment", "/deploy-check", False
+        )
+        assert "description: Validate deployment" in content
+
+    def test_frontmatter_has_license_and_compatibility(self, cs):
+        content = cs._build_skill_md(
+            "deploy-check", "Validate deployment", "/deploy-check", False
+        )
+        assert "license: MIT" in content
+        assert "compatibility: opencode" in content
+
+    def test_contains_invocation(self, cs):
+        content = cs._build_skill_md(
+            "deploy-check", "Validate deployment", "/deploy-check", False
+        )
+        assert "/deploy-check" in content
+
+    def test_standard_sections_present(self, cs):
+        content = cs._build_skill_md(
+            "deploy-check", "Validate deployment", "/deploy-check", False
+        )
+        assert "## Purpose" in content
+        assert "## When to Use" in content
+        assert "## Invocation" in content
+        assert "## Process" in content
+        assert "## Examples" in content
+        assert "## Checklist" in content
+
+    def test_no_scripts_section_when_not_requested(self, cs):
+        content = cs._build_skill_md(
+            "deploy-check", "Validate deployment", "/deploy-check", False
+        )
+        assert "## Scripts" not in content
+
+    def test_scripts_section_present_when_requested(self, cs):
+        content = cs._build_skill_md(
+            "s3-cleanup", "Clean S3 buckets", "/s3-cleanup", True
+        )
+        assert "## Scripts" in content
+
+    def test_scripts_section_references_skill_name(self, cs):
+        content = cs._build_skill_md(
+            "s3-cleanup", "Clean S3 buckets", "/s3-cleanup", True
+        )
+        assert "s3-cleanup.py" in content
+
+    def test_scripts_section_uses_skill_dir_var(self, cs):
+        content = cs._build_skill_md(
+            "s3-cleanup", "Clean S3 buckets", "/s3-cleanup", True
+        )
+        assert "${SKILL_DIR}" in content
+
+
+# ---------------------------------------------------------------------------
+# _build_pep723_script
+# ---------------------------------------------------------------------------
+
+
+class TestBuildPep723Script:
+    def test_has_pep723_header(self, cs):
+        content = cs._build_pep723_script("s3-cleanup", "Clean S3 buckets")
+        assert "# /// script" in content
+
+    def test_has_requires_python(self, cs):
+        content = cs._build_pep723_script("s3-cleanup", "Clean S3 buckets")
+        assert "requires-python" in content
+
+    def test_has_dependencies_field(self, cs):
+        content = cs._build_pep723_script("s3-cleanup", "Clean S3 buckets")
+        assert "dependencies" in content
+
+    def test_has_closing_marker(self, cs):
+        content = cs._build_pep723_script("s3-cleanup", "Clean S3 buckets")
+        assert "# ///" in content
+
+    def test_has_main_function(self, cs):
+        content = cs._build_pep723_script("s3-cleanup", "Clean S3 buckets")
+        assert "def main()" in content
+
+    def test_has_dunder_main_guard(self, cs):
+        content = cs._build_pep723_script("s3-cleanup", "Clean S3 buckets")
+        assert '__name__ == "__main__"' in content
+
+    def test_description_in_docstring(self, cs):
+        content = cs._build_pep723_script("s3-cleanup", "Clean S3 buckets")
+        assert "Clean S3 buckets" in content
+
+
+# ---------------------------------------------------------------------------
+# scaffold_skill: markdown-only path
+# ---------------------------------------------------------------------------
+
+
+class TestScaffoldSkillMarkdownOnly:
+    def test_creates_skill_directory(self, cs, tmp_path, monkeypatch):
+        artifacts_dir = tmp_path / ".agentic-beacon" / "artifacts"
+        artifacts_dir.mkdir(parents=True)
+        monkeypatch.chdir(tmp_path)
+
+        skill_dir = cs.scaffold_skill(
+            "deploy-check", "Validate deployment", "/deploy-check", False
+        )
+
+        assert skill_dir.exists()
+        assert skill_dir.is_dir()
+
+    def test_skill_directory_name_matches(self, cs, tmp_path, monkeypatch):
+        artifacts_dir = tmp_path / ".agentic-beacon" / "artifacts"
+        artifacts_dir.mkdir(parents=True)
+        monkeypatch.chdir(tmp_path)
+
+        skill_dir = cs.scaffold_skill(
+            "deploy-check", "Validate deployment", "/deploy-check", False
+        )
+
+        assert skill_dir.name == "deploy-check"
+
+    def test_skill_md_is_created(self, cs, tmp_path, monkeypatch):
+        artifacts_dir = tmp_path / ".agentic-beacon" / "artifacts"
+        artifacts_dir.mkdir(parents=True)
+        monkeypatch.chdir(tmp_path)
+
+        skill_dir = cs.scaffold_skill(
+            "deploy-check", "Validate deployment", "/deploy-check", False
+        )
+
+        assert (skill_dir / "SKILL.md").exists()
+
+    def test_skill_md_has_correct_frontmatter(self, cs, tmp_path, monkeypatch):
+        artifacts_dir = tmp_path / ".agentic-beacon" / "artifacts"
+        artifacts_dir.mkdir(parents=True)
+        monkeypatch.chdir(tmp_path)
+
+        skill_dir = cs.scaffold_skill(
+            "deploy-check", "Validate deployment", "/deploy-check", False
+        )
+        content = (skill_dir / "SKILL.md").read_text()
+
+        assert "name: deploy-check" in content
+        assert "description: Validate deployment" in content
+
+    def test_no_scripts_directory_created(self, cs, tmp_path, monkeypatch):
+        artifacts_dir = tmp_path / ".agentic-beacon" / "artifacts"
+        artifacts_dir.mkdir(parents=True)
+        monkeypatch.chdir(tmp_path)
+
+        skill_dir = cs.scaffold_skill(
+            "deploy-check", "Validate deployment", "/deploy-check", False
+        )
+
+        assert not (skill_dir / "scripts").exists()
+
+    def test_returns_path_under_artifacts_skills(self, cs, tmp_path, monkeypatch):
+        artifacts_dir = tmp_path / ".agentic-beacon" / "artifacts"
+        artifacts_dir.mkdir(parents=True)
+        monkeypatch.chdir(tmp_path)
+
+        skill_dir = cs.scaffold_skill(
+            "deploy-check", "Validate deployment", "/deploy-check", False
+        )
+
+        assert skill_dir == artifacts_dir / "skills" / "deploy-check"
+
+
+# ---------------------------------------------------------------------------
+# scaffold_skill: markdown + scripts path
+# ---------------------------------------------------------------------------
+
+
+class TestScaffoldSkillWithScript:
+    def test_creates_scripts_directory(self, cs, tmp_path, monkeypatch):
+        artifacts_dir = tmp_path / ".agentic-beacon" / "artifacts"
+        artifacts_dir.mkdir(parents=True)
+        monkeypatch.chdir(tmp_path)
+
+        skill_dir = cs.scaffold_skill(
+            "s3-cleanup", "Clean S3 buckets", "/s3-cleanup", True
+        )
+
+        assert (skill_dir / "scripts").exists()
+        assert (skill_dir / "scripts").is_dir()
+
+    def test_creates_python_script(self, cs, tmp_path, monkeypatch):
+        artifacts_dir = tmp_path / ".agentic-beacon" / "artifacts"
+        artifacts_dir.mkdir(parents=True)
+        monkeypatch.chdir(tmp_path)
+
+        skill_dir = cs.scaffold_skill(
+            "s3-cleanup", "Clean S3 buckets", "/s3-cleanup", True
+        )
+
+        assert (skill_dir / "scripts" / "s3-cleanup.py").exists()
+
+    def test_script_has_pep723_header(self, cs, tmp_path, monkeypatch):
+        artifacts_dir = tmp_path / ".agentic-beacon" / "artifacts"
+        artifacts_dir.mkdir(parents=True)
+        monkeypatch.chdir(tmp_path)
+
+        skill_dir = cs.scaffold_skill(
+            "s3-cleanup", "Clean S3 buckets", "/s3-cleanup", True
+        )
+        script_content = (skill_dir / "scripts" / "s3-cleanup.py").read_text()
+
+        assert "# /// script" in script_content
+        assert "requires-python" in script_content
+        assert "dependencies" in script_content
+
+    def test_script_named_after_skill(self, cs, tmp_path, monkeypatch):
+        artifacts_dir = tmp_path / ".agentic-beacon" / "artifacts"
+        artifacts_dir.mkdir(parents=True)
+        monkeypatch.chdir(tmp_path)
+
+        skill_dir = cs.scaffold_skill(
+            "s3-cleanup", "Clean S3 buckets", "/s3-cleanup", True
+        )
+
+        assert (skill_dir / "scripts" / "s3-cleanup.py").exists()
+
+    def test_skill_md_references_script(self, cs, tmp_path, monkeypatch):
+        artifacts_dir = tmp_path / ".agentic-beacon" / "artifacts"
+        artifacts_dir.mkdir(parents=True)
+        monkeypatch.chdir(tmp_path)
+
+        skill_dir = cs.scaffold_skill(
+            "s3-cleanup", "Clean S3 buckets", "/s3-cleanup", True
+        )
+        content = (skill_dir / "SKILL.md").read_text()
+
+        assert "s3-cleanup.py" in content
+
+    def test_both_skill_md_and_script_exist(self, cs, tmp_path, monkeypatch):
+        artifacts_dir = tmp_path / ".agentic-beacon" / "artifacts"
+        artifacts_dir.mkdir(parents=True)
+        monkeypatch.chdir(tmp_path)
+
+        skill_dir = cs.scaffold_skill(
+            "s3-cleanup", "Clean S3 buckets", "/s3-cleanup", True
+        )
+
+        assert (skill_dir / "SKILL.md").exists()
+        assert (skill_dir / "scripts" / "s3-cleanup.py").exists()
+
+
+# ---------------------------------------------------------------------------
+# scaffold_skill: error cases
+# ---------------------------------------------------------------------------
+
+
+class TestScaffoldSkillErrorCases:
+    def test_exits_when_no_artifacts_dir(self, cs, tmp_path, monkeypatch):
+        """scaffold_skill calls sys.exit(1) when .agentic-beacon/artifacts/ is absent."""
+        monkeypatch.chdir(tmp_path)
+
+        with pytest.raises(SystemExit) as exc_info:
+            cs.scaffold_skill("new-skill", "A new skill", "/new-skill", False)
+
+        assert exc_info.value.code == 1
+
+    def test_exits_when_skill_already_exists(self, cs, tmp_path, monkeypatch):
+        """scaffold_skill calls sys.exit(1) when the target skill dir already exists."""
+        artifacts_dir = tmp_path / ".agentic-beacon" / "artifacts"
+        artifacts_dir.mkdir(parents=True)
+        existing = artifacts_dir / "skills" / "dup-skill"
+        existing.mkdir(parents=True)
+        monkeypatch.chdir(tmp_path)
+
+        with pytest.raises(SystemExit) as exc_info:
+            cs.scaffold_skill("dup-skill", "Duplicate skill", "/dup-skill", False)
+
+        assert exc_info.value.code == 1

--- a/libs/beacon/tests/unit/test_skill_description.py
+++ b/libs/beacon/tests/unit/test_skill_description.py
@@ -1,0 +1,41 @@
+"""Unit tests for beacon.domains.artifact.skill helpers."""
+
+from beacon.domains.artifact.skill import _extract_skill_description
+
+
+class TestExtractSkillDescription:
+    """Tests for _extract_skill_description with skill_name fallback."""
+
+    def test_extracts_description_from_frontmatter(self):
+        content = "---\ndescription: Generate tests\n---\n\n# Skill"
+        assert _extract_skill_description(content) == "Generate tests"
+
+    def test_empty_description_with_skill_name_fallback(self):
+        """Empty description field falls back to skill_name."""
+        content = "---\nname: foo\ndescription:\n---\n# Skill"
+        assert _extract_skill_description(content, "foo") == "Use the foo skill"
+
+    def test_missing_description_with_skill_name_fallback(self):
+        """Missing description field falls back to skill_name."""
+        content = "---\nname: foo\n---\n# Skill"
+        assert _extract_skill_description(content, "foo") == "Use the foo skill"
+
+    def test_no_frontmatter_no_skill_name(self):
+        """No frontmatter and no skill_name returns empty string."""
+        content = "# My Skill\n\nSome content here.\n"
+        assert _extract_skill_description(content) == ""
+
+    def test_no_frontmatter_with_skill_name(self):
+        """No frontmatter but skill_name provided returns fallback."""
+        content = "# My Skill\n\nSome content here.\n"
+        assert (
+            _extract_skill_description(content, "my-skill") == "Use the my-skill skill"
+        )
+
+    def test_whitespace_only_description_fallback(self):
+        """Description with only whitespace falls back to skill_name."""
+        content = "---\ndescription:    \n---\n# Skill"
+        assert (
+            _extract_skill_description(content, "test-skill")
+            == "Use the test-skill skill"
+        )


### PR DESCRIPTION
## Summary

This PR adds `record-skill` as a bundled skill and ensures all bundled skills are automatically wired with `abc-` prefixed OpenCode command stubs.

## Changes

### New Bundled Skill
- **record-skill**: Extracted from `~/.config/opencode/skills/record-skill/` into the project bundled skills directory (`libs/beacon/src/beacon/data/skills/record-skill/`)
- Added to `abc warehouse init` template generation
- Added to `examples/sample-warehouse/` to match init output

### Automatic Command Stubs
- Bundled skills now get per-project wiring with `abc-{name}.md` command stubs
- Enables slash commands like `/abc-record-knowledge` and `/abc-record-skill` in OpenCode
- Added `wire_bundled_skills_per_project()` function to handle this automatically during `abc sync`
- Updated `unwire_skill()` to clean up both legacy and prefixed command stubs

### Contribute Exclusion
- Bundled skills are now excluded from `abc contribute` scope
- They are package-managed artifacts, not user content
- Fixed `find_untracked_local_files()` to skip bundled skills

### Dry-run Support
- Bundled skill wiring respects `--dry-run` flag (no files created)

### Tests
- Updated all command stub path assertions to use `abc-` prefix
- Added `record-skill` to warehouse init tests
- Added e2e test for `record-skill` bundled skill installation
- Updated bundled skills test to verify per-project wiring

## Verification

- All 888 tests pass
- Manual test: `abc sync` creates `.opencode/command/abc-record-knowledge.md` and `.opencode/command/abc-record-skill.md`
- `abc contribute` no longer suggests bundled skills