### PR TITLE
fix(beacon): write per-tool .gitignore skills/ entry on dir existence (PER-136)

### DIFF
--- a/libs/beacon/src/beacon/domains/distribution/orchestrator.py
+++ b/libs/beacon/src/beacon/domains/distribution/orchestrator.py
@@ -499,13 +499,16 @@ def run_sync(
             force=force,
             skill_conflict_callback=skill_conflict_callback,
         )
-        # Write per-tool gitignore entries for skill directories
-        claude_dir = project_root / ".claude"
-        if claude_dir.is_dir():
-            GitignoreManager(claude_dir).ensure_entries(["skills/"])
-        opencode_dir = project_root / ".opencode"
-        if opencode_dir.is_dir():
-            GitignoreManager(opencode_dir).ensure_entries(["skills/", "command/"])
+
+    # Per-tool gitignore entries — gated on directory existence only (PER-136).
+    # Restores pre-PR-113 behaviour: any project with .claude/ or .opencode/
+    # gets tool-managed skills/ (and command/) subdirs ignored from VCS.
+    claude_dir = project_root / ".claude"
+    if claude_dir.is_dir():
+        GitignoreManager(claude_dir).ensure_entries(["skills/"])
+    opencode_dir = project_root / ".opencode"
+    if opencode_dir.is_dir():
+        GitignoreManager(opencode_dir).ensure_entries(["skills/", "command/"])
 
     # PER-113: gate on declared agents so contexts-only or skills-only projects
     # don't dirty their .gitignore with unused agent dir entries.

