### PR TITLE
fix(beacon): add transactional rollback to abc sync agent wiring (PER-131)

### DIFF
--- a/libs/beacon/src/beacon/domains/artifact/agent.py
+++ b/libs/beacon/src/beacon/domains/artifact/agent.py
@@ -81,3 +81,22 @@ def update_agent_gitignores(project_root: Path) -> None:
 
     new_content = existing_content + prefix + "\n".join(missing) + "\n"
     gitignore_path.write_text(new_content, encoding="utf-8")
+
+
+def snapshot_agent_path(p: Path) -> tuple[str, Path | None]:
+    """Snapshot a per-tool agent destination's pre-wire state.
+
+    Used by transactional wiring helpers (e.g. wire_agents_atomically in
+    domains/setup/wiring.py) to capture enough state to restore the
+    destination if a later wire step fails.
+
+    Returns:
+        ("symlink", current_target) — already-wired symlink, target captured.
+        ("regular_file", None)      — user-owned file at the destination.
+        ("missing", None)           — nothing there yet.
+    """
+    if p.is_symlink():
+        return ("symlink", p.readlink())
+    if p.exists():
+        return ("regular_file", None)
+    return ("missing", None)

--- a/libs/beacon/src/beacon/domains/distribution/orchestrator.py
+++ b/libs/beacon/src/beacon/domains/distribution/orchestrator.py
@@ -54,8 +54,7 @@ from beacon.domains.setup.wiring import (
     confirm_prune,
     has_synced_contexts,
     unwire_pruned_artifacts,
-    wire_agent_claudecode,
-    wire_agent_opencode,
+    wire_agents_atomically,
     wire_contexts_claudecode,
     wire_contexts_opencode,
 )
