### PR TITLE
docs(openspec): plan pending-artifacts-and-record-revamp (PER-111 + record-* skill revamp)

### DIFF
--- a/openspec/changes/pending-artifacts-and-record-revamp/design.md
+++ b/openspec/changes/pending-artifacts-and-record-revamp/design.md
@@ -1,0 +1,195 @@
+## Context
+
+This change is the resolution of PER-111 (pending artifacts flow) combined with the long-overdue revamp of `record-knowledge` and `record-skill` against the current artifact model. The three pieces are tightly coupled: `pending.yaml` without authoring-skill writers is an empty file nobody populates; the record-* revamp without a staging buffer has nowhere to send its output without polluting `beacon.yaml`; and `abc adopt` without both sides has nothing distinctive to resolve.
+
+Predecessor context that shapes this change:
+
+- **`project-scoped-agents`** (in progress, 31/45 tasks done at planning time) introduces `artifacts.agents` to `beacon.yaml` and reworks the `abc adopt` TUI to treat agents as project-scoped selectables with transitive skill dependencies. This change builds on that TUI rather than forking a second one — the three-way accept/reject/defer semantics graft onto the existing TUI infrastructure (`textual`-based, already in tree).
+- **Artifact distribution model.** The warehouse is the single write target for artifacts; projects consume via per-file symlinks under `.agentic-beacon/artifacts/`. The record-* skills today write into the symlink tree, which happens to work but backwards — this change realigns them to write into the warehouse working tree directly, discovered via `.agentic-beacon/config.toml`.
+- **`config.toml` as the warehouse pointer.** Already modelled as `WorkspaceConfig` in `core/manifest/workspace.py`; already the canonical answer for "where is the warehouse" in every existing command (`sync`, `contribute`, `status`, `diagnostics`). Authoring skills adopt the same mechanism.
+- **Current `create_skill.py`.** 210-line interactive scaffolder with three responsibilities (prompting, templating, file writes), all of which the LLM handles more naturally in markdown instructions. Its hardcoded target (`.agentic-beacon/artifacts/skills/<name>/`) is incompatible with the warehouse-write model.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Introduce `.agentic-beacon/pending.yaml` as the single staging buffer for authored artifacts; populate via authoring skills only; never via `abc sync` or `abc warehouse contribute`.
+- Rebuild `record-knowledge` and `record-skill` to target the warehouse working tree, append to `pending.yaml`, and not touch `AGENTS.md` / `beacon.yaml` directly.
+- Extend `abc adopt` with three-way per-entry actions (accept / reject / defer) and session-atomic commit (no mutations until confirm; full rollback on mid-commit failure).
+- Add a one-line alert to every in-project `abc` invocation when `pending.yaml` is non-empty.
+- Retire `create_skill.py`; replace with LLM-driven scaffold flow + per-skill PEP 723 helper scripts for mechanical plumbing only.
+
+**Non-Goals:**
+- Refactoring the warehouse-side artifact taxonomy (`knowledge/`, `skills/`, `contexts/`, `agents/`). Unchanged.
+- Introducing a shared helper module across skills. Each record-* skill carries its own `scripts/` directory with independent copies — duplication is cheaper than coupling.
+- Changing `abc warehouse contribute`. It remains warehouse-scoped and orthogonal to `pending.yaml`.
+- Uninstalling or pruning artifacts on reject. Reject touches `pending.yaml` only; warehouse files are preserved.
+- Per-entry atomic mutations during the adopt TUI session. Commits are session-atomic; partial state during choice-marking is never persisted to disk.
+- Auto-backfilling `pending.yaml` on upgrade. Users with hand-authored warehouse artifacts rely on the `.last-adopt` diff path to surface them.
+- A separate `abc try` command. `abc adopt` is the single resolution surface for both pending and warehouse-modified entries.
+
+## Decisions
+
+### Decision 1 — Warehouse root via `config.toml`, not symlink resolution
+
+**Chosen:** Authoring skills walk up from `$PWD` to find `.agentic-beacon/config.toml` and read `[warehouse] local_path`. Hard-error if the file is absent or the field is missing.
+
+**Alternatives considered:**
+
+- **Symlink resolution.** `readlink .agentic-beacon/artifacts/<something>` → walk up to warehouse root. Rejected: fails when the project has zero adopted artifacts (no symlinks exist yet), relies on per-platform `readlink -f` semantics, and doesn't match the rest of the codebase where `config.toml` is already the canonical answer.
+- **Environment variable `BEACON_WAREHOUSE_ROOT`.** Rejected: introduces external state that has to be kept in sync with `config.toml`; invisible per-shell configuration invites drift.
+- **New pointer file at `.agentic-beacon/warehouse-path`.** Rejected: would duplicate what `config.toml` already stores.
+
+**Rationale:** `config.toml` is the system of record for "which warehouse is this project connected to." Every existing `abc` command already uses it (`preconditions.ensure_sync_ready`). Authoring skills adopting the same mechanism keeps one discovery path across the codebase.
+
+### Decision 2 — `pending.yaml` entry schema: five required fields, no optionals
+
+**Chosen:** `path`, `type`, `action`, `source`, `created_at` — all required in v1. `source` is free-form string; everything else is a fixed enum or typed scalar.
+
+**Alternatives considered:**
+
+- **Minimal (`path` only).** Rejected: insufficient for TUI grouping, can't distinguish created-vs-modified, no provenance for mixed-source populated files.
+- **Rich + wiring hints** (e.g. `suggested_target: artifacts.contexts`). Rejected as premature coupling: the TUI is the source of wiring truth per PER-111's design; embedding writer-side hints couples writers to TUI logic and creates drift when adopt logic evolves. Adopt recomputes wiring from `type` alone.
+- **`source` as fixed enum** (e.g. `record-knowledge | record-skill | manual`). Rejected: every new authoring skill would require a beacon release to extend the enum. Free-form string with graceful "unknown source" handling is strictly more extensible.
+
+**Rationale:** Five fields are the minimum to support the TUI's display/grouping/dedup logic without over-fitting to current behaviour. Free-form `source` keeps the schema open to future authoring skills without beacon releases.
+
+### Decision 3 — Pointer targets are warehouse contexts only; never `AGENTS.md`
+
+**Chosen:** `record-knowledge` offers `<warehouse>/contexts/*.md` plus "skip" as the pointer target list. `AGENTS.md` never appears.
+
+**Alternatives considered:**
+
+- **Keep `AGENTS.md` as the default target** (current behaviour). Rejected: `AGENTS.md` holds project-specific context — editing it from a warehouse-authoring skill is a category confusion, and pointers from a project-local file can't propagate to other projects that adopt the same knowledge.
+- **Let the user pick any file** (warehouse or project). Rejected: blurs the project-vs-warehouse boundary and invites pointer sprawl. The distinction matters.
+- **Drop the pointer step entirely.** Rejected: regresses discoverability. Knowledge without a context pointer is effectively orphaned; the existing "Brief / Read" pattern in warehouse contexts is exactly what makes the knowledge base navigable.
+
+**Rationale:** Knowledge files exist to be found through context files. The context-pointer edge is how skills and agents transitively surface relevant knowledge via `requires.contexts`. `AGENTS.md` is out-of-band for that model.
+
+### Decision 4 — Inserts must land under an existing section; never auto-create section headings
+
+**Chosen:** When inserting a pointer into a context file, the LLM identifies an existing section (`## <heading>`) that best fits the topic. If none fits, the skill surfaces that and asks the user to skip or pick a section manually. The skill never auto-creates section headings.
+
+**Alternatives considered:**
+
+- **Allow auto-create when no section fits.** Rejected: creating a new section is a structural change to the context file; it should be a deliberate user decision, not a side effect of `record-knowledge`. Auto-creation produces noisy diffs and invites one-off section sprawl.
+- **Always append at the end of the file.** Rejected: order in context files carries semantic grouping; end-appending scrambles that.
+
+**Rationale:** Record-knowledge's job is content; structural edits to context files are a human decision. The "skip or pick manually" fallback preserves the skill's usefulness for edge cases without letting it quietly reshape context files.
+
+### Decision 5 — Session-atomic adopt with explicit Apply + confirm
+
+**Chosen:** TUI accumulates choice marks in memory. No filesystem or config mutation until the user hits Apply and confirms the summary screen. On confirm, all mutations execute as a single logical transaction; any mid-commit failure triggers a full rollback to pre-commit state.
+
+**Alternatives considered:**
+
+- **Per-entry atomic** (apply each choice as the user clicks it). Rejected: gives no path to "undo" within a session; a mistake marked at entry 1 is already committed by entry 3. Also fragile against crashes mid-session.
+- **Session-atomic, per-category batches** (accept all → reject all → defer all). Effectively equivalent to the chosen design but framed differently. Chosen design is more transparent to users.
+
+**Rationale:** The confirm step is worth the extra keystroke because the adopt TUI's mutations are substantive (beacon.yaml edits, symlink syncs, pending.yaml rewrites). Preview-then-commit is the pattern users expect for anything touching git-tracked state.
+
+### Decision 6 — Reject drops from `pending.yaml` only; warehouse untouched
+
+**Chosen:** Rejecting an entry removes it from `pending.yaml`. The warehouse file is preserved byte-identical. Warehouse cleanup is separately the user's deliberate decision.
+
+**Alternatives considered:**
+
+- **Reject → delete warehouse file.** Rejected: `pending.yaml` is project-local state; the warehouse is shared across projects. One project's reject MUST NOT mutate shared state.
+- **Reject → prompt whether to also delete warehouse file.** Rejected: even an opt-in cross-project mutation is a bad pattern. Keep the project / warehouse axes orthogonal.
+
+**Rationale:** The invariant "pending.yaml is local working state; warehouse is shared" keeps the mental model simple and prevents accidental cross-project deletion.
+
+### Decision 7 — Retire `create_skill.py`; no `_shared/` helper module
+
+**Chosen:** Delete `libs/beacon/src/beacon/data/skills/record-skill/scripts/create_skill.py`. Move content generation, templating, and prompting into the skill's markdown instructions. Keep a thin `scripts/` directory per record-* skill with PEP 723 helpers (`resolve_warehouse.py`, `append_pending.py`). Duplicate these helpers across the two skills rather than introducing a shared module.
+
+**Alternatives considered:**
+
+- **Keep `create_skill.py`, rewrite it for warehouse targets.** Rejected: rewriting line-by-line would preserve a layer of indirection with no functional upside. The LLM handles prompting, templating, and conversation more naturally.
+- **Introduce `_shared/authoring_helpers.py`.** Rejected: a shared module becomes an implicit contract between every future authoring skill. Two small duplications are cheaper than one coupling point that expands over time.
+- **Move all plumbing into markdown** (no scripts). Rejected: YAML/TOML parsing and filesystem walks expressed as markdown instructions invite LLM drift; these deterministic bits belong in Python.
+
+**Rationale:** The right split is LLM for judgment and content, PEP 723 helpers for mechanical plumbing. Per-skill ownership of helpers keeps skills independently reshapable.
+
+### Decision 8 — `requires.contexts` suggestion at scaffold time
+
+**Chosen:** `record-skill` scans `<warehouse>/contexts/*.md` and proposes a `requires.contexts:` list for the new skill, with rationale per match. User accepts, edits, or skips. Suggestion writes to the generated SKILL.md frontmatter; empty list permitted; always hand-editable afterward.
+
+**Alternatives considered:**
+
+- **Force the user to declare `requires.contexts` explicitly.** Rejected: doubles user work for a field most new skills start empty.
+- **Always default to empty; require post-scaffold hand-edit.** Rejected: the warehouse contexts are readable at scaffold time; there's no reason to punt the suggestion to later.
+
+**Rationale:** Opportunistic suggestion is cheap (read the warehouse we already know how to find) and removes friction for the common case. The escape hatch of "skip" preserves the hand-edit path.
+
+### Decision 9 — `.last-adopt` advances only on successful commit
+
+**Chosen:** The marker is touched only when `abc adopt` commits successfully. Session open, cancel, or Ctrl-C leaves the marker unchanged.
+
+**Alternatives considered:**
+
+- **Advance on session open.** Rejected: breaks the invariant that the marker represents "last successful resolution"; cancelled sessions would hide warehouse-modified entries on next run.
+- **Advance on any session close, success or cancel.** Same problem.
+
+**Rationale:** The marker's purpose is to serve as a cursor for "what has the user actually resolved." Tying advancement to successful commit is the only semantics that preserves that.
+
+### Decision 10 — Alert suppressed outside a project
+
+**Chosen:** The pre-command pending alert only fires when `.agentic-beacon/config.toml` is discoverable via cwd-walk. Commands like `abc warehouse init` run from fresh directories do not trigger the check.
+
+**Alternatives considered:**
+
+- **Always attempt the alert check.** Rejected: emits confusing no-op logs outside projects; couples unrelated commands to a project-scoped invariant.
+
+**Rationale:** Symmetric with how the rest of the codebase scopes "is this a project" — `config.toml` discoverability is the boolean.
+
+## Risks / Trade-offs
+
+**[Risk]** Users accustomed to `create_skill.py`'s interactive prompts get confused by the new LLM-driven flow, particularly in non-LLM contexts (e.g. running the skill from plain shell).
+**Mitigation:** The skill is explicitly an LLM-driven authoring tool — invoking it without an LLM context has never been a supported workflow. Release notes and `record-skill`'s updated SKILL.md clarify this.
+
+**[Risk]** Authoring skills writing directly into the warehouse working tree pollute the warehouse's git status even when the user hasn't committed their work.
+**Mitigation:** This is intentional and already how the current record-* skills work (via the symlink path). The `abc adopt` flow is the explicit hand-off point; users who want to discard can `git restore` in the warehouse. `pending.yaml` serves as a handoff record for exactly this state.
+
+**[Risk]** Session-atomic adopt with rollback-on-failure makes the commit logic significantly more complex than today's linear mutation.
+**Mitigation:** The transaction model is bounded — three files (`beacon.yaml`, `pending.yaml`, `.last-adopt`) plus N symlinks. Pre-commit snapshots of the three files plus idempotent symlink operations give a tractable rollback implementation. Integration test covers mid-commit failure.
+
+**[Risk]** `.last-adopt` + `pending.yaml` diverge (e.g. file corruption, manual edit, partial git operations), surfacing stale or inconsistent adopt candidates.
+**Mitigation:** Both files are gitignored local state — any inconsistency is recoverable by deleting them and re-running `abc adopt`, which falls back to "everything is new." The alert system surfaces obvious divergences (e.g. non-empty `pending.yaml` after user thought they adopted) via the count mismatch.
+
+**[Risk]** The warehouse-context-only pointer restriction frustrates users who have adopted a context into their project and want the pointer to appear "in their AGENTS.md" automatically.
+**Mitigation:** The pointer lands in the warehouse context; when the user adopts that context (already in `beacon.yaml`), the symlink surfaces the updated context body — the pointer propagates automatically via the adopt mechanism. No manual `AGENTS.md` edit needed. This is actually the better UX; the restriction protects it.
+
+**[Risk]** Two record-* skills each shipping independent copies of `resolve_warehouse.py` and `append_pending.py` creates drift when one skill fixes a bug the other doesn't.
+**Mitigation:** Accepted as the cost of avoiding cross-skill coupling. The helper scripts are each <50 lines; divergence is visible in `git diff`. A future change can consolidate if duplication genuinely becomes painful — but introducing shared infrastructure speculatively is the worse failure mode.
+
+## Migration Plan
+
+**For this repo (agentic-beacon):**
+
+1. Land `project-scoped-agents` first (already in progress, blocking this change).
+2. Implement in the order: (a) `pending.py` core module + gitignore update, (b) `.last-adopt` handling in adoption domain, (c) alert hook in CLI entry point, (d) `abc adopt` TUI three-way actions + session-atomic commit, (e) `record-knowledge` rewrite + new `scripts/`, (f) `record-skill` rewrite + new `scripts/`, (g) delete `create_skill.py`.
+3. Regenerate `examples/sample-warehouse/` if the sample's gitignore template changes.
+4. Integration tests covering the happy path (author → pending → adopt → wired) and rollback path (author → adopt → mid-commit failure → state preserved).
+5. Update migration doc and `AGENTS.md` wiring notes.
+
+**For existing users:**
+
+1. Upgrade Beacon. Existing projects gain `.agentic-beacon/pending.yaml` and `.agentic-beacon/.last-adopt` as optional local state (both gitignored).
+2. First `abc adopt` after upgrade: `.last-adopt` is absent, so every warehouse file modified since the existing sync cursor appears as a discovery candidate. Users either defer everything (noisy-but-safe) or accept selectively. Subsequent adopts are tight.
+3. Authoring skills (`record-knowledge`, `record-skill`) work differently on first use — warehouse-target write, `pending.yaml` append. Release notes call this out.
+
+**Rollback:** Revert the Beacon release. `pending.yaml` and `.last-adopt` become unknown local files; older Beacon ignores them. `record-knowledge` / `record-skill` fail hard on invocation (they depend on the new flow). Users pin to the previous Beacon version and re-upgrade once the issue is fixed.
+
+## Open Questions
+
+**Q1:** Should the pre-command pending alert be suppressible via a flag (e.g. `--quiet-pending` or `BEACON_NO_ALERT=1`) for scripted contexts?
+
+**Proposed default:** No, not in v1. The alert is one line on stderr; scripts can already redirect `2>/dev/null`. Adding a suppression flag invites forgetting to clear the flag in interactive sessions. Revisit if real users ask.
+
+**Q2:** When an authoring skill fails partway through (e.g. warehouse write succeeds, `pending.yaml` append fails), what's the recovery?
+
+**Proposed default:** Hard error with both paths surfaced. The skill prints: "Wrote `<warehouse path>` but failed to append to `pending.yaml`: <reason>. The warehouse file exists; to register it, either fix `pending.yaml` and re-run, or discard via `git restore` in the warehouse." Simple, explicit, no implicit retries.
+
+**Q3:** Should `pending.yaml` entries carry an expiry / age-out rule (e.g. "older than 30 days → auto-reject")?
+
+**Proposed default:** No. Deferred entries stay until the user resolves them. Auto-expiry would silently drop state the user explicitly kept. If the buffer bloats over time, that's a signal the user should `abc adopt` more often, not a case for automatic cleanup.