--- a/libs/beacon/src/beacon/domains/distribution/orchestrator.py
+++ b/libs/beacon/src/beacon/domains/distribution/orchestrator.py
@@ -503,12 +503,15 @@ def run_sync(
     # Per-tool gitignore entries — gated on directory existence only (PER-136).
     # Restores pre-PR-113 behaviour: any project with .claude/ or .opencode/
     # gets tool-managed skills/ (and command/) subdirs ignored from VCS.
-    claude_dir = project_root / ".claude"
-    if claude_dir.is_dir():
-        GitignoreManager(claude_dir).ensure_entries(["skills/"])
-    opencode_dir = project_root / ".opencode"
-    if opencode_dir.is_dir():
-        GitignoreManager(opencode_dir).ensure_entries(["skills/", "command/"])
+    # Wrapped in `if not dry_run:` to match the rest of run_sync — no
+    # mutations during dry-run.
+    if not dry_run:
+        claude_dir = project_root / ".claude"
+        if claude_dir.is_dir():
+            GitignoreManager(claude_dir).ensure_entries(["skills/"])
+        opencode_dir = project_root / ".opencode"
+        if opencode_dir.is_dir():
+            GitignoreManager(opencode_dir).ensure_entries(["skills/", "command/"])
 
     # PER-113: gate on declared agents so contexts-only or skills-only projects
     # don't dirty their .gitignore with unused agent dir entries.

--- a/libs/beacon/tests/integration/test_agent_sync_lifecycle.py
+++ b/libs/beacon/tests/integration/test_agent_sync_lifecycle.py
@@ -383,6 +383,50 @@ def test_sync_with_no_skills_declared_writes_skill_gitignore_entries(
     )
 
 
+def test_sync_dry_run_does_not_write_skill_gitignore_entries(
+    project_dir: Path, warehouse: Path, monkeypatch
+):
+    """A `sync --dry-run` MUST NOT write per-tool skill .gitignore entries.
+
+    Regression guard for PER-136 review Finding 1: when the per-tool gitignore
+    writes were hoisted out of `if has_skills:`, they lost the implicit `not
+    dry_run` gate that came from `has_skills = bool(effective_set.skills) and
+    not dry_run`. Every other mutation in run_sync is gated on `not dry_run`;
+    this test ensures the hoisted block stays consistent with that contract.
+    """
+    runner = CliRunner()
+    monkeypatch.chdir(project_dir)
+
+    # Arrange
+    beacon_yaml = project_dir / ".agentic-beacon" / "beacon.yaml"
+    beacon_yaml.write_text("artifacts:\n  contexts: []\n  skills: []\n  agents: []\n")
+
+    claude_dir = project_dir / ".claude"
+    claude_dir.mkdir(exist_ok=True)
+    opencode_dir = project_dir / ".opencode"
+    opencode_dir.mkdir(exist_ok=True)
+
+    # Wipe any pre-existing per-tool .gitignore files so we can detect mutation.
+    claude_gitignore = claude_dir / ".gitignore"
+    opencode_gitignore = opencode_dir / ".gitignore"
+    claude_gitignore.unlink(missing_ok=True)
+    opencode_gitignore.unlink(missing_ok=True)
+
+    # Act
+    r = runner.invoke(main, ["sync", "--dry-run", "--skip-git-check"])
+    assert r.exit_code == 0, f"sync --dry-run failed: {r.output}"
+
+    # Assert — neither file should exist after a dry-run
+    assert not claude_gitignore.exists(), (
+        f".claude/.gitignore must NOT be created by --dry-run: "
+        f"{claude_gitignore.read_text() if claude_gitignore.exists() else ''!r}"
+    )
+    assert not opencode_gitignore.exists(), (
+        f".opencode/.gitignore must NOT be created by --dry-run: "
+        f"{opencode_gitignore.read_text() if opencode_gitignore.exists() else ''!r}"
+    )
+
+
 def test_sync_unwires_removed_agent(project_dir: Path, warehouse: Path, monkeypatch):
     """Removing an agent from beacon.yaml and re-syncing removes all three paths.
 

--- a/libs/beacon/tests/integration/test_agent_sync_lifecycle.py
+++ b/libs/beacon/tests/integration/test_agent_sync_lifecycle.py
@@ -334,6 +334,55 @@ def test_sync_with_no_agents_declared_does_not_mutate_gitignore(
     )
 
 
+def test_sync_with_no_skills_declared_writes_skill_gitignore_entries(
+    project_dir: Path, warehouse: Path, monkeypatch
+):
+    """A sync with zero declared skills MUST still write skills/ gitignore entries.
+
+    Regression guard for PER-136: the per-tool .gitignore writes for skills/
+    and command/ were gated inside `if has_skills:` after PR #109, meaning
+    projects with no declared skills never got those entries even when .claude/
+    or .opencode/ directories existed. This test confirms the fix — entries
+    are written on directory existence alone.
+    """
+    runner = CliRunner()
+    monkeypatch.chdir(project_dir)
+
+    # Arrange
+    beacon_yaml = project_dir / ".agentic-beacon" / "beacon.yaml"
+    beacon_yaml.write_text("artifacts:\n  contexts: []\n  skills: []\n  agents: []\n")
+
+    claude_dir = project_dir / ".claude"
+    claude_dir.mkdir(exist_ok=True)
+    opencode_dir = project_dir / ".opencode"
+    opencode_dir.mkdir(exist_ok=True)
+
+    # Remove any pre-existing per-tool .gitignore files so the assertion detects
+    # that sync wrote them rather than that they already existed.
+    claude_gitignore = claude_dir / ".gitignore"
+    opencode_gitignore = opencode_dir / ".gitignore"
+    claude_gitignore.unlink(missing_ok=True)
+    opencode_gitignore.unlink(missing_ok=True)
+
+    # Act
+    r = runner.invoke(main, ["sync", "--skip-git-check"])
+    assert r.exit_code == 0, f"sync failed: {r.output}"
+
+    # Assert
+    assert claude_gitignore.exists(), ".claude/.gitignore must be created by sync"
+    assert "skills/" in claude_gitignore.read_text(), (
+        f".claude/.gitignore must contain 'skills/' entry: {claude_gitignore.read_text()!r}"
+    )
+    assert opencode_gitignore.exists(), ".opencode/.gitignore must be created by sync"
+    opencode_content = opencode_gitignore.read_text()
+    assert "skills/" in opencode_content, (
+        f".opencode/.gitignore must contain 'skills/' entry: {opencode_content!r}"
+    )
+    assert "command/" in opencode_content, (
+        f".opencode/.gitignore must contain 'command/' entry: {opencode_content!r}"
+    )
+
+
 def test_sync_unwires_removed_agent(project_dir: Path, warehouse: Path, monkeypatch):
     """Removing an agent from beacon.yaml and re-syncing removes all three paths.
 


### PR DESCRIPTION
## Summary

Restores pre-PR-113 behaviour for per-tool `.gitignore` skill-entry writes in `distribution/orchestrator.py`. PR #109 inadvertently wrapped the writes for `.claude/.gitignore` (`skills/`) and `.opencode/.gitignore` (`skills/` + `command/`) inside `if has_skills:`, so projects with `.claude/` or `.opencode/` but no declared skills no longer got those tool-managed subdirs ignored.

This PR hoists the writes out of the `has_skills` gate so they fire on directory existence alone — matching the pre-PR-113 contract.

- Hoists 4 lines out of `if has_skills:` in `domains/distribution/orchestrator.py` (`wire_skills_post_sync(...)` correctly remains inside the gate)
- Adds regression test `test_sync_with_no_skills_declared_writes_skill_gitignore_entries` next to the existing `test_sync_with_no_agents_declared_does_not_mutate_gitignore`

Closes [PER-136](https://linear.app/personal-syk950527/issue/PER-136).

## Test plan

- [x] New regression test passes: `pytest tests/integration/test_agent_sync_lifecycle.py::test_sync_with_no_skills_declared_writes_skill_gitignore_entries -v`
- [x] Existing agent-side regression guard still passes: `test_sync_with_no_agents_declared_does_not_mutate_gitignore`
- [x] Full unit + integration suite: 1013 passed (7 pre-existing failures, all `git config user.email`-related test-fixture issues, identical on `main` — filed separately)
- [ ] CI green
- [ ] Manual verification: in a project with `.claude/` but `skills: []` in `beacon.yaml`, `abc sync` writes `.claude/.gitignore` containing `skills/`

## Out of scope

- Broader gitignore-management refactor — see PER-130 (`GitignoreManager` consolidation) and PER-138 (rename `update_agent_gitignores`).
- The 7 git-identity test-fixture failures observed during verification — should be filed as a separate Low-priority Bug.