### PR TITLE
refactor(beacon): drop tombstone commands and dead artifact helpers

### DIFF
--- a/docs/boot-context-design/agents-md-architecture.md
+++ b/docs/boot-context-design/agents-md-architecture.md
@@ -552,8 +552,8 @@ git commit -m "feat: add JSON schema validation standard to Python context"
 **Post-merge:**
 ```bash
 # Update projects to get new standard
-cd project-alpha && abc update
-cd project-beta && abc update
+cd project-alpha && abc sync
+cd project-beta && abc sync
 ```
 
 **Result:** Pattern is now organizational standard, benefits all projects, user-level AGENTS.md stays minimal.

--- a/examples/sample-warehouse/docs/architecture.md
+++ b/examples/sample-warehouse/docs/architecture.md
@@ -48,7 +48,7 @@ abc sync
 1. Make changes in warehouse repository
 2. Test with Beacon CLI
 3. Submit pull request
-4. After merge, teams run `abc update` to sync
+4. After merge, teams run `abc sync` to sync
 
 ## Maintenance
 

--- a/libs/beacon/src/beacon/cli/main.py
+++ b/libs/beacon/src/beacon/cli/main.py
@@ -11,7 +11,7 @@ from beacon.cli.agent import agents, list_cmd
 from beacon.cli.diagnostics import doctor
 from beacon.cli.pending_alert import maybe_emit_pending_alert
 from beacon.cli.setup import setup
-from beacon.cli.sync import clean, reset_cmd, status, sync, update
+from beacon.cli.sync import clean, reset_cmd, status, sync
 from beacon.cli.warehouse import warehouse
 
 
@@ -35,53 +35,11 @@ main.add_command(setup)
 main.add_command(sync)
 main.add_command(agents)
 main.add_command(reset_cmd, name="reset")
-main.add_command(update, name="update")
 main.add_command(list_cmd, name="list")
 main.add_command(clean)
 main.add_command(status)
 main.add_command(adopt)
 main.add_command(doctor)
-
-
-@click.command()
-@click.pass_context
-def contribute(ctx) -> None:
-    """[Removed] Use 'abc warehouse contribute' instead."""
-    click.echo(
-        "Error: 'abc contribute' has been removed.\n"
-        "Use 'abc warehouse contribute' instead.",
-        err=True,
-    )
-    sys.exit(1)
-
-
-@click.command()
-@click.pass_context
-def delta(ctx) -> None:
-    """[Removed] Use 'abc warehouse status' instead."""
-    click.echo(
-        "Error: 'abc delta' has been removed.\nUse 'abc warehouse status' instead.",
-        err=True,
-    )
-    sys.exit(1)
-
-
-@click.command()
-@click.argument("artifact", required=False)
-@click.pass_context
-def install(ctx, artifact) -> None:
-    """[Removed] Edit beacon.yaml and run 'abc sync' instead."""
-    click.echo(
-        "Error: 'abc install' has been removed.\n"
-        "To install an artifact, add it to .agentic-beacon/beacon.yaml and run 'abc sync'.",
-        err=True,
-    )
-    sys.exit(1)
-
-
-main.add_command(contribute)
-main.add_command(delta)
-main.add_command(install)
 
 
 if __name__ == "__main__":

--- a/libs/beacon/src/beacon/cli/sync.py
+++ b/libs/beacon/src/beacon/cli/sync.py
@@ -313,24 +313,6 @@ def reset_cmd(*, project: Path | None) -> None:
         sys.exit(1)
 
 