--- a/openspec/changes/pending-artifacts-and-record-revamp/specs/pending-artifacts-flow/spec.md
+++ b/openspec/changes/pending-artifacts-and-record-revamp/specs/pending-artifacts-flow/spec.md
@@ -1,0 +1,302 @@
+## ADDED Requirements
+
+### Requirement: pending.yaml file location and lifecycle
+
+The system SHALL maintain a project-scoped file at `.agentic-beacon/pending.yaml` representing artifacts authored or modified in the warehouse from within this project but not yet wired into `beacon.yaml`. The file SHALL be gitignored by default so per-developer working state is never committed.
+
+#### Scenario: File created on first authoring-skill write
+
+- **WHEN** a user runs `record-knowledge` in a project with no existing `pending.yaml` and the skill completes successfully
+- **THEN** the system creates `.agentic-beacon/pending.yaml` containing the new entry and the project's gitignore (or warehouse-supplied gitignore template) already excludes it
+
+#### Scenario: File absent when project has no pending artifacts
+
+- **WHEN** a project has never been authored into or has had every entry resolved via `abc adopt`
+- **THEN** `.agentic-beacon/pending.yaml` MAY be absent, or present with `pending: []`; both states are equivalent
+
+#### Scenario: Warehouse contribute does not touch pending.yaml
+
+- **WHEN** a user runs `abc warehouse contribute` in any project
+- **THEN** the command reads and writes the warehouse only; `pending.yaml` in the project is not created, read, or modified
+
+---
+
+### Requirement: pending.yaml entry schema
+
+Each entry in `pending.yaml` SHALL carry exactly five fields: `path`, `type`, `action`, `source`, and `created_at`. All fields are required in v1; entries missing any field SHALL cause the file to fail validation at read time.
+
+- `path`: warehouse-relative path to the artifact (e.g. `knowledge/lessons/foo.md`, `skills/bar/`).
+- `type`: one of `knowledge`, `skill`, `context`, `agent`.
+- `action`: one of `created` (a new artifact written by the skill) or `modified` (an existing warehouse file the skill edited).
+- `source`: free-form string identifying the authoring skill (e.g. `record-knowledge`, `record-skill`); unknown values are tolerated by consumers.
+- `created_at`: ISO-8601 UTC timestamp of when the entry was appended.
+
+#### Scenario: Well-formed entry parses round-trip
+
+- **WHEN** `pending.yaml` contains `[{path: knowledge/lessons/x.md, type: knowledge, action: created, source: record-knowledge, created_at: 2026-05-06T14:22:00Z}]`
+- **THEN** loading and re-dumping the file preserves all fields exactly, with no field reordering that would change YAML key order beyond schema-defined order
+
+#### Scenario: Missing required field fails validation
+
+- **WHEN** a `pending.yaml` entry omits `type`
+- **THEN** loading the file raises a validation error identifying the missing field and the entry index
+
+#### Scenario: Invalid enum value fails validation
+
+- **WHEN** a `pending.yaml` entry has `action: deleted`
+- **THEN** loading the file raises a validation error listing the allowed values (`created`, `modified`)
+
+#### Scenario: Unknown source is accepted
+
+- **WHEN** a `pending.yaml` entry has `source: my-custom-authoring-skill`
+- **THEN** the entry loads successfully; downstream consumers SHALL treat the source as a display grouping hint without coupling to a fixed enum
+
+---
+
+### Requirement: Authoring skill write contract
+
+Any skill that authors or modifies a warehouse artifact SHALL append one entry to the current project's `pending.yaml` per artifact touched. The skill SHALL NOT write to `beacon.yaml`, the project's `AGENTS.md`, or any wiring file; the only project-side write target is `pending.yaml`.
+
+#### Scenario: record-knowledge appends a single knowledge entry with no context pointer
+
+- **WHEN** the user runs `record-knowledge`, accepts the generated knowledge file, and selects "skip" at the context-pointer prompt
+- **THEN** exactly one entry is appended to `pending.yaml` with `path` pointing to the new knowledge file, `type: knowledge`, `action: created`, `source: record-knowledge`
+
+#### Scenario: record-knowledge appends two entries when a context pointer is added
+
+- **WHEN** the user runs `record-knowledge`, accepts the generated knowledge file, selects a warehouse context, and confirms the proposed pointer insert
+- **THEN** two entries are appended to `pending.yaml`: one for the created knowledge file (`action: created`) and one for the modified context file (`action: modified`), both with `source: record-knowledge`
+
+#### Scenario: record-skill appends a single skill entry
+
+- **WHEN** the user runs `record-skill` and the skill successfully scaffolds `<warehouse>/skills/<name>/SKILL.md`
+- **THEN** exactly one entry is appended with `path: skills/<name>/`, `type: skill`, `action: created`, `source: record-skill`
+
+#### Scenario: Authoring skill does not mutate beacon.yaml
+
+- **WHEN** any authoring skill completes successfully
+- **THEN** `beacon.yaml` is byte-identical before and after the skill run
+
+---
+
+### Requirement: Warehouse root discovery via config.toml
+
+Authoring skills SHALL discover the warehouse root by walking up from `$PWD` to find `.agentic-beacon/config.toml` and reading its `[warehouse] local_path` field. If no `config.toml` is found or the field is missing, the skill SHALL hard-error with a message directing the user to `abc warehouse connect`.
+
+#### Scenario: Warehouse discovered from project root
+
+- **WHEN** the user runs `record-knowledge` from a project whose `.agentic-beacon/config.toml` contains `[warehouse] local_path = "/home/user/warehouse"`
+- **THEN** the skill writes the new knowledge file under `/home/user/warehouse/knowledge/<type>/<name>.md`
+
+#### Scenario: Warehouse discovered from nested subdirectory
+
+- **WHEN** the user runs `record-knowledge` from `<project>/src/foo/bar/`
+- **THEN** the skill walks up to find `<project>/.agentic-beacon/config.toml` and resolves the warehouse the same as from the project root
+
+#### Scenario: Missing config.toml hard-errors
+
+- **WHEN** the user runs `record-knowledge` from a directory with no `.agentic-beacon/config.toml` in the cwd-walk chain
+- **THEN** the skill aborts before any file write and prints: `Error: no warehouse connected. Run 'abc warehouse connect <path>' first.`
+
+#### Scenario: Malformed config.toml hard-errors
+
+- **WHEN** `.agentic-beacon/config.toml` is present but has no `[warehouse] local_path` field
+- **THEN** the skill aborts with a parse error identifying the missing field
+
+---
+
+### Requirement: record-knowledge context-pointer behaviour
+
+The `record-knowledge` skill SHALL offer to insert a pointer into a warehouse context file only. The project's `AGENTS.md` SHALL NOT appear as a pointer target. The pointer SHALL be inserted under an existing section in the target context file; the skill SHALL NOT create new section headings as a side effect.
+
+#### Scenario: Context list shown from warehouse only
+
+- **WHEN** `record-knowledge` reaches the pointer-target prompt
+- **THEN** the user sees exactly: the list of `<warehouse>/contexts/*.md` files plus a "skip" option; `AGENTS.md` is not in the list
+
+#### Scenario: Pointer inserted under existing section
+
+- **WHEN** the user picks `contexts/python-standards.md` and the LLM identifies `## Exception Handling` as the best-fit existing section
+- **THEN** the skill inserts a `**Brief:** ... **Read:** ...` block under that section, shows the user the proposed diff, and writes only on confirmation
+
+#### Scenario: No fitting section surfaces a choice
+
+- **WHEN** the user picks a context file but the LLM cannot identify any existing section that fits the knowledge topic
+- **THEN** the skill surfaces "No section in <file> obviously fits this knowledge. Skip pointer, or pick a section manually?" and does not auto-create a new section under any circumstance
+
+#### Scenario: Diff rejected leaves context file untouched
+
+- **WHEN** the user declines the proposed pointer diff
+- **THEN** the context file is byte-identical before and after; only the knowledge file entry is appended to `pending.yaml`
+
+---
+
+### Requirement: record-skill requires.contexts suggestion
+
+The `record-skill` skill SHALL scan `<warehouse>/contexts/*.md` and propose a `requires.contexts:` list for the new skill based on the declared purpose. The user SHALL be able to accept, edit, or skip the suggestion. The skill's generated `SKILL.md` frontmatter SHALL include the resulting list (empty list permitted).
+
+#### Scenario: Suggestion offered based on purpose match
+
+- **WHEN** the user describes a new skill as "validate deployment readiness checklist" and the warehouse has `contexts/cicd-flow.md` and `contexts/python-standards.md`
+- **THEN** `record-skill` proposes `requires.contexts: [contexts/cicd-flow.md, contexts/python-standards.md]` with rationale for each match
+
+#### Scenario: User accepts the suggestion
+
+- **WHEN** the user confirms the proposed `requires.contexts` list
+- **THEN** the generated `SKILL.md` frontmatter contains that exact list
+
+#### Scenario: User skips the suggestion
+
+- **WHEN** the user declines all suggestions
+- **THEN** the generated `SKILL.md` frontmatter contains `requires:\n  contexts: []`
+
+#### Scenario: No matching contexts found
+
+- **WHEN** the warehouse `contexts/` directory is empty or no context matches the declared purpose
+- **THEN** the skill defaults to `requires.contexts: []` without prompting
+
+---
+
+### Requirement: .last-adopt timestamp marker
+
+The system SHALL maintain a single-line ISO-8601 UTC timestamp at `.agentic-beacon/.last-adopt` recording when `abc adopt` last successfully committed. The marker SHALL be gitignored. The marker SHALL advance only on a successful adopt-session commit; session open, Ctrl-C, or cancel SHALL NOT modify the marker.
+
+#### Scenario: Marker absent on first adopt
+
+- **WHEN** `abc adopt` runs in a project where `.last-adopt` does not exist
+- **THEN** warehouse-modified-since-marker discovery treats every warehouse file as new; the marker is created on successful commit
+
+#### Scenario: Marker advances on successful commit
+
+- **WHEN** `abc adopt` commits a session at `2026-05-06T15:00:00Z`
+- **THEN** `.last-adopt` after the command contains exactly `2026-05-06T15:00:00Z` on a single line
+
+#### Scenario: Marker unchanged on cancel
+
+- **WHEN** the user opens `abc adopt`, marks accept/reject/defer choices, and cancels at the confirm screen
+- **THEN** `.last-adopt` is byte-identical before and after the command
+
+---
+
+### Requirement: abc command pending alert
+
+Every `abc` subcommand run inside a project (detected by the presence of `.agentic-beacon/config.toml` in the cwd-walk chain) SHALL print a one-line stderr notice when `pending.yaml` is non-empty. The notice SHALL include the entry count and point the user at `abc adopt`. The alert SHALL NOT block the invoked command from running.
+
+#### Scenario: Alert printed when pending is non-empty
+
+- **WHEN** the user runs `abc warehouse status` in a project whose `pending.yaml` contains 3 entries
+- **THEN** the first line of stderr is `⚠ 3 pending artifacts. Run 'abc adopt' to wire them.` and the `warehouse status` command executes normally afterward
+
+#### Scenario: No alert when pending is empty or absent
+
+- **WHEN** the user runs `abc warehouse status` in a project with no `pending.yaml` or with `pending: []`
+- **THEN** no pending-alert line appears on stderr
+
+#### Scenario: Alert outside a project is suppressed
+
+- **WHEN** the user runs `abc warehouse init` from a directory with no `.agentic-beacon/config.toml` in the cwd-walk chain
+- **THEN** no pending-alert check is performed; command runs normally
+
+---
+
+### Requirement: abc adopt merged discovery of pending + warehouse-modified
+
+The `abc adopt` TUI SHALL display entries drawn from two sources: entries in `.agentic-beacon/pending.yaml`, and warehouse files modified since `.last-adopt`. Entries appearing in both sources SHALL be deduplicated by `path`, with the `pending.yaml` entry's metadata (source, created_at, action) preferred. The TUI SHALL group or annotate entries by source so users can distinguish intent-driven entries from warehouse-diff entries.
+
+#### Scenario: Pending-only entry appears
+
+- **WHEN** `pending.yaml` contains `skills/new-skill/` (created) and no warehouse files have changed since `.last-adopt`
+- **THEN** the TUI displays exactly one entry for `skills/new-skill/` with its `source` field visible
+
+#### Scenario: Warehouse-only entry appears
+
+- **WHEN** `pending.yaml` is empty but a warehouse file `contexts/hand-edited.md` was modified after `.last-adopt`
+- **THEN** the TUI displays one entry for `contexts/hand-edited.md` annotated as "warehouse-modified (no source)"
+
+#### Scenario: Entry in both sources is deduplicated
+
+- **WHEN** `pending.yaml` contains `knowledge/lessons/x.md` and the warehouse diff since `.last-adopt` also shows `knowledge/lessons/x.md` as modified
+- **THEN** the TUI displays exactly one entry for that path using the `pending.yaml` entry's source and created_at; no duplicate row appears
+
+---
+
+### Requirement: abc adopt three-way per-entry actions
+
+For each displayed entry, the TUI SHALL allow the user to mark one of: **accept**, **reject**, or **defer**. Marking choices in the TUI SHALL NOT apply any filesystem or config mutation; choices are recorded in session state only until the user confirms at Apply.
+
+#### Scenario: Accept selected for a pending entry
+
+- **WHEN** the user marks a `skills/foo/` pending entry as accept
+- **THEN** no file is changed yet; the session state records `foo → accept`
+
+#### Scenario: Reject selected
+
+- **WHEN** the user marks a `knowledge/lessons/x.md` pending entry as reject
+- **THEN** no file is changed yet; the session state records `x → reject`
+
+#### Scenario: Defer is the no-op default
+
+- **WHEN** the user makes no explicit choice for an entry and hits Apply
+- **THEN** the entry is treated as deferred and remains in `pending.yaml` after the session
+
+---
+
+### Requirement: abc adopt session-atomic Apply with confirm
+
+The TUI SHALL require an explicit Apply action followed by a confirmation screen before any filesystem or config mutation. The confirmation screen SHALL summarise the totals of accepted / rejected / deferred entries and the projected mutations (beacon.yaml additions, symlink syncs, pending.yaml reductions). All mutations on confirm SHALL execute as a single logical transaction: on any mutation failure mid-commit, the system SHALL restore the pre-commit state of `beacon.yaml`, `pending.yaml`, and `.last-adopt`.
+
+#### Scenario: Apply shows summary before commit
+
+- **WHEN** the user marks 2 entries accept, 1 reject, 1 defer, and hits Apply
+- **THEN** a confirm screen displays "2 accepted → wiring in beacon.yaml + syncing symlinks / 1 rejected → removing from pending.yaml / 1 deferred → keeping in pending.yaml" and waits for explicit confirmation
+
+#### Scenario: Cancel from confirm screen makes no changes
+
+- **WHEN** the user hits Cancel on the confirm screen
+- **THEN** `beacon.yaml`, `pending.yaml`, and `.last-adopt` are byte-identical to their pre-session state
+
+#### Scenario: Successful commit atomically advances state
+
+- **WHEN** the user confirms a session with 2 accept / 1 reject / 1 defer
+- **THEN** `beacon.yaml` has the 2 accepted entries appended to the correct artifact categories, symlinks for those entries are synced, `pending.yaml` contains only the 1 deferred entry, and `.last-adopt` is set to the commit timestamp
+
+#### Scenario: Commit failure rolls back
+
+- **WHEN** symlink sync for an accepted entry fails partway through the commit
+- **THEN** `beacon.yaml`, `pending.yaml`, and `.last-adopt` are restored to their pre-commit state and the user sees a clear error identifying which entry failed
+
+---
+
+### Requirement: Reject does not touch warehouse files
+
+Rejecting a pending entry SHALL remove it from `pending.yaml` only. The warehouse file referenced by the rejected entry SHALL be byte-identical before and after the adopt session. Warehouse-side cleanup is an explicit separate action via `abc warehouse contribute` or manual edit.
+
+#### Scenario: Reject of a pending entry preserves the warehouse file
+
+- **WHEN** the user rejects a `knowledge/lessons/x.md` pending entry and confirms
+- **THEN** `pending.yaml` no longer contains the entry, and `<warehouse>/knowledge/lessons/x.md` exists with unchanged contents
+
+#### Scenario: Reject of a warehouse-modified-only entry is a no-op beyond .last-adopt advance
+
+- **WHEN** the user rejects a warehouse-modified entry that came only from the `.last-adopt` diff (not from `pending.yaml`)
+- **THEN** no file is changed; the entry simply fails to appear in future adopt sessions because `.last-adopt` advances past its modification time
+
+---
+
+### Requirement: create_skill.py is removed
+
+The PEP 723 script at `libs/beacon/src/beacon/data/skills/record-skill/scripts/create_skill.py` SHALL be deleted from the repository. Each record-* skill SHALL ship its own small helper scripts under its own `scripts/` directory, following the PEP 723 inline metadata convention. Shared helpers across skills SHALL NOT be introduced; duplication between `record-knowledge/scripts/` and `record-skill/scripts/` is the accepted cost of avoiding cross-skill coupling.
+
+#### Scenario: File no longer exists
+
+- **WHEN** the change is merged and a fresh checkout is inspected
+- **THEN** `libs/beacon/src/beacon/data/skills/record-skill/scripts/create_skill.py` is absent from the tree
+
+#### Scenario: Each record-* skill carries its own helpers
+
+- **WHEN** the change is merged
+- **THEN** both `record-knowledge/scripts/` and `record-skill/scripts/` directories contain their own independent copies of helpers (e.g. `resolve_warehouse.py`, `append_pending.py`) with PEP 723 `# /// script` metadata at the top of each
+
+**Reason for retirement**: The script's three responsibilities (interactive prompting, markdown templating, file writes) are all handled more naturally by the LLM in the skill's markdown instructions. Its filesystem-target assumption (`.agentic-beacon/artifacts/skills/<name>/`) is incompatible with the warehouse-write model this change establishes. Rewriting it line-for-line would leave a layer of indirection with no functional benefit.
+
+**Migration**: Users do not invoke `create_skill.py` directly in steady state (it is a skill-internal script). No user-facing migration is required. Skill behaviour changes are covered in `record-skill` requirements above.

