### PR TITLE
fix(beacon): agents sync fallback on fresh machine (PER-112)

### DIFF
--- a/libs/beacon/src/beacon/domains/artifact/agent.py
+++ b/libs/beacon/src/beacon/domains/artifact/agent.py
@@ -248,7 +248,16 @@ def sync_agents_from_warehouse(
 
     tools = detect_agents_global()
     if not tools:
-        return
+        # Fresh machine: neither ~/.config/opencode/ nor ~/.claude/ exists yet.
+        # The user explicitly invoked agent sync, so install to canonical paths
+        # for every known tool — install_agent_global creates parent dirs.
+        tools = list(_ALL_KNOWN_AGENTS)
+        console.print(
+            "[yellow]No agent tools detected[/yellow] "
+            "(neither ~/.config/opencode/ nor ~/.claude/ exists).\n"
+            "Installing to canonical paths so agents are ready when you "
+            "set up Claude Code or OpenCode."
+        )
 
     agent_dirs = global_agent_dirs()
 

--- a/libs/beacon/tests/unit/cli/test_sync_agents_from_warehouse.py
+++ b/libs/beacon/tests/unit/cli/test_sync_agents_from_warehouse.py
@@ -43,13 +43,15 @@ def test_fresh_machine_creates_both_global_dirs(
     claude_dest = fake_home / ".claude" / "agents" / "code-reviewer.md"
     opencode_dest = fake_home / ".config" / "opencode" / "agents" / "code-reviewer.md"
     assert claude_dest.is_symlink()
-    assert claude_dest.resolve() == (
-        warehouse_with_agent / "agents" / "code-reviewer.md"
-    ).resolve()
+    assert (
+        claude_dest.resolve()
+        == (warehouse_with_agent / "agents" / "code-reviewer.md").resolve()
+    )
     assert opencode_dest.is_symlink()
-    assert opencode_dest.resolve() == (
-        warehouse_with_agent / "agents" / "code-reviewer.md"
-    ).resolve()
+    assert (
+        opencode_dest.resolve()
+        == (warehouse_with_agent / "agents" / "code-reviewer.md").resolve()
+    )
 
 
 def test_fresh_machine_prints_warning(fake_home, warehouse_with_agent, capsys):
@@ -99,9 +101,7 @@ def test_warehouse_without_agents_dir_returns_silently(fake_home, tmp_path, caps
     assert "No agent tools detected" not in out
 
 
-def test_warehouse_with_empty_agents_dir_returns_silently(
-    fake_home, tmp_path, capsys
-):
+def test_warehouse_with_empty_agents_dir_returns_silently(fake_home, tmp_path, capsys):
     """agents/ dir present but no *.md files → no-op, no fallback warning."""
     wh = tmp_path / "warehouse"
     (wh / "agents").mkdir(parents=True)

--- a/libs/beacon/tests/unit/cli/test_sync_agents_from_warehouse.py
+++ b/libs/beacon/tests/unit/cli/test_sync_agents_from_warehouse.py
@@ -1,0 +1,112 @@
+"""Tests for sync_agents_from_warehouse() — covers PER-112 fresh-machine fallback."""
+
+from pathlib import Path
+
+import pytest
+from beacon.domains.artifact.agent import sync_agents_from_warehouse
+
+AGENT_CONTENT = """\
+---
+name: code-reviewer
+description: Reviews code changes
+---
+# Code Reviewer Agent
+"""
+
+
+@pytest.fixture
+def fake_home(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: home))
+    return home
+
+
+@pytest.fixture
+def warehouse_with_agent(tmp_path):
+    wh = tmp_path / "warehouse"
+    (wh / "agents").mkdir(parents=True)
+    (wh / "agents" / "code-reviewer.md").write_text(AGENT_CONTENT)
+    return wh
+
+
+def test_fresh_machine_creates_both_global_dirs(
+    fake_home, warehouse_with_agent, capsys
+):
+    """PER-112: when neither ~/.claude nor ~/.config/opencode exists, sync still
+    installs to both canonical paths instead of silently no-op'ing."""
+    assert not (fake_home / ".claude").exists()
+    assert not (fake_home / ".config" / "opencode").exists()
+
+    sync_agents_from_warehouse(warehouse_with_agent, force=True)
+
+    claude_dest = fake_home / ".claude" / "agents" / "code-reviewer.md"
+    opencode_dest = fake_home / ".config" / "opencode" / "agents" / "code-reviewer.md"
+    assert claude_dest.is_symlink()
+    assert claude_dest.resolve() == (
+        warehouse_with_agent / "agents" / "code-reviewer.md"
+    ).resolve()
+    assert opencode_dest.is_symlink()
+    assert opencode_dest.resolve() == (
+        warehouse_with_agent / "agents" / "code-reviewer.md"
+    ).resolve()
+
+
+def test_fresh_machine_prints_warning(fake_home, warehouse_with_agent, capsys):
+    """User must see why both dirs were created — silent fallback is a regression."""
+    sync_agents_from_warehouse(warehouse_with_agent, force=True)
+
+    out = capsys.readouterr().out
+    assert "No agent tools detected" in out
+
+
+def test_only_claude_dir_present_installs_only_to_claude(
+    fake_home, warehouse_with_agent
+):
+    """When ~/.claude exists but ~/.config/opencode does not, install only to claudecode."""
+    (fake_home / ".claude").mkdir()
+
+    sync_agents_from_warehouse(warehouse_with_agent, force=True)
+
+    claude_dest = fake_home / ".claude" / "agents" / "code-reviewer.md"
+    opencode_dest = fake_home / ".config" / "opencode" / "agents" / "code-reviewer.md"
+    assert claude_dest.is_symlink()
+    assert not opencode_dest.exists()
+
+
+def test_only_opencode_dir_present_installs_only_to_opencode(
+    fake_home, warehouse_with_agent
+):
+    """When ~/.config/opencode exists but ~/.claude does not, install only to opencode."""
+    (fake_home / ".config" / "opencode").mkdir(parents=True)
+
+    sync_agents_from_warehouse(warehouse_with_agent, force=True)
+
+    claude_dest = fake_home / ".claude" / "agents" / "code-reviewer.md"
+    opencode_dest = fake_home / ".config" / "opencode" / "agents" / "code-reviewer.md"
+    assert opencode_dest.is_symlink()
+    assert not claude_dest.exists()
+
+
+def test_warehouse_without_agents_dir_returns_silently(fake_home, tmp_path, capsys):
+    """No warehouse agents/ dir → no-op, no fallback warning."""
+    wh = tmp_path / "empty-warehouse"
+    wh.mkdir()
+
+    sync_agents_from_warehouse(wh, force=True)
+
+    out = capsys.readouterr().out
+    assert "No agent tools detected" not in out
+
+
+def test_warehouse_with_empty_agents_dir_returns_silently(
+    fake_home, tmp_path, capsys
+):
+    """agents/ dir present but no *.md files → no-op, no fallback warning."""
+    wh = tmp_path / "warehouse"
+    (wh / "agents").mkdir(parents=True)
+
+    sync_agents_from_warehouse(wh, force=True)
+
+    out = capsys.readouterr().out
+    assert "No agent tools detected" not in out


### PR DESCRIPTION
## Summary

- Fixes [PER-112](https://linear.app/shadowsong-personal/issue/PER-112): on a fresh computer where neither `~/.claude/` nor `~/.config/opencode/` exists, `abc agents sync` silently did nothing.
- `sync_agents_from_warehouse` now falls back to all known tools and prints a clear notice when no tool dir is detected. `install_agent_global` already creates parent dirs, so both canonical agent dirs (`~/.claude/agents/`, `~/.config/opencode/agents/`) get populated.
- Adds 6 unit tests in `test_sync_agents_from_warehouse.py` covering the fallback, single-tool-detected paths, and the silent no-op cases when the warehouse has no agents.

**Out of scope:** `abc sync` still does NOT install agents — that's PER-109, deferred. Existing `TestSyncDoesNotInstallAgents` guards continue to pass.

## Test plan

- [x] `pytest libs/beacon/tests/unit/cli/test_sync_agents_from_warehouse.py` — 6 new tests pass
- [x] `pytest` on related suites (test_detect_agents_global, test_install_agent_global, test_sync_wiring, test_auto_pull_deps_e2e, test_agent_manifest_validation) — 105 tests pass
- [x] Manual repro: `sync_agents_from_warehouse` on a fake `HOME` with no tool dirs → both `~/.claude/agents/` and `~/.config/opencode/agents/` are created with the expected symlinks, plus a yellow notice is printed.