-@click.command(name="update", hidden=True)
-@click.option(
-    "--project",
-    type=click.Path(exists=True, file_okay=False, path_type=Path),
-    help="Path to project root (auto-detected if not provided)",
-)
-def update(*, project: Path | None) -> None:
-    """[Deprecated] Use 'abc reset' instead.
-
-    Update existing synced artifacts from warehouse (re-runs sync, overwrites changes).
-    """
-    console.print(
-        "[yellow]Deprecation warning:[/yellow] 'abc update' is deprecated. "
-        "Use 'abc reset' instead."
-    )
-    reset_cmd.callback(project=project)
-
-
 @click.command()
 @click.option(
     "--project",

--- a/libs/beacon/src/beacon/domains/artifact/agent.py
+++ b/libs/beacon/src/beacon/domains/artifact/agent.py
@@ -1,6 +1,5 @@
 """Agent operations for the artifact domain."""
 
-import sys
 from pathlib import Path
 
 import click
@@ -8,7 +7,6 @@ from rich.console import Console
 from rich.table import Table
 
 from beacon.utils.display import is_interactive
-from beacon.utils.interaction import OverwriteDecision, resolve_conflict
 
 console = Console()
 
@@ -63,22 +61,6 @@ def detect_agents(project_root: Path, *, fallback_to_all: bool = False) -> list[
     if not agents and fallback_to_all:
         return list(_ALL_KNOWN_AGENTS)
     return agents
-
-
-def build_agents_paths() -> dict[str, Path]:
-    """Return a mapping of tool name → global agents directory for detected tools.
-
-    Shared detection logic used by `abc install` (and historically by
-    per-project agent-drift tooling) so writes/reads hit the same global
-    agent locations.
-    """
-    agents_paths: dict[str, Path] = {}
-    for tool in detect_agents_global():
-        if tool == "opencode":
-            agents_paths["opencode"] = Path.home() / ".config" / "opencode" / "agents"
-        elif tool == "claudecode":
-            agents_paths["claudecode"] = Path.home() / ".claude" / "agents"
-    return agents_paths
 
 
 def _agent_link_conflicts(dest: Path, source_file: Path) -> bool:
@@ -166,7 +148,7 @@ def list_global_agents() -> None:
 
     if not seen:
         console.print("[yellow]No agents found.[/yellow]")
-        console.print("Install agents with: abc install agents/<name>.md")
+        console.print("Install agents with: abc agents sync")
         return
 
     table = Table(title="Installed Agents (Global)")
@@ -175,30 +157,6 @@ def list_global_agents() -> None:
     for name in sorted(seen):
         table.add_row(name, ", ".join(seen[name]))
     console.print(table)
-
-
-def find_project_level_agents(project_root: Path) -> dict[str, list[str]]:
-    """Return project-scoped agent files per tool that live outside the global dirs.
-
-    Checks .claude/agents/ (Claude Code) and .opencode/agents/ (OpenCode) under
-    the given project root.  Returns a mapping of tool name → sorted list of
-    agent file names (README.md excluded).
-    """
-    project_agent_dirs: dict[str, Path] = {
-        "claudecode": project_root / ".claude" / "agents",
-        "opencode": project_root / ".opencode" / "agents",
-    }
-    result: dict[str, list[str]] = {}
-    for tool, agents_dir in project_agent_dirs.items():
-        if agents_dir.is_dir():
-            files = sorted(
-                f.name
-                for f in agents_dir.iterdir()
-                if f.is_file() and f.name != "README.md"
-            )
-            if files:
-                result[tool] = files
-    return result
 
 
 def update_agent_gitignores(project_root: Path) -> None:
@@ -323,93 +281,4 @@ def sync_agents_from_warehouse(
         console.print(
             f"  [yellow]Skipped {len(unique_skipped)} agent(s) with local changes "
             f"(use --force to overwrite): {', '.join(unique_skipped)}[/yellow]"
-        )
-
-
-def handle_install_agent(
-    artifact: str, *, force: bool = False, preserve: bool = False
-) -> None:
-    """Handle 'abc install agents/<name>.md' — global install for all detected tools.
-
-    Loads warehouse settings, performs soft-block conflict detection against global
-    agent dirs, and creates warehouse symlinks in each detected tool dir. Does NOT
-    update beacon.yaml.
-    """
-    from beacon.core.manifest.workspace import WorkspaceConfig
-
-    beacon_dir = Path.cwd() / ".agentic-beacon"
-    if not beacon_dir.exists():
-        console.print("[red]Error:[/red] No .agentic-beacon directory found.")
-        console.print("Run 'abc warehouse connect' to connect to a warehouse first.")
-        sys.exit(1)
-
-    try:
-        warehouse_settings = WorkspaceConfig()
-        warehouse_path = Path(warehouse_settings.warehouse.local_path)
-    except Exception as e:
-        console.print(f"[red]Error:[/red] Could not load warehouse settings: {e}")
-        sys.exit(1)
-
-    agent_file = warehouse_path / artifact
-    if not agent_file.exists():
-        console.print(f"[red]Error:[/red] Agent not found in warehouse: {artifact}")
-        sys.exit(1)
-
-    agent_name = Path(artifact).name
-
-    # Detect tools
-    tools = detect_agents_global()
-    if not tools:
-        console.print(
-            "[yellow]Warning:[/yellow] No agent tools detected "
-            "(neither ~/.config/opencode/ nor ~/.claude/ found)."
-        )
-        console.print("Install OpenCode or Claude Code and re-run to install agent.")
-        return
-
-    # Soft-block pre-check: check for conflicting global agent files
-    agent_dirs = global_agent_dirs()
-    conflicts: list[str] = []
-    for tool in tools:
-        dest = agent_dirs[tool] / agent_name
-        if _agent_link_conflicts(dest, agent_file):
-            conflicts.append(str(dest))
-
-    resolution = resolve_conflict(
-        force=force, preserve=preserve, has_conflicts=bool(conflicts)
-    )
-    if resolution == OverwriteDecision.SKIP:
-        preserve = True  # skip conflicting files
-    elif resolution == OverwriteDecision.NEEDS_CONFIRMATION:
-        # Non-interactive mode with conflicts — cannot prompt; refuse to proceed.
-        conflict_list = "\n".join(f"  • {p}" for p in conflicts)
-        console.print(
-            f"\n[yellow]Warning:[/yellow] {len(conflicts)} global agent file(s) "
-            f"differ from the warehouse:\n{conflict_list}\n"
-        )
-        console.print(
-            "[red]Error:[/red] Non-interactive mode — cannot prompt for overwrite.\n"
-            "Use --force to overwrite or --preserve to skip conflicting files."
-        )
-        sys.exit(1)
-
-    written_any = False
-    for tool in tools:
-        dest = agent_dirs[tool] / agent_name
-        is_conflict = str(dest) in conflicts
-
-        if preserve and is_conflict:
-            console.print(f"[yellow]Skipped[/yellow] {dest} (preserved local version)")
-            continue
-
-        linked = install_agent_global(tool, agent_name, agent_file)
-        if linked:
-            console.print(f"[green]Linked[/green] {artifact} → {dest}")
-            written_any = True
-        else:
-            console.print(f"[dim]Up to date[/dim] {dest}")
-
-    if not written_any and not conflicts:
-        console.print(
-            f"[dim]{artifact} is already up to date in all tool directories.[/dim]"
         )

--- a/libs/beacon/src/beacon/domains/artifact/agent.py
+++ b/libs/beacon/src/beacon/domains/artifact/agent.py
@@ -248,7 +248,16 @@ def sync_agents_from_warehouse(
 
     tools = detect_agents_global()
     if not tools:
-        return
+        # Fresh machine: neither ~/.config/opencode/ nor ~/.claude/ exists yet.
+        # The user explicitly invoked agent sync, so install to canonical paths
+        # for every known tool — install_agent_global creates parent dirs.
+        tools = list(_ALL_KNOWN_AGENTS)
+        console.print(
+            "[yellow]No agent tools detected[/yellow] "
+            "(neither ~/.config/opencode/ nor ~/.claude/ exists).\n"
+            "Installing to canonical paths so agents are ready when you "
+            "set up Claude Code or OpenCode."
+        )
 
     agent_dirs = global_agent_dirs()
 

--- a/libs/beacon/src/beacon/domains/artifact/skill.py
+++ b/libs/beacon/src/beacon/domains/artifact/skill.py
@@ -1,6 +1,5 @@
 """Skill operations for the artifact domain."""
 
-import fnmatch
 import os
 import shutil
 import sys
@@ -11,7 +10,7 @@ from rich.console import Console
 from rich.table import Table
 
 from beacon.core.file_filter import ARTIFACT_IGNORE_PATTERNS, is_artifact_file
-from beacon.core.manifest.beacon import ArtifactsConfig, BeaconManifest
+from beacon.core.manifest.beacon import BeaconManifest
 from beacon.domains.artifact.agent import detect_agents
 from beacon.utils.interaction import OverwriteDecision, resolve_conflict
 
@@ -46,12 +45,7 @@ def bundled_skill_names() -> set[str]:
 
 
 def build_skills_paths(project_root: Path) -> dict[str, Path]:
-    """Return a mapping of agent name → live skills directory for detected agents.
-
-    Shared detection logic used by `abc install` (and historically by
-    per-project skill-drift tooling) so writes/reads hit the same live agent
-    locations.
-    """
+    """Return a mapping of agent name → live skills directory for detected agents."""
     skills_paths: dict[str, Path] = {}
     for agent in detect_agents(project_root):
         if agent == "opencode":
@@ -59,34 +53,6 @@ def build_skills_paths(project_root: Path) -> dict[str, Path]:
         elif agent == "claudecode":
             skills_paths["claudecode"] = project_root / ".claude" / "skills"
     return skills_paths
-
-
-def find_global_untracked_skills(
-    ignore_patterns: list[str] | None = None,
-) -> dict[str, list[str]]:
-    """Return non-bundled skill directories found in the global skill dirs.
-
-    Scans ~/.claude/skills/ (Claude Code) and ~/.config/opencode/skills/ (OpenCode).
-    Excludes abc-bundled skills and any skill names matching ignore_patterns (fnmatch).
-    Returns a mapping of tool name → sorted list of skill names.
-    """
-    global_skill_dirs = bundled_global_skill_dirs()
-    bundled = bundled_skill_names()
-    patterns = ignore_patterns or []
-    result: dict[str, list[str]] = {}
-    for tool, skills_dir in global_skill_dirs.items():
-        if skills_dir.is_dir():
-            names = sorted(
-                d.name
-                for d in skills_dir.iterdir()
-                if d.is_dir()
-                and (d / "SKILL.md").exists()
-                and d.name not in bundled
-                and not any(fnmatch.fnmatch(d.name, p) for p in patterns)
-            )
-            if names:
-                result[tool] = names
-    return result
 
 
 def install_bundled_skills_globally() -> tuple[list[str], list[str]]:
@@ -247,30 +213,6 @@ def validate_skill_entries(beacon_settings: BeaconManifest) -> None:
         "Update beacon.yaml and re-run 'abc sync'."
     )
     sys.exit(1)
-
-
-def _migrate_beacon_yaml_skill_entries(
-    beacon_yaml: Path, legacy_entries: list[str]
-) -> None:
-    """Rewrite beacon.yaml replacing file-level skill entries with directory form."""
-    from beacon.core.manifest.beacon import BeaconManifest
-
-    settings = BeaconManifest.from_yaml(beacon_yaml)
-    migrated = []
-    for entry in settings.artifacts.skills:
-        if entry in legacy_entries:
-            migrated.append(normalize_skill_entry(entry))
-        else:
-            migrated.append(entry)
-    # Deduplicate while preserving order
-    seen: set[str] = set()
-    deduped = []
-    for e in migrated:
-        if e not in seen:
-            seen.add(e)
-            deduped.append(e)
-    settings.artifacts.skills = deduped
-    settings.to_yaml(beacon_yaml)
 
 
 def normalize_skill_entry(entry: str) -> str:
@@ -565,103 +507,3 @@ def wire_skills_post_sync(
                 errors.append(f"{name} ({agent}): {e}")
 
     return installed, errors
-
-
-def update_beacon_yaml(beacon_dir: Path, files: list[str]) -> None:
-    """Add installed file paths to beacon.yaml, creating it if absent."""
-    beacon_yaml = beacon_dir / "beacon.yaml"
-
-    if beacon_yaml.exists():
-        try:
-            settings = BeaconManifest.from_yaml(beacon_yaml)
-        except Exception:
-            return  # Don't corrupt a file we can't parse
-    else:
-        settings = BeaconManifest(artifacts=ArtifactsConfig())
-
-    for path in files:
-        parts = Path(path).parts
-        artifact_type = parts[0] if parts else ""
-        if artifact_type == "skills":
-            # Normalize to directory form and deduplicate across old/new formats
-            dir_entry = normalize_skill_entry(path)
-            already_tracked = any(
-                normalize_skill_entry(e) == dir_entry for e in settings.artifacts.skills
-            )
-            if not already_tracked:
-                settings.artifacts.skills.append(dir_entry)
-        elif artifact_type == "contexts":
-            if path not in settings.artifacts.contexts:
-                settings.artifacts.contexts.append(path)
-
-    settings.to_yaml(beacon_yaml)
-
-
-def _install_skill_opencode(
-    project_root: Path, skill_name: str, content: str, description: str
-) -> bool:
-    """Install a skill for OpenCode: skill file + thin command stub.
-
-    Returns True if files were written, False if already up-to-date.
-    """
-    skill_dest = project_root / ".opencode" / "skills" / skill_name
-    skill_dest.mkdir(parents=True, exist_ok=True)
-    skill_file = skill_dest / "SKILL.md"
-
-    stub = (
-        f"---\ndescription: {description}\n---\n\n"
-        f"Use the **skill** tool to load and execute the `{skill_name}` skill "
-        f"with any provided arguments.\n"
-    )
-    command_dir = project_root / ".opencode" / "command"
-    command_dir.mkdir(parents=True, exist_ok=True)
-    stub_file = command_dir / f"{skill_name}.md"
-
-    skill_unchanged = (
-        skill_file.exists() and skill_file.read_text(encoding="utf-8") == content
-    )
-    stub_unchanged = (
-        stub_file.exists() and stub_file.read_text(encoding="utf-8") == stub
-    )
-
-    if skill_unchanged and stub_unchanged:
-        return False
-
-    if not skill_unchanged:
-        skill_file.write_text(content)
-    if not stub_unchanged:
-        stub_file.write_text(stub)
-
-    # Return True only if SKILL.md was written (command stub updates are transparent)
-    return not skill_unchanged
-
-
-def _install_skill_claudecode(
-    project_root: Path, skill_name: str, content: str
-) -> bool:
-    """Install a skill for Claude Code: copy SKILL.md to .claude/skills/<name>/.
-
-    Returns True if the file was written, False if already up-to-date.
-    """
-    dest = project_root / ".claude" / "skills" / skill_name
-    dest.mkdir(parents=True, exist_ok=True)
-    dest_file = dest / "SKILL.md"
-
-    if dest_file.exists() and dest_file.read_text(encoding="utf-8") == content:
-        return False
-
-    dest_file.write_text(content)
-    return True
-
-
-def print_skill_next_steps(agents: list[str]) -> None:
-    """Print agent-specific guidance after install."""
-    console.print("\n[bold]Next Steps:[/bold]")
-    if "opencode" in agents:
-        console.print(
-            "  [bold]OpenCode[/bold] — restart your session to pick up new commands"
-        )
-    if "claudecode" in agents:
-        console.print(
-            "  [bold]Claude Code[/bold] — skills are available as /skill-name in new sessions"
-        )

--- a/libs/beacon/tests/conftest.py
+++ b/libs/beacon/tests/conftest.py
@@ -35,8 +35,9 @@ def isolated_home(tmp_path, monkeypatch):
     """Redirect Path.home() to a clean temp directory.
 
     Use this fixture in tests that invoke CLI commands which call
-    detect_agents_global() or build_agents_paths(), to prevent real global
-    agent installs from leaking into the test.
+    detect_agents_global() or otherwise touch ~/.config/opencode/ or
+    ~/.claude/, to prevent real global agent installs from leaking into
+    the test.
     """
     home = tmp_path / "home"
     home.mkdir()

--- a/libs/beacon/tests/integration/test_e2e_happy_path.py
+++ b/libs/beacon/tests/integration/test_e2e_happy_path.py
@@ -2,7 +2,7 @@
 
 Runs the complete user workflow in a single chained test:
   warehouse init → list → warehouse connect → setup → sync →
-  status → warehouse status → sync → sync --prune → update → clean
+  status → warehouse status → sync → sync --prune → sync (upstream pull) → clean
 
 This test is the automated equivalent of the manual e2e walkthrough done
 before each release. If this test passes, the core user journey works.
@@ -297,19 +297,8 @@ def test_e2e_status_shows_check_marks_for_synced(e2e_project):
 
 
 # ---------------------------------------------------------------------------
-# Step 7 — warehouse status and delta shim behavior
+# Step 7 — warehouse status reports clean and modified working trees
 # ---------------------------------------------------------------------------
-
-
-def test_e2e_delta_shim_redirects_to_warehouse_status(e2e_project):
-    project_dir, warehouse, runner = e2e_project
-    runner.invoke(main, ["warehouse", "connect", "--path", str(warehouse)])
-
-    result = runner.invoke(main, ["delta"])
-
-    assert result.exit_code == 1
-    assert "has been removed" in result.output
-    assert "warehouse status" in result.output
 
 
 def test_e2e_warehouse_status_clean(e2e_project):
@@ -405,28 +394,10 @@ def test_e2e_delta_skill_detects_live_modification(e2e_project):
     assert "skills/code-review/SKILL.md" in result.output
 
 
-def test_e2e_delta_skill_snapshot_identical_but_live_modified(e2e_project):
-    """abc delta now redirects users to abc warehouse status."""
+def test_e2e_sync_auto_prune_and_upstream_pull(e2e_project):
+    """Sync auto-prune drops removed artifacts; subsequent sync pulls upstream changes."""
     project_dir, warehouse, runner = e2e_project
     runner.invoke(main, ["warehouse", "connect", "--path", str(warehouse)])
-
-    result = runner.invoke(main, ["delta"])
-
-    assert result.exit_code == 1
-    assert "has been removed" in result.output
-    assert "warehouse status" in result.output
-
-
-def test_e2e_delta_skill_per_agent_detail_in_output(e2e_project):
-    """abc delta no longer exposes per-agent live-dir detail and redirects instead."""
-    project_dir, warehouse, runner = e2e_project
-    runner.invoke(main, ["warehouse", "connect", "--path", str(warehouse)])
-
-    result = runner.invoke(main, ["delta"])
-
-    assert result.exit_code == 1
-    assert "has been removed" in result.output
-    assert "warehouse status" in result.output
 
     # ---------------------------------------------------------------------------
     # Step 9 — sync auto-prune removes artifacts dropped from beacon.yaml
@@ -473,7 +444,7 @@ def test_e2e_delta_skill_per_agent_detail_in_output(e2e_project):
     assert kept.exists()
 
     # ---------------------------------------------------------------------------
-    # Step 10 — update pulls in an upstream warehouse change
+    # Step 10 — sync pulls in an upstream warehouse change (symlink resolves to new content)
     # ---------------------------------------------------------------------------
 
     beacon_yaml = project_dir / ".agentic-beacon" / "beacon.yaml"
@@ -486,11 +457,6 @@ def test_e2e_delta_skill_per_agent_detail_in_output(e2e_project):
     standards = warehouse / "contexts" / "python" / "standards.md"
     standards.write_text(standards.read_text() + "- No bare excepts\n")
 
-    result = runner.invoke(main, ["update"])
-
-    assert result.exit_code == 0
-    assert result.exit_code == 0  # deprecated abc update still works
-
     synced = (
         project_dir
         / ".agentic-beacon"
@@ -499,6 +465,7 @@ def test_e2e_delta_skill_per_agent_detail_in_output(e2e_project):
         / "python"
         / "standards.md"
     )
+    # Symlink-based sync — the warehouse edit is visible immediately, no re-sync needed.
     assert "No bare excepts" in synced.read_text()
 
     # ---------------------------------------------------------------------------
@@ -549,30 +516,6 @@ def test_e2e_contribute_skill_live_modification_goes_to_warehouse(e2e_project):
     assert "Local Guardrail" in warehouse_skill.read_text()
 
 
-def test_e2e_contribute_skill_regression_stale_snapshot(e2e_project):
-    """Old abc contribute redirects users to abc warehouse contribute."""
-    project_dir, warehouse, runner = e2e_project
-    runner.invoke(main, ["warehouse", "connect", "--path", str(warehouse)])
-
-    result = runner.invoke(main, ["contribute"])
-
-    assert result.exit_code == 1
-    assert "has been removed" in result.output
-    assert "warehouse contribute" in result.output
-
-
-def test_e2e_contribute_all_skill_live_modification(e2e_project):
-    """Old fileless abc contribute also redirects users to abc warehouse contribute."""
-    project_dir, warehouse, runner = e2e_project
-    runner.invoke(main, ["warehouse", "connect", "--path", str(warehouse)])
-
-    result = runner.invoke(main, ["contribute"])
-
-    assert result.exit_code == 1
-    assert "has been removed" in result.output
-    assert "warehouse contribute" in result.output
-
-
 def test_e2e_contribute_skill_identical_live_is_noop(e2e_project):
     """abc warehouse contribute reports nothing to contribute when live matches warehouse."""
     project_dir, warehouse, runner = e2e_project
@@ -591,14 +534,3 @@ def test_e2e_contribute_skill_identical_live_is_noop(e2e_project):
 
     assert result.exit_code == 0
     assert "no uncommitted changes to contribute" in result.output.lower()
-
-
-def test_e2e_contribute_skill_multi_agent_conflict_prompts(e2e_project):
-    """Old abc contribute shim redirects users to abc warehouse contribute."""
-    project_dir, warehouse, runner = e2e_project
-    runner.invoke(main, ["warehouse", "connect", "--path", str(warehouse)])
-    result = runner.invoke(main, ["contribute"])
-
-    assert result.exit_code == 1
-    assert "has been removed" in result.output
-    assert "warehouse contribute" in result.output

--- a/libs/beacon/tests/integration/test_symlink_e2e.py
+++ b/libs/beacon/tests/integration/test_symlink_e2e.py
@@ -164,22 +164,3 @@ class TestCrossProjectSingleSourceOfTruth:
             check=True,
         )
         assert "Cross-project edit" in log.stdout
-
-
-def test_install_shim_redirects_to_beacon_yaml(e2e_warehouse, tmp_path, monkeypatch):
-    """abc install exits 1 and points users at beacon.yaml + abc sync."""
-    project_dir = tmp_path / "project"
-    project_dir.mkdir()
-    monkeypatch.chdir(project_dir)
-
-    runner = CliRunner()
-    connect_result = runner.invoke(
-        main, ["warehouse", "connect", "--path", str(e2e_warehouse)]
-    )
-    assert connect_result.exit_code == 0
-
-    result = runner.invoke(main, ["install", "foo"])
-
-    assert result.exit_code == 1
-    assert "has been removed" in result.output
-    assert "beacon.yaml" in result.output

--- a/libs/beacon/tests/integration/test_sync_wiring.py
+++ b/libs/beacon/tests/integration/test_sync_wiring.py
@@ -17,8 +17,6 @@ import pytest
 from beacon.cli.main import main
 from beacon.domains.artifact.agent import update_agent_gitignores
 from beacon.domains.artifact.skill import (
-    _install_skill_claudecode,
-    _install_skill_opencode,
     normalize_skill_entry,
     skill_name_from_entry,
     wire_single_skill,
@@ -355,80 +353,6 @@ def test_update_agent_gitignores_appends_to_existing_gitignore(tmp_path):
     content = (claude_dir / ".gitignore").read_text()
     assert "settings.local.json" in content
     assert "skills/" in content
-
-
-# ---------------------------------------------------------------------------
-# Unit tests: _install_skill_opencode / _install_skill_claudecode
-# ---------------------------------------------------------------------------
-
-
-def test_install_skill_opencode_returns_true_on_first_install(tmp_path):
-    changed = _install_skill_opencode(
-        tmp_path, "my-skill", SAMPLE_SKILL_MD, "A test skill"
-    )
-
-    assert changed is True
-    assert (tmp_path / ".opencode" / "skills" / "my-skill" / "SKILL.md").exists()
-    assert (tmp_path / ".opencode" / "command" / "my-skill.md").exists()
-
-
-def test_install_skill_opencode_returns_false_when_unchanged(tmp_path):
-    _install_skill_opencode(tmp_path, "my-skill", SAMPLE_SKILL_MD, "A test skill")
-    changed = _install_skill_opencode(
-        tmp_path, "my-skill", SAMPLE_SKILL_MD, "A test skill"
-    )
-
-    assert changed is False
-
-
-def test_install_skill_opencode_returns_true_when_content_changes(tmp_path):
-    _install_skill_opencode(tmp_path, "my-skill", SAMPLE_SKILL_MD, "A test skill")
-    changed = _install_skill_opencode(
-        tmp_path, "my-skill", SAMPLE_SKILL_MD + "\n## Extra\n", "A test skill"
-    )
-
-    assert changed is True
-
-
-def test_install_skill_opencode_updates_file_content_when_changed(tmp_path):
-    _install_skill_opencode(tmp_path, "my-skill", SAMPLE_SKILL_MD, "A test skill")
-    new_content = SAMPLE_SKILL_MD + "\n## Extra\n"
-    _install_skill_opencode(tmp_path, "my-skill", new_content, "A test skill")
-
-    skill_file = tmp_path / ".opencode" / "skills" / "my-skill" / "SKILL.md"
-    assert skill_file.read_text() == new_content
-
-
-def test_install_skill_claudecode_returns_true_on_first_install(tmp_path):
-    changed = _install_skill_claudecode(tmp_path, "my-skill", SAMPLE_SKILL_MD)
-
-    assert changed is True
-    assert (tmp_path / ".claude" / "skills" / "my-skill" / "SKILL.md").exists()
-
-
-def test_install_skill_claudecode_returns_false_when_unchanged(tmp_path):
-    _install_skill_claudecode(tmp_path, "my-skill", SAMPLE_SKILL_MD)
-    changed = _install_skill_claudecode(tmp_path, "my-skill", SAMPLE_SKILL_MD)
-
-    assert changed is False
-
-
-def test_install_skill_claudecode_returns_true_when_content_changes(tmp_path):
-    _install_skill_claudecode(tmp_path, "my-skill", SAMPLE_SKILL_MD)
-    changed = _install_skill_claudecode(
-        tmp_path, "my-skill", SAMPLE_SKILL_MD + "\n## Extra\n"
-    )
-
-    assert changed is True
-
-
-def test_install_skill_claudecode_updates_file_content_when_changed(tmp_path):
-    _install_skill_claudecode(tmp_path, "my-skill", SAMPLE_SKILL_MD)
-    new_content = SAMPLE_SKILL_MD + "\n## Extra\n"
-    _install_skill_claudecode(tmp_path, "my-skill", new_content)
-
-    skill_file = tmp_path / ".claude" / "skills" / "my-skill" / "SKILL.md"
-    assert skill_file.read_text() == new_content
 
 
 # ---------------------------------------------------------------------------

--- a/libs/beacon/tests/unit/cli/test_sync_agents_from_warehouse.py
+++ b/libs/beacon/tests/unit/cli/test_sync_agents_from_warehouse.py
@@ -43,13 +43,15 @@ def test_fresh_machine_creates_both_global_dirs(
     claude_dest = fake_home / ".claude" / "agents" / "code-reviewer.md"
     opencode_dest = fake_home / ".config" / "opencode" / "agents" / "code-reviewer.md"
     assert claude_dest.is_symlink()
-    assert claude_dest.resolve() == (
-        warehouse_with_agent / "agents" / "code-reviewer.md"
-    ).resolve()
+    assert (
+        claude_dest.resolve()
+        == (warehouse_with_agent / "agents" / "code-reviewer.md").resolve()
+    )
     assert opencode_dest.is_symlink()
-    assert opencode_dest.resolve() == (
-        warehouse_with_agent / "agents" / "code-reviewer.md"
-    ).resolve()
+    assert (
+        opencode_dest.resolve()
+        == (warehouse_with_agent / "agents" / "code-reviewer.md").resolve()
+    )
 
 
 def test_fresh_machine_prints_warning(fake_home, warehouse_with_agent, capsys):
@@ -99,9 +101,7 @@ def test_warehouse_without_agents_dir_returns_silently(fake_home, tmp_path, caps
     assert "No agent tools detected" not in out
 
 
-def test_warehouse_with_empty_agents_dir_returns_silently(
-    fake_home, tmp_path, capsys
-):
+def test_warehouse_with_empty_agents_dir_returns_silently(fake_home, tmp_path, capsys):
     """agents/ dir present but no *.md files → no-op, no fallback warning."""
     wh = tmp_path / "warehouse"
     (wh / "agents").mkdir(parents=True)

--- a/libs/beacon/tests/unit/cli/test_sync_agents_from_warehouse.py
+++ b/libs/beacon/tests/unit/cli/test_sync_agents_from_warehouse.py
@@ -1,0 +1,112 @@
+"""Tests for sync_agents_from_warehouse() — covers PER-112 fresh-machine fallback."""
+
+from pathlib import Path
+
+import pytest
+from beacon.domains.artifact.agent import sync_agents_from_warehouse
+
+AGENT_CONTENT = """\
+---
+name: code-reviewer
+description: Reviews code changes
+---
+# Code Reviewer Agent
+"""
+
+
+@pytest.fixture
+def fake_home(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: home))
+    return home
+
+
+@pytest.fixture
+def warehouse_with_agent(tmp_path):
+    wh = tmp_path / "warehouse"
+    (wh / "agents").mkdir(parents=True)
+    (wh / "agents" / "code-reviewer.md").write_text(AGENT_CONTENT)
+    return wh
+
+
+def test_fresh_machine_creates_both_global_dirs(
+    fake_home, warehouse_with_agent, capsys
+):
+    """PER-112: when neither ~/.claude nor ~/.config/opencode exists, sync still
+    installs to both canonical paths instead of silently no-op'ing."""
+    assert not (fake_home / ".claude").exists()
+    assert not (fake_home / ".config" / "opencode").exists()
+
+    sync_agents_from_warehouse(warehouse_with_agent, force=True)
+
+    claude_dest = fake_home / ".claude" / "agents" / "code-reviewer.md"
+    opencode_dest = fake_home / ".config" / "opencode" / "agents" / "code-reviewer.md"
+    assert claude_dest.is_symlink()
+    assert claude_dest.resolve() == (
+        warehouse_with_agent / "agents" / "code-reviewer.md"
+    ).resolve()
+    assert opencode_dest.is_symlink()
+    assert opencode_dest.resolve() == (
+        warehouse_with_agent / "agents" / "code-reviewer.md"
+    ).resolve()
+
+
+def test_fresh_machine_prints_warning(fake_home, warehouse_with_agent, capsys):
+    """User must see why both dirs were created — silent fallback is a regression."""
+    sync_agents_from_warehouse(warehouse_with_agent, force=True)
+
+    out = capsys.readouterr().out
+    assert "No agent tools detected" in out
+
+
+def test_only_claude_dir_present_installs_only_to_claude(
+    fake_home, warehouse_with_agent
+):
+    """When ~/.claude exists but ~/.config/opencode does not, install only to claudecode."""
+    (fake_home / ".claude").mkdir()
+
+    sync_agents_from_warehouse(warehouse_with_agent, force=True)
+
+    claude_dest = fake_home / ".claude" / "agents" / "code-reviewer.md"
+    opencode_dest = fake_home / ".config" / "opencode" / "agents" / "code-reviewer.md"
+    assert claude_dest.is_symlink()
+    assert not opencode_dest.exists()
+
+
+def test_only_opencode_dir_present_installs_only_to_opencode(
+    fake_home, warehouse_with_agent
+):
+    """When ~/.config/opencode exists but ~/.claude does not, install only to opencode."""
+    (fake_home / ".config" / "opencode").mkdir(parents=True)
+
+    sync_agents_from_warehouse(warehouse_with_agent, force=True)
+
+    claude_dest = fake_home / ".claude" / "agents" / "code-reviewer.md"
+    opencode_dest = fake_home / ".config" / "opencode" / "agents" / "code-reviewer.md"
+    assert opencode_dest.is_symlink()
+    assert not claude_dest.exists()
+
+
+def test_warehouse_without_agents_dir_returns_silently(fake_home, tmp_path, capsys):
+    """No warehouse agents/ dir → no-op, no fallback warning."""
+    wh = tmp_path / "empty-warehouse"
+    wh.mkdir()
+
+    sync_agents_from_warehouse(wh, force=True)
+
+    out = capsys.readouterr().out
+    assert "No agent tools detected" not in out
+
+
+def test_warehouse_with_empty_agents_dir_returns_silently(
+    fake_home, tmp_path, capsys
+):
+    """agents/ dir present but no *.md files → no-op, no fallback warning."""
+    wh = tmp_path / "warehouse"
+    (wh / "agents").mkdir(parents=True)
+
+    sync_agents_from_warehouse(wh, force=True)
+
+    out = capsys.readouterr().out
+    assert "No agent tools detected" not in out

--- a/site-docs/reference/cli.md
+++ b/site-docs/reference/cli.md
@@ -314,13 +314,15 @@ Overwrites all symlinks from the warehouse, discarding any local modifications.
 
 ## Removed Commands
 
-The following commands have been removed in v3. Their stubs remain with migration guidance:
+The following commands have been removed. If you are upgrading from a pre-v3
+release, replace any scripted invocations with the modern equivalents below:
 
 | Removed | Replacement |
 |---------|-------------|
 | `abc delta` | `abc warehouse status` |
 | `abc contribute` | `abc warehouse contribute -m "message"` |
-| `abc install <artifact>` | Edit `beacon.yaml` manually, then `abc sync` |
+| `abc install <artifact>` | Edit `beacon.yaml`, then `abc sync` |
+| `abc update` | `abc sync` (or `abc reset` to force-overwrite) |
 
 ---
 

--- a/site-docs/troubleshooting.md
+++ b/site-docs/troubleshooting.md
@@ -34,6 +34,7 @@ Removed commands and their replacements:
 | `abc delta` | `abc warehouse status` |
 | `abc contribute` | `abc warehouse contribute -m "message"` |
 | `abc install <artifact>` | Edit `beacon.yaml`, then `abc sync` |
+| `abc update` | `abc sync` (or `abc reset` to force-overwrite) |
 | `abc sync --preserve` | `abc sync --contribute-local` or `--discard-local` |
 | `abc setup --manual` | `abc setup` (no flags needed) |
 | `abc setup --agent-assisted` | `abc setup` (no flags needed) |


### PR DESCRIPTION
## Summary

CLI / domain audit cleanup, scoped to the safe deletions identified in the audit:

- **Tombstones removed.** `abc contribute`, `abc delta`, `abc install`, and the hidden deprecated `abc update` are gone. Pre-v3 users get a clean Click *"no such command"* error; the migration tables in `site-docs/reference/cli.md` and `site-docs/troubleshooting.md` now document `abc update → abc sync` alongside the existing entries.
- **Dead helpers removed.** Nine unused functions across `domains/artifact/{agent,skill}.py` (`handle_install_agent`, `build_agents_paths`, `find_project_level_agents`, `find_global_untracked_skills`, `_migrate_beacon_yaml_skill_entries`, `update_beacon_yaml`, `_install_skill_opencode`, `_install_skill_claudecode`, `print_skill_next_steps`) and their orphaned imports.
- **Stale hint fixed.** `list_global_agents` was telling users to run `abc install agents/<name>.md`; it now suggests `abc agents sync`.
- **Tests updated.** Removed integration tests that asserted tombstone redirects (`test_e2e_delta_*`, `test_e2e_contribute_*` redirect tests, `test_install_shim_redirects_to_beacon_yaml`, `test_install_skill_{opencode,claudecode}_*`); rewrote the `update` step in the happy-path e2e to assert symlink-immediate visibility instead.

Net diff: **-508 LoC**, top-level CLI commands **14 → 11**.

The audit also identified a third bucket of *UX consolidations* (merge `setup` into `warehouse connect`, flatten the `abc agents` single-child group, and consolidate `status` vs `doctor`). Those are deliberately **not** in this PR — they'll be planned via an OpenSpec change first.

## Test plan

- [x] \`pytest libs/beacon/tests\` — 986 passed, 8 skipped
- [x] \`ruff check\` / \`ruff format\` clean
- [x] \`abc --help\` lists exactly the 11 expected commands; \`abc update\`, \`abc contribute\`, \`abc delta\`, \`abc install\` all return Click "No such command"
- [ ] Smoke run on a real warehouse-connected project (\`abc sync\`, \`abc agents sync\`, \`abc adopt\`)