--- a/openspec/changes/pending-artifacts-and-record-revamp/tasks.md
+++ b/openspec/changes/pending-artifacts-and-record-revamp/tasks.md
@@ -1,0 +1,83 @@
+## 1. Core manifest & gitignore
+
+- [ ] 1.1 Create `libs/beacon/src/beacon/core/manifest/pending.py` with `PendingEntry` Pydantic model (fields: `path: str`, `type: Literal["knowledge", "skill", "context", "agent"]`, `action: Literal["created", "modified"]`, `source: str`, `created_at: datetime`) and `PendingManifest` (wraps `pending: list[PendingEntry]`).
+- [ ] 1.2 Implement `PendingManifest.from_yaml(path: Path) -> PendingManifest` that tolerates absent file (returns empty manifest) and raises clear validation errors on schema violations.
+- [ ] 1.3 Implement `PendingManifest.to_yaml(path: Path) -> None` preserving field order (path / type / action / source / created_at) and pretty-printing with trailing newline.
+- [ ] 1.4 Implement `PendingManifest.append(entry: PendingEntry) -> None` with in-memory mutation (persistence via `to_yaml`).
+- [ ] 1.5 Unit tests: round-trip serialization, missing-field validation, invalid-enum validation, append-then-dump ordering, empty-file handling.
+- [ ] 1.6 Update `libs/beacon/src/beacon/core/gitignore.py` template to include `.agentic-beacon/pending.yaml` and `.agentic-beacon/.last-adopt` alongside the existing `config.toml` entry.
+- [ ] 1.7 Regenerate `examples/sample-warehouse/` gitignore output to reflect 1.6.
+
+## 2. `.last-adopt` marker
+
+- [ ] 2.1 Add helper `libs/beacon/src/beacon/domains/adoption/last_adopt.py` with `read_last_adopt(project_root: Path) -> datetime | None` and `write_last_adopt(project_root: Path, when: datetime) -> None`. Format: single ISO-8601 UTC line.
+- [ ] 2.2 Unit tests: absent file returns `None`, write-then-read round-trips exactly, malformed file raises a clear error.
+
+## 3. Pending alert hook
+
+- [ ] 3.1 Add helper `libs/beacon/src/beacon/cli/pending_alert.py` with `maybe_emit_pending_alert(cwd: Path) -> None` that walks up for `.agentic-beacon/config.toml`, reads `pending.yaml` if present, and emits the one-line stderr notice when entries exist.
+- [ ] 3.2 Wire the helper into the Click group entry in `libs/beacon/src/beacon/cli/main.py` (or root command decorator) so it runs before every `abc` subcommand.
+- [ ] 3.3 Unit tests: alert fires with correct count, alert suppressed when `pending.yaml` absent or empty, alert suppressed when no `config.toml` in cwd-walk chain, alert does not block subcommand execution.
+
+## 4. Adopt discovery merge
+
+- [ ] 4.1 Extend `libs/beacon/src/beacon/domains/adoption/discovery.py` to merge two sources into one candidate list: entries from `pending.yaml`, and warehouse files modified since `.last-adopt` (via existing git-diff machinery).
+- [ ] 4.2 Implement dedup by `path`: when both sources present, prefer the `pending.yaml` entry's metadata (source, created_at, action).
+- [ ] 4.3 Annotate warehouse-diff-only entries with `source = "warehouse-modified"` (display-only; not written back to `pending.yaml`).
+- [ ] 4.4 Unit tests: pending-only entry, warehouse-only entry, both-sources dedup, empty-both case.
+
+## 5. Adopt TUI three-way actions
+
+- [ ] 5.1 Extend `libs/beacon/src/beacon/domains/adoption/tui.py` per-entry action model from binary (accept/skip) to three-way (accept/reject/defer); update key bindings.
+- [ ] 5.2 Add visual affordance showing each entry's current mark + its `source` label.
+- [ ] 5.3 Ensure marking choices only update in-memory session state; no filesystem or config mutation during mark phase.
+- [ ] 5.4 TUI unit/snapshot tests for the three-way mark transitions and display layout.
+
+## 6. Adopt session-atomic Apply + confirm + rollback
+
+- [ ] 6.1 Add Apply key binding that transitions to a confirm screen summarising `N accepted / N rejected / N deferred` with projected mutations (beacon.yaml adds, symlink syncs, pending.yaml reductions).
+- [ ] 6.2 Implement commit transaction in `libs/beacon/src/beacon/domains/adoption/apply.py`: pre-snapshot `beacon.yaml`, `pending.yaml`, `.last-adopt`; apply accepts (beacon.yaml + symlink sync); apply rejects (drop from pending.yaml only, warehouse untouched); keep defers in pending.yaml; advance `.last-adopt`.
+- [ ] 6.3 Implement rollback: on any mutation failure mid-commit, restore all three files to their pre-snapshot contents and surface a clear error identifying the failing entry.
+- [ ] 6.4 Cancel from confirm screen leaves filesystem unchanged; verify by byte-equality of the three files before/after.
+- [ ] 6.5 Integration test: 2 accept / 1 reject / 1 defer happy path → post-state matches expectations.
+- [ ] 6.6 Integration test: induced symlink-sync failure mid-commit → all three files restored to pre-state; error message identifies failing entry.
+
+## 7. record-knowledge skill revamp
+
+- [ ] 7.1 Create `libs/beacon/src/beacon/data/skills/record-knowledge/scripts/resolve_warehouse.py` (PEP 723): walks up from `$PWD` for `.agentic-beacon/config.toml`, parses `[warehouse] local_path`, prints absolute path or errors to stderr and exits non-zero with the documented error text.
+- [ ] 7.2 Create `libs/beacon/src/beacon/data/skills/record-knowledge/scripts/append_pending.py` (PEP 723): CLI flags `--path --type --action --source`; auto-stamps `created_at`; resolves project root via cwd-walk; appends to `.agentic-beacon/pending.yaml`; creates the file if absent.
+- [ ] 7.3 Rewrite `record-knowledge/SKILL.md`: warehouse-target write flow, pointer-target prompt restricted to `<warehouse>/contexts/*.md` + "skip", diff-confirm before writing pointer, append-pending for both files (or just knowledge) depending on pointer decision, hard-error path when `resolve_warehouse.py` fails.
+- [ ] 7.4 Explicitly remove all mention of writing to `.agentic-beacon/artifacts/knowledge/` and of updating `AGENTS.md` from the SKILL.md.
+- [ ] 7.5 Manual happy-path test: run `record-knowledge` in this repo; verify knowledge file lands in warehouse, pointer diff is shown, `pending.yaml` receives correct entries.
+
+## 8. record-skill skill revamp
+
+- [ ] 8.1 Create `libs/beacon/src/beacon/data/skills/record-skill/scripts/resolve_warehouse.py` (PEP 723): independent copy of the record-knowledge helper.
+- [ ] 8.2 Create `libs/beacon/src/beacon/data/skills/record-skill/scripts/append_pending.py` (PEP 723): independent copy of the record-knowledge helper.
+- [ ] 8.3 Delete `libs/beacon/src/beacon/data/skills/record-skill/scripts/create_skill.py` and its compiled `__pycache__/create_skill.cpython-312.pyc`.
+- [ ] 8.4 Rewrite `record-skill/SKILL.md`: LLM-driven flow gathering name / description / invocation / include-script; warehouse context scan for `requires.contexts` suggestion with accept / edit / skip; warehouse-target SKILL.md write (+ optional `scripts/<name>.py` PEP 723 scaffold); append-pending with `type: skill action: created source: record-skill`; hard-error path when `resolve_warehouse.py` fails.
+- [ ] 8.5 Manual happy-path test: run `record-skill` in this repo; verify skill directory lands in warehouse, `requires.contexts` suggestion surfaces correctly, `pending.yaml` receives entry.
+
+## 9. End-to-end integration tests
+
+- [ ] 9.1 Integration test: author knowledge (no pointer) → one pending entry → `abc adopt` accept → beacon.yaml unchanged (knowledge is not a beacon.yaml artifact), pending.yaml empty, `.last-adopt` advanced.
+- [ ] 9.2 Integration test: author knowledge (with pointer) → two pending entries → `abc adopt` accept both → context file symlink reflects the updated body in the project.
+- [ ] 9.3 Integration test: author skill → one pending entry → `abc adopt` accept → beacon.yaml has new `skills/<name>/` entry, symlink created, pending.yaml empty.
+- [ ] 9.4 Integration test: hand-edit a warehouse context file → no `pending.yaml` change → `abc adopt` picks up via `.last-adopt` diff → user accepts → handled correctly.
+- [ ] 9.5 Integration test: run `abc warehouse status` in a project with non-empty `pending.yaml` → alert line appears first on stderr, command output follows, exit code unaffected.
+- [ ] 9.6 Integration test: run `record-knowledge` in a project without `.agentic-beacon/config.toml` → hard error with documented text, no file writes.
+
+## 10. Docs & sample warehouse
+
+- [ ] 10.1 Add `docs/migrations/pending-artifacts-flow-and-record-revamp.md` covering: what `pending.yaml` is, how authoring skills changed, how `abc adopt` changed, breaking changes for `record-*` users, rollback path.
+- [ ] 10.2 Update root `AGENTS.md` to reflect new `abc adopt` three-way actions and the pending alert.
+- [ ] 10.3 Update site-docs page describing `.agentic-beacon/` layout to list `pending.yaml` and `.last-adopt`.
+- [ ] 10.4 Regenerate `examples/sample-warehouse/` if anything structural changed (verify via `abc warehouse init` fresh-diff).
+
+## 11. Release & verification
+
+- [ ] 11.1 Run full test suite from repo root: `pytest` passes.
+- [ ] 11.2 Verify `abc --version` and basic commands still work after install.
+- [ ] 11.3 Smoke test `abc warehouse init test-warehouse` and confirm `.gitignore` in output includes new entries.
+- [ ] 11.4 Smoke test `record-knowledge` and `record-skill` end-to-end in a fresh project connected to the sample warehouse.
+- [ ] 11.5 Update CHANGELOG with breaking-change callout for `record-*` skills.