@@ -444,16 +443,15 @@ def run_sync(
     if summary.pruned_paths and not dry_run:
         unwire_pruned_artifacts(project_root, summary.pruned_paths, artifacts_dir)
 
-    # Wire declared agents into project-local tool directories
+    # Wire declared agents into project-local tool directories — atomic
+    # with rollback on partial failure (PER-131).
     if not dry_run:
         detected_tools = detect_agent_targets(project_root)
-        for agent_entry in beacon_settings.artifacts.agents:
-            # agent_entry is like "agents/spec-planner.md"
-            artifact_file = artifacts_dir / agent_entry
-            if "claudecode" in detected_tools:
-                wire_agent_claudecode(project_root, artifact_file)
-            if "opencode" in detected_tools:
-                wire_agent_opencode(project_root, artifact_file)
+        agent_artifact_files = [
+            artifacts_dir / agent_entry
+            for agent_entry in beacon_settings.artifacts.agents
+        ]
+        wire_agents_atomically(project_root, agent_artifact_files, detected_tools)
 
     # Use effective set for wiring decisions
     has_contexts = bool(effective_set.contexts) and not dry_run

--- a/libs/beacon/src/beacon/domains/setup/wiring.py
+++ b/libs/beacon/src/beacon/domains/setup/wiring.py
@@ -420,6 +420,91 @@ def wire_agent_opencode(project_root: Path, artifact_file: Path) -> Path:
     return dest
 
 
+def _snapshot_agent_path(p: Path) -> tuple[str, Path | None]:
+    """Snapshot a per-tool agent destination's pre-wire state.
+
+    Returns:
+        ("symlink", current_target) — already-wired symlink, target captured.
+        ("regular_file", None)      — user-owned file at the destination.
+        ("missing", None)           — nothing there yet.
+    """
+    if p.is_symlink():
+        return ("symlink", p.readlink())
+    if p.exists():
+        return ("regular_file", None)
+    return ("missing", None)
+
+
+def wire_agents_atomically(
+    project_root: Path,
+    agent_artifact_files: list[Path],
+    detected_tools: set[str],
+) -> None:
+    """Wire each agent into every detected tool with snapshot-based rollback.
+
+    For every (agent_artifact_file, tool) pair, snapshots the destination's
+    pre-wire state, then calls the tool-specific wire_agent_* helper. If any
+    wire raises, restores ALL previously-wired destinations to their pre-wire
+    state and re-raises the original exception.
+
+    Args:
+        project_root: Root of the project (where .claude/ / .opencode/ live).
+        agent_artifact_files: Resolved artifact symlink paths
+            (e.g. <project>/.agentic-beacon/artifacts/agents/spec-planner.md).
+        detected_tools: Set of tool keys detected for this project; subset
+            of {"claudecode", "opencode"}.
+
+    Raises:
+        Whatever `wire_agent_claudecode` / `wire_agent_opencode` raise
+        (typically BeaconSyncError) — re-raised AFTER rollback.
+
+    Note:
+        This helper covers ONLY the per-tool agent paths. It does not
+        rollback artifact symlinks under .agentic-beacon/artifacts/agents/
+        or any gitignore changes. Callers that need broader transactional
+        scope (see apply.commit_session) should compose this with their
+        own snapshot machinery in a future refactor.
+    """
+    snapshots: list[tuple[Path, str, Path | None]] = []
+
+    def _rollback() -> None:
+        for path, kind, prior_target in reversed(snapshots):
+            try:
+                if kind == "missing":
+                    if path.is_symlink() or path.exists():
+                        path.unlink()
+                elif kind == "symlink":
+                    if path.is_symlink():
+                        if path.readlink() != prior_target:
+                            path.unlink()
+                            path.symlink_to(prior_target)
+                    else:
+                        if path.exists():
+                            path.unlink()
+                        path.parent.mkdir(parents=True, exist_ok=True)
+                        path.symlink_to(prior_target)
+                # "regular_file" snapshots imply wire never succeeded for
+                # that path (the wire helpers refuse to overwrite regular
+                # files), so no restore is needed.
+            except OSError:
+                pass
+
+    try:
+        for artifact_file in agent_artifact_files:
+            leaf = artifact_file.name
+            if "claudecode" in detected_tools:
+                cc_dest = project_root / ".claude" / "agents" / leaf
+                snapshots.append((cc_dest, *_snapshot_agent_path(cc_dest)))
+                wire_agent_claudecode(project_root, artifact_file)
+            if "opencode" in detected_tools:
+                oc_dest = project_root / ".opencode" / "agents" / leaf
+                snapshots.append((oc_dest, *_snapshot_agent_path(oc_dest)))
+                wire_agent_opencode(project_root, artifact_file)
+    except Exception:
+        _rollback()
+        raise
+
+
 def unwire_agent(project_root: Path, agent_name: str) -> None:
     """Remove project-local agent symlinks for the given agent.
 

--- a/libs/beacon/src/beacon/domains/setup/wiring.py
+++ b/libs/beacon/src/beacon/domains/setup/wiring.py
@@ -2,6 +2,7 @@
 
 import json
 import shutil
+from collections.abc import Iterable
 from pathlib import Path
 
 import click
@@ -9,6 +10,7 @@ from loguru import logger
 from rich.console import Console
 
 from beacon.core.exceptions import BeaconSyncError
+from beacon.domains.artifact.agent import snapshot_agent_path
 
 console = Console()
 
@@ -420,25 +422,10 @@ def wire_agent_opencode(project_root: Path, artifact_file: Path) -> Path:
     return dest
 
 
-def _snapshot_agent_path(p: Path) -> tuple[str, Path | None]:
-    """Snapshot a per-tool agent destination's pre-wire state.
-
-    Returns:
-        ("symlink", current_target) — already-wired symlink, target captured.
-        ("regular_file", None)      — user-owned file at the destination.
-        ("missing", None)           — nothing there yet.
-    """
-    if p.is_symlink():
-        return ("symlink", p.readlink())
-    if p.exists():
-        return ("regular_file", None)
-    return ("missing", None)
-
-
 def wire_agents_atomically(
     project_root: Path,
     agent_artifact_files: list[Path],
-    detected_tools: set[str],
+    detected_tools: Iterable[str],
 ) -> None:
     """Wire each agent into every detected tool with snapshot-based rollback.
 
@@ -451,8 +438,10 @@ def wire_agents_atomically(
         project_root: Root of the project (where .claude/ / .opencode/ live).
         agent_artifact_files: Resolved artifact symlink paths
             (e.g. <project>/.agentic-beacon/artifacts/agents/spec-planner.md).
-        detected_tools: Set of tool keys detected for this project; subset
-            of {"claudecode", "opencode"}.
+        detected_tools: Iterable of tool keys detected for this project;
+            entries outside {"claudecode", "opencode"} are silently ignored
+            (forward-compat). Accepts list or set; in practice the orchestrator
+            passes the list returned by `detect_agent_targets`.
 
     Raises:
         Whatever `wire_agent_claudecode` / `wire_agent_opencode` raise
@@ -464,6 +453,17 @@ def wire_agents_atomically(
         or any gitignore changes. Callers that need broader transactional
         scope (see apply.commit_session) should compose this with their
         own snapshot machinery in a future refactor.
+
+        The internal _rollback closure is intentionally **best-effort** —
+        per-path OSError during restore is logged via loguru.warning and
+        swallowed so the original wire exception always surfaces to the
+        caller. This differs from apply.py's commit_session rollback,
+        which lets restore-step OSError propagate. Rationale: in the sync
+        orchestrator the user's primary signal is the original wire
+        failure (e.g. "regular file at .claude/agents/foo.md"); masking it
+        with a downstream rollback OSError would degrade UX. apply.py
+        operates at a tighter atomic boundary (single session commit) where
+        any partial restore is itself a correctness concern worth raising.
     """
     snapshots: list[tuple[Path, str, Path | None]] = []
 
@@ -503,11 +503,11 @@ def wire_agents_atomically(
             leaf = artifact_file.name
             if "claudecode" in detected_tools:
                 cc_dest = project_root / ".claude" / "agents" / leaf
-                snapshots.append((cc_dest, *_snapshot_agent_path(cc_dest)))
+                snapshots.append((cc_dest, *snapshot_agent_path(cc_dest)))
                 wire_agent_claudecode(project_root, artifact_file)
             if "opencode" in detected_tools:
                 oc_dest = project_root / ".opencode" / "agents" / leaf
-                snapshots.append((oc_dest, *_snapshot_agent_path(oc_dest)))
+                snapshots.append((oc_dest, *snapshot_agent_path(oc_dest)))
                 wire_agent_opencode(project_root, artifact_file)
     except Exception:
         _rollback()

--- a/libs/beacon/src/beacon/domains/setup/wiring.py
+++ b/libs/beacon/src/beacon/domains/setup/wiring.py
@@ -486,8 +486,17 @@ def wire_agents_atomically(
                 # "regular_file" snapshots imply wire never succeeded for
                 # that path (the wire helpers refuse to overwrite regular
                 # files), so no restore is needed.
-            except OSError:
-                pass
+            except OSError as e:
+                logger.warning(
+                    "wire_agents_atomically: rollback step failed for "
+                    "{} (kind={}, prior_target={}): {}. "
+                    "Continuing with remaining snapshots; "
+                    "post-failure state may be partially restored.",
+                    path,
+                    kind,
+                    prior_target,
+                    e,
+                )
 
     try:
         for artifact_file in agent_artifact_files:

--- a/libs/beacon/tests/integration/test_agent_sync_lifecycle.py
+++ b/libs/beacon/tests/integration/test_agent_sync_lifecycle.py
@@ -535,3 +535,80 @@ def test_sync_rollback_when_agent_wire_fails(
     assert (project_dir / ".claude" / "agents" / "agent-b.md").read_text() == (
         "user content"
     ), "user-owned regular file must be preserved"
+
+
+def test_sync_rollback_when_agent_wire_fails_dual_tool(
+    project_dir: Path, warehouse: Path, monkeypatch
+):
+    """Dual-tool variant of the rollback regression guard.
+
+    When BOTH .claude/ and .opencode/ exist, wire_agents_atomically takes
+    two snapshots per agent (one per tool). The rollback must reverse all
+    snapshots, not just one tool's. This test exercises the path where
+    spec-planner is fully wired into BOTH tools before agent-b's opencode
+    wire fails — both spec-planner destinations must be rolled back.
+    """
+    runner = CliRunner()
+    monkeypatch.chdir(project_dir)
+
+    # Add a second agent to the warehouse.
+    (warehouse / "agents" / "agent-b.md").write_text(
+        "---\nname: agent-b\n---\n# Agent B\n"
+    )
+    manifest_path = warehouse / "agents" / "agents.yaml"
+    manifest = yaml.safe_load(manifest_path.read_text()) or {}
+    manifest["agent-b"] = {"skills": []}
+    manifest_path.write_text(yaml.safe_dump(manifest))
+    _git_add_commit(warehouse, "add agent-b")
+
+    # Ensure BOTH tool dirs exist so detect_agent_targets returns both.
+    (project_dir / ".opencode").mkdir(exist_ok=True)
+
+    # Plant a regular file at agent-b's .opencode destination — this is the
+    # LAST wire in the helper's loop (claudecode runs first per agent), so
+    # spec-planner is fully wired into BOTH tools AND agent-b's claudecode
+    # wire succeeds before the opencode wire on agent-b fails. Rollback
+    # must restore three previously-wired destinations.
+    (project_dir / ".opencode" / "agents").mkdir(parents=True, exist_ok=True)
+    (project_dir / ".opencode" / "agents" / "agent-b.md").write_text("user content")
+
+    beacon_yaml = project_dir / ".agentic-beacon" / "beacon.yaml"
+    beacon_yaml.write_text(
+        "artifacts:\n"
+        "  contexts: []\n"
+        "  skills: []\n"
+        "  agents:\n"
+        "    - agents/spec-planner.md\n"
+        "    - agents/agent-b.md\n"
+    )
+
+    # Act: sync must fail due to the regular-file blocker on agent-b's .opencode.
+    r = runner.invoke(main, ["sync", "--skip-git-check"])
+    assert r.exit_code != 0, (
+        f"sync should have failed but exited {r.exit_code}: {r.output}"
+    )
+
+    # Assert: spec-planner's BOTH destinations were rolled back.
+    cc_a = project_dir / ".claude" / "agents" / "spec-planner.md"
+    oc_a = project_dir / ".opencode" / "agents" / "spec-planner.md"
+    assert not cc_a.exists() and not cc_a.is_symlink(), (
+        f".claude/agents/spec-planner.md must be rolled back; "
+        f"still present: {cc_a.is_symlink()=}, {cc_a.exists()=}"
+    )
+    assert not oc_a.exists() and not oc_a.is_symlink(), (
+        f".opencode/agents/spec-planner.md must be rolled back; "
+        f"still present: {oc_a.is_symlink()=}, {oc_a.exists()=}"
+    )
+
+    # Assert: agent-b's .claude wire was rolled back (it succeeded before
+    # the opencode failure).
+    cc_b = project_dir / ".claude" / "agents" / "agent-b.md"
+    assert not cc_b.exists() and not cc_b.is_symlink(), (
+        f".claude/agents/agent-b.md must be rolled back; "
+        f"still present: {cc_b.is_symlink()=}, {cc_b.exists()=}"
+    )
+
+    # The user's regular file at agent-b's .opencode dest must be UNTOUCHED.
+    assert (project_dir / ".opencode" / "agents" / "agent-b.md").read_text() == (
+        "user content"
+    ), "user-owned regular file must be preserved"

--- a/libs/beacon/tests/integration/test_agent_sync_lifecycle.py
+++ b/libs/beacon/tests/integration/test_agent_sync_lifecycle.py
@@ -470,3 +470,68 @@ def test_sync_unwires_removed_agent(project_dir: Path, warehouse: Path, monkeypa
     assert not claude_link.exists() and not claude_link.is_symlink(), (
         ".claude/agents symlink must be removed when agent is pruned"
     )
+
+
+# ---------------------------------------------------------------------------
+# PER-131: rollback when agent wire fails mid-sync
+# ---------------------------------------------------------------------------
+
+
+def test_sync_rollback_when_agent_wire_fails(
+    project_dir: Path, warehouse: Path, monkeypatch
+):
+    """A wire failure mid-sync rolls back successfully-wired agent symlinks.
+
+    Regression guard for PER-131: wire_agent_claudecode / wire_agent_opencode
+    can raise BeaconSyncError (e.g., regular file at destination per the
+    round-5 user-owned-content policy). Without rollback, the project ends up
+    half-wired. The wire_agents_atomically helper must restore all wired
+    destinations to their pre-wire state before re-raising.
+    """
+    runner = CliRunner()
+    monkeypatch.chdir(project_dir)
+
+    # Add a second agent to the warehouse so we have two to wire.
+    (warehouse / "agents" / "agent-b.md").write_text(
+        "---\nname: agent-b\n---\n# Agent B\n"
+    )
+    manifest_path = warehouse / "agents" / "agents.yaml"
+    manifest = yaml.safe_load(manifest_path.read_text()) or {}
+    manifest["agent-b"] = {"skills": []}
+    manifest_path.write_text(yaml.safe_dump(manifest))
+    _git_add_commit(warehouse, "add agent-b")
+
+    # Plant a regular file at agent-b's .claude destination so the second
+    # agent's claudecode wire raises BeaconSyncError (user-owned-content
+    # policy). agent-a's .claude wire must have already succeeded by then;
+    # rollback must remove it.
+    (project_dir / ".claude" / "agents").mkdir(parents=True, exist_ok=True)
+    (project_dir / ".claude" / "agents" / "agent-b.md").write_text("user content")
+
+    beacon_yaml = project_dir / ".agentic-beacon" / "beacon.yaml"
+    beacon_yaml.write_text(
+        "artifacts:\n"
+        "  contexts: []\n"
+        "  skills: []\n"
+        "  agents:\n"
+        "    - agents/spec-planner.md\n"
+        "    - agents/agent-b.md\n"
+    )
+
+    # Act: sync must fail due to the regular-file blocker on agent-b.
+    r = runner.invoke(main, ["sync", "--skip-git-check"])
+    assert r.exit_code != 0, (
+        f"sync should have failed but exited {r.exit_code}: {r.output}"
+    )
+
+    # Assert: spec-planner's .claude destination was rolled back.
+    cc_a = project_dir / ".claude" / "agents" / "spec-planner.md"
+    assert not cc_a.exists() and not cc_a.is_symlink(), (
+        f".claude/agents/spec-planner.md must be rolled back; "
+        f"still present: {cc_a.is_symlink()=}, {cc_a.exists()=}"
+    )
+
+    # The user's regular file at agent-b's .claude dest must be UNTOUCHED.
+    assert (project_dir / ".claude" / "agents" / "agent-b.md").read_text() == (
+        "user content"
+    ), "user-owned regular file must be preserved"

--- a/libs/beacon/tests/unit/test_wire_agents.py
+++ b/libs/beacon/tests/unit/test_wire_agents.py
@@ -6,12 +6,15 @@ Covers TC1-TC5 from tasks 1.1, TC1-TC3 from task 1.2, and TC1-TC4 from task 1.3.
 from pathlib import Path
 
 import pytest
+from beacon.core.exceptions import BeaconSyncError
 from beacon.domains.setup.wiring import (
+    _snapshot_agent_path,
     unwire_agent,
     unwire_agent_with_undo,
     unwire_pruned_artifacts,
     wire_agent_claudecode,
     wire_agent_opencode,
+    wire_agents_atomically,
 )
 
 # ---------------------------------------------------------------------------
@@ -365,3 +368,192 @@ def test_wire_agent_opencode_refuses_to_overwrite_regular_file(tmp_path):
         wire_agent_opencode(tmp_path, artifact_file)
     assert "regular file" in str(exc.value)
     assert target.read_text() == "user-authored content"
+
+
+# ---------------------------------------------------------------------------
+# _snapshot_agent_path (PER-131)
+# ---------------------------------------------------------------------------
+
+
+class TestSnapshotAgentPath:
+    def test_missing_returns_missing_none(self, tmp_path):
+        """Path that does not exist → ('missing', None)."""
+        p = tmp_path / "nope.md"
+        assert _snapshot_agent_path(p) == ("missing", None)
+
+    def test_regular_file_returns_regular_file_none(self, tmp_path):
+        """Regular file at path → ('regular_file', None)."""
+        p = tmp_path / "file.md"
+        p.write_text("user content")
+        assert _snapshot_agent_path(p) == ("regular_file", None)
+
+    def test_symlink_returns_symlink_with_target(self, tmp_path):
+        """Symlink at path → ('symlink', target). Target captured even if dangling."""
+        target = tmp_path / "target.md"
+        target.write_text("artifact content")
+        link = tmp_path / "link.md"
+        link.symlink_to(target)
+
+        kind, captured = _snapshot_agent_path(link)
+        assert kind == "symlink"
+        assert captured == target
+
+    def test_dangling_symlink_returns_symlink_with_target(self, tmp_path):
+        """Dangling symlink (target deleted) still snapshots as ('symlink', target)."""
+        target = tmp_path / "ghost.md"
+        link = tmp_path / "link.md"
+        link.symlink_to(target)
+        # target never created — symlink is dangling
+
+        kind, captured = _snapshot_agent_path(link)
+        assert kind == "symlink"
+        assert captured == target
+
+
+# ---------------------------------------------------------------------------
+# wire_agents_atomically (PER-131)
+# ---------------------------------------------------------------------------
+
+
+def _make_artifact(base: Path, name: str, content: str = "x") -> Path:
+    """Create an artifact file under base/agents/ and return its Path."""
+    artifact = base / "agents" / name
+    artifact.parent.mkdir(parents=True, exist_ok=True)
+    artifact.write_text(content)
+    return artifact
+
+
+class TestWireAgentsAtomically:
+    def test_empty_list_is_noop(self, tmp_path):
+        """No agents → helper returns without touching anything."""
+        project = tmp_path / "proj"
+        project.mkdir()
+
+        wire_agents_atomically(project, [], {"claudecode", "opencode"})
+
+        # No directories should have been created by the helper itself.
+        assert not (project / ".claude" / "agents").exists()
+        assert not (project / ".opencode" / "agents").exists()
+
+    def test_happy_path_single_tool(self, tmp_path):
+        """One agent, one tool, missing dest → wired symlink."""
+        project = tmp_path / "proj"
+        project.mkdir()
+        artifact = _make_artifact(tmp_path / "warehouse", "spec-planner.md")
+
+        wire_agents_atomically(project, [artifact], {"claudecode"})
+
+        dest = project / ".claude" / "agents" / "spec-planner.md"
+        assert dest.is_symlink()
+        assert dest.readlink() == artifact
+
+    def test_happy_path_dual_tool(self, tmp_path):
+        """One agent, both tools detected → wired in both."""
+        project = tmp_path / "proj"
+        project.mkdir()
+        artifact = _make_artifact(tmp_path / "warehouse", "spec-planner.md")
+
+        wire_agents_atomically(project, [artifact], {"claudecode", "opencode"})
+
+        for tool in (".claude", ".opencode"):
+            dest = project / tool / "agents" / "spec-planner.md"
+            assert dest.is_symlink(), f"{dest} must be a symlink"
+            assert dest.readlink() == artifact
+
+    def test_rollback_unwires_when_second_agent_fails(self, tmp_path):
+        """First agent wires; second raises → first is unwired (rollback)."""
+        project = tmp_path / "proj"
+        project.mkdir()
+
+        artifact_a = _make_artifact(tmp_path / "warehouse", "agent-a.md")
+        artifact_b = _make_artifact(tmp_path / "warehouse", "agent-b.md")
+
+        # Plant a regular-file blocker at agent-b's claudecode dest so the
+        # SECOND wire_agent_claudecode call raises BeaconSyncError.
+        blocker = project / ".claude" / "agents" / "agent-b.md"
+        blocker.parent.mkdir(parents=True, exist_ok=True)
+        blocker.write_text("user content")
+
+        with pytest.raises(BeaconSyncError):
+            wire_agents_atomically(project, [artifact_a, artifact_b], {"claudecode"})
+
+        # agent-a's destination must be rolled back (no symlink left).
+        dest_a = project / ".claude" / "agents" / "agent-a.md"
+        assert not dest_a.is_symlink() and not dest_a.exists()
+
+        # User's regular file at agent-b's dest must be untouched.
+        assert blocker.read_text() == "user content"
+
+    def test_rollback_restores_prior_symlink_target(self, tmp_path):
+        """Pre-existing symlink at dest → wire replaces → rollback restores prior target.
+
+        This exercises the 'symlink' branch of _rollback that the missing→wired
+        integration tests don't cover.
+        """
+        project = tmp_path / "proj"
+        project.mkdir()
+
+        # Pre-existing symlink at agent-a's dest → /tmp/.../old-target
+        old_target = tmp_path / "old-target.md"
+        old_target.write_text("old content")
+        dest_a = project / ".claude" / "agents" / "agent-a.md"
+        dest_a.parent.mkdir(parents=True, exist_ok=True)
+        dest_a.symlink_to(old_target)
+
+        # New artifact-a (different from old_target) — wire will replace.
+        artifact_a = _make_artifact(tmp_path / "warehouse", "agent-a.md", "new")
+        artifact_b = _make_artifact(tmp_path / "warehouse", "agent-b.md")
+
+        # Blocker on agent-b's claudecode dest → second wire raises.
+        blocker = project / ".claude" / "agents" / "agent-b.md"
+        blocker.write_text("user content")
+
+        with pytest.raises(BeaconSyncError):
+            wire_agents_atomically(project, [artifact_a, artifact_b], {"claudecode"})
+
+        # agent-a's dest must be restored to point at old_target, NOT artifact_a.
+        assert dest_a.is_symlink(), "agent-a dest must remain a symlink"
+        assert dest_a.readlink() == old_target, (
+            f"agent-a must be restored to old-target; "
+            f"current readlink={dest_a.readlink()}"
+        )
+
+    def test_rollback_preserves_user_regular_file(self, tmp_path):
+        """A regular-file snapshot is recorded but rollback must not touch it.
+
+        The wire helpers refuse to overwrite regular files, so the wire never
+        succeeded for that path and rollback's regular_file branch is a no-op.
+        """
+        project = tmp_path / "proj"
+        project.mkdir()
+
+        # User-owned regular file at the very FIRST destination — wire fails
+        # immediately.
+        dest = project / ".claude" / "agents" / "agent-a.md"
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_text("user content")
+
+        artifact_a = _make_artifact(tmp_path / "warehouse", "agent-a.md")
+
+        with pytest.raises(BeaconSyncError):
+            wire_agents_atomically(project, [artifact_a], {"claudecode"})
+
+        # User's file is preserved verbatim.
+        assert dest.read_text() == "user content"
+        assert not dest.is_symlink()
+
+    def test_unknown_tool_in_detected_set_is_ignored(self, tmp_path):
+        """Tool keys not in {'claudecode', 'opencode'} are silently ignored.
+
+        Forward-compat guard: future tool additions must be opt-in via explicit
+        if-branches in the helper, not via the detected_tools set alone.
+        """
+        project = tmp_path / "proj"
+        project.mkdir()
+        artifact = _make_artifact(tmp_path / "warehouse", "spec-planner.md")
+
+        wire_agents_atomically(project, [artifact], {"claudecode", "future-tool"})
+
+        # Only claudecode wired; future-tool was ignored.
+        assert (project / ".claude" / "agents" / "spec-planner.md").is_symlink()
+        assert not (project / ".future-tool").exists()

--- a/libs/beacon/tests/unit/test_wire_agents.py
+++ b/libs/beacon/tests/unit/test_wire_agents.py
@@ -7,8 +7,8 @@ from pathlib import Path
 
 import pytest
 from beacon.core.exceptions import BeaconSyncError
+from beacon.domains.artifact.agent import snapshot_agent_path
 from beacon.domains.setup.wiring import (
-    _snapshot_agent_path,
     unwire_agent,
     unwire_agent_with_undo,
     unwire_pruned_artifacts,
@@ -371,7 +371,7 @@ def test_wire_agent_opencode_refuses_to_overwrite_regular_file(tmp_path):
 
 
 # ---------------------------------------------------------------------------
-# _snapshot_agent_path (PER-131)
+# snapshot_agent_path (PER-131)
 # ---------------------------------------------------------------------------
 
 
@@ -379,13 +379,13 @@ class TestSnapshotAgentPath:
     def test_missing_returns_missing_none(self, tmp_path):
         """Path that does not exist → ('missing', None)."""
         p = tmp_path / "nope.md"
-        assert _snapshot_agent_path(p) == ("missing", None)
+        assert snapshot_agent_path(p) == ("missing", None)
 
     def test_regular_file_returns_regular_file_none(self, tmp_path):
         """Regular file at path → ('regular_file', None)."""
         p = tmp_path / "file.md"
         p.write_text("user content")
-        assert _snapshot_agent_path(p) == ("regular_file", None)
+        assert snapshot_agent_path(p) == ("regular_file", None)
 
     def test_symlink_returns_symlink_with_target(self, tmp_path):
         """Symlink at path → ('symlink', target). Target captured even if dangling."""
@@ -394,7 +394,7 @@ class TestSnapshotAgentPath:
         link = tmp_path / "link.md"
         link.symlink_to(target)
 
-        kind, captured = _snapshot_agent_path(link)
+        kind, captured = snapshot_agent_path(link)
         assert kind == "symlink"
         assert captured == target
 
@@ -405,7 +405,7 @@ class TestSnapshotAgentPath:
         link.symlink_to(target)
         # target never created — symlink is dangling
 
-        kind, captured = _snapshot_agent_path(link)
+        kind, captured = snapshot_agent_path(link)
         assert kind == "symlink"
         assert captured == target
 


### PR DESCRIPTION
## Summary

Closes a HIGH-severity correctness gap from PR #109 round-7 review: `wire_agent_claudecode` / `wire_agent_opencode` can raise `BeaconSyncError` (e.g., regular file at the destination per the round-5 user-owned-content policy). Without rollback, partial wiring left the project in an inconsistent state — artifact symlinks created, tool symlinks half-installed.

`apply.commit_session` has had transactional rollback since round 4; the sync orchestrator did not.

- Adds `wire_agents_atomically()` in `domains/setup/wiring.py` with snapshot-based rollback. Mirrors the `_snapshot_path` / `_rollback` pattern in `apply.py:_default_post_sync_wiring`.
- Replaces the inline wire loop in `distribution/orchestrator.py` with a single call to the new helper.
- Adds integration regression test `test_sync_rollback_when_agent_wire_fails`. Plants a regular-file blocker at agent-b's `.claude` destination and asserts that spec-planner's wire is rolled back when agent-b's wire fails.

`apply.py` is intentionally NOT migrated — its existing rollback is part of a broader *session* rollback (beacon.yaml + pending.yaml + artifact symlinks + tool snapshots) and refactoring it risks regressions in the adopt flow. The new helper's docstring documents this so a future migration ticket has a starting point.

Closes [PER-131](https://linear.app/personal-syk950527/issue/PER-131).

## Test plan

- [x] `test_sync_rollback_when_agent_wire_fails` passes (red-without-fix verified — without rollback, spec-planner stays wired after agent-b failure).
- [x] All 10 tests in `test_agent_sync_lifecycle.py` pass.
- [x] Acceptance grep: `wire_agent_claudecode|wire_agent_opencode` returns 0 matches in `orchestrator.py`.
- [x] Same 7 pre-existing git-identity test-fixture failures as on \`main\` — unchanged.
- [x] `abc --version` loads cleanly.
- [x] Implicit-gate check: `if not dry_run:` preserved around the new `wire_agents_atomically(...)` call (no dry-run regression).
- [ ] CI green
- [ ] opencode-review bot clean

## Out of scope

- Migrating `apply.py` to use `wire_agents_atomically` (separate cleanup ticket).
- Refactoring the broader sync pipeline transaction model (artifact symlinks, prune, etc.).
- Changing the round-5 user-owned-content refusal policy.