### PR DESCRIPTION
## Summary

Planning artifacts only (proposal, design, specs, tasks) for the combined [PER-111](https://linear.app/shadowsong-personal/issue/PER-111/pending-artifacts-flow-pendingyaml-adopt-tui) pending-artifacts flow and the overdue revamp of `record-knowledge` and `record-skill` against the post-warehouse artifact model. **No code changes.**

## Why one change for both

The three pieces are tightly coupled and meaningless in isolation:
- `pending.yaml` without authoring-skill writers is an empty file nobody populates
- The record-* revamp without a staging buffer has nowhere to send output without polluting `beacon.yaml`
- `abc adopt` without both sides has nothing distinctive to resolve

Bundling them in one change forces PER-111's schema to be designed with real writer consumers.

## What's in the plan

### Pending-artifacts flow (PER-111)
- **New file** `.agentic-beacon/pending.yaml` — gitignored staging buffer populated only by authoring skills
- **New file** `.agentic-beacon/.last-adopt` — timestamp cursor, advances only on successful adopt commit
- **Entry schema** — `path`, `type`, `action`, `source`, `created_at` (five required fields; `source` free-form)
- **Pre-command alert** — one-line stderr notice on every in-project `abc` invocation when pending is non-empty
- **`abc adopt` rework** — three-way per-entry actions (accept/reject/defer), session-atomic Apply + confirm with rollback-on-failure; reject drops from pending only (warehouse untouched)

### record-* skill revamp
- **Warehouse-target writes** — skills write to `<warehouse>/knowledge/…` and `<warehouse>/skills/…`, not `.agentic-beacon/artifacts/`
- **Warehouse root discovery via `config.toml`** — walk up for `.agentic-beacon/config.toml`, read `[warehouse] local_path`; hard-error if absent
- **`record-knowledge` pointer targets** — warehouse contexts only (never `AGENTS.md`); inserts under an existing section (never auto-creates)
- **`record-skill` `requires.contexts` suggestion** — LLM scans warehouse contexts and proposes the list at scaffold time; user accepts/edits/skips
- **Per-skill PEP 723 helper scripts** — each record-* skill carries its own `scripts/resolve_warehouse.py` and `scripts/append_pending.py` (duplication over coupling)
- **Retire `create_skill.py`** — the monolithic interactive scaffolder; replaced by LLM-driven markdown instructions

## Implementation order (from tasks.md)

1. Core manifest (`pending.py`) + gitignore
2. `.last-adopt` marker helpers
3. Pending alert hook
4. Adopt discovery merge (pending + warehouse-modified dedup)
5. Adopt TUI three-way actions
6. Adopt session-atomic Apply + confirm + rollback
7. `record-knowledge` revamp
8. `record-skill` revamp (delete `create_skill.py`)
9. End-to-end integration tests
10. Docs + sample warehouse regeneration
11. Release verification

## Dependencies

Depends on [PR #104](https://github.com/Shadowsong27/agentic-beacon/pull/104) (`project-scoped-agents`) — **already merged**. Builds on the adopt TUI established there rather than forking a second one.

## What's NOT in this PR

- No code. Implementation comes in a follow-up after this proposal is reviewed and merged.
- No changes to `beacon.yaml` schema in this PR (the schema change for `pending.yaml` is described in the spec, implemented later).

## Merge strategy

Single commit, straightforward merge (no squash needed).

## Related

- Linear: [PER-111](https://linear.app/shadowsong-personal/issue/PER-111/pending-artifacts-flow-pendingyaml-adopt-tui)
- OpenSpec: `openspec/changes/pending-artifacts-and-record-revamp/`