### PR TITLE
refactor(beacon): use GitignoreManager for agent-dir entries + prune when empty (PER-130)

### DIFF
--- a/libs/beacon/src/beacon/cli/warehouse.py
+++ b/libs/beacon/src/beacon/cli/warehouse.py
@@ -11,7 +11,6 @@ from rich.table import Table
 
 from beacon.core.gitignore import GitignoreManager
 from beacon.core.manifest.workspace import WorkspaceConfig
-from beacon.domains.artifact.agent import ensure_agent_dirs_gitignored
 from beacon.domains.distribution.distributor import WarehouseDistributor
 from beacon.domains.distribution.upgrader import WarehouseUpgrader
 from beacon.domains.setup.initializer import WarehouseInitializer, ensure_beacon_dir
@@ -265,7 +264,10 @@ def connect(*, path: Path | None) -> None:
         gitignore_mgr = GitignoreManager(Path.cwd())
         if gitignore_mgr.ensure_entries():
             console.print("[green]✓[/green] Updated .gitignore")
-        ensure_agent_dirs_gitignored(Path.cwd())
+        # PER-130 round-1 (LOW finding): agent-dir gitignore entries are NOT
+        # added during connect — `abc sync` is the authoritative gate, and
+        # adding them eagerly here churns the .gitignore for projects that
+        # will never declare agents.
 
         console.print("\n[bold green]✓ Connected to warehouse[/bold green]")
         console.print(f"  [blue]Location:[/blue] {warehouse_path}")

--- a/libs/beacon/src/beacon/cli/warehouse.py
+++ b/libs/beacon/src/beacon/cli/warehouse.py
@@ -11,7 +11,7 @@ from rich.table import Table
 
 from beacon.core.gitignore import GitignoreManager
 from beacon.core.manifest.workspace import WorkspaceConfig
-from beacon.domains.artifact.agent import update_agent_gitignores
+from beacon.domains.artifact.agent import ensure_agent_dirs_gitignored
 from beacon.domains.distribution.distributor import WarehouseDistributor
 from beacon.domains.distribution.upgrader import WarehouseUpgrader
 from beacon.domains.setup.initializer import WarehouseInitializer, ensure_beacon_dir
@@ -265,7 +265,7 @@ def connect(*, path: Path | None) -> None:
         gitignore_mgr = GitignoreManager(Path.cwd())
         if gitignore_mgr.ensure_entries():
             console.print("[green]✓[/green] Updated .gitignore")
-        update_agent_gitignores(Path.cwd())
+        ensure_agent_dirs_gitignored(Path.cwd())
 
         console.print("\n[bold green]✓ Connected to warehouse[/bold green]")
         console.print(f"  [blue]Location:[/blue] {warehouse_path}")

--- a/libs/beacon/src/beacon/core/gitignore.py
+++ b/libs/beacon/src/beacon/core/gitignore.py
@@ -96,6 +96,56 @@ class GitignoreManager:
 
         return True
 
+    def remove_entries(self, entries: list[str]) -> bool:
+        """Remove specific entries from .gitignore.
+
+        Reads the .gitignore, drops any line that exactly matches one of the
+        given entries, and writes the result back. The `# Agentic Beacon`
+        section header is preserved (other Beacon entries may still be using it).
+
+        Args:
+            entries: Lines to remove. Each is matched against `.gitignore`
+                lines via exact-string equality (after splitting on newlines).
+                Comments and unrelated entries are preserved.
+
+        Returns:
+            True if .gitignore was modified, False otherwise (file missing or
+            no matching entries).
+
+        Raises:
+            PermissionError: If cannot write to .gitignore.
+        """
+        if not self.gitignore_path.exists():
+            return False
+
+        existing_content = self.gitignore_path.read_text(encoding="utf-8")
+        existing_lines = existing_content.splitlines()
+        to_remove = set(entries)
+
+        filtered = [line for line in existing_lines if line not in to_remove]
+
+        if len(filtered) == len(existing_lines):
+            return False  # nothing matched
+
+        # Preserve trailing-newline state to match the original file's shape.
+        new_content = "\n".join(filtered)
+        if existing_content.endswith("\n") and filtered:
+            new_content += "\n"
+        elif not filtered:
+            new_content = ""
+
+        try:
+            self.gitignore_path.write_text(new_content, encoding="utf-8")
+            logger.debug(
+                "Removed {} entries from .gitignore: {}",
+                len(existing_lines) - len(filtered),
+                [line for line in existing_lines if line in to_remove],
+            )
+        except PermissionError as e:
+            raise PermissionError(f"Cannot write to {self.gitignore_path}: {e}") from e
+
+        return True
+
     def has_entry(self, entry: str) -> bool:
         """Check if a specific entry exists in .gitignore.
 

--- a/libs/beacon/src/beacon/domains/adoption/apply.py
+++ b/libs/beacon/src/beacon/domains/adoption/apply.py
@@ -252,7 +252,7 @@ def commit_session(
         if agent_candidates:
             from beacon.domains.artifact.agent import (
                 detect_agent_targets,
-                update_agent_gitignores,
+                ensure_agent_dirs_gitignored,
             )
             from beacon.domains.setup.wiring import (
                 wire_agent_claudecode,
@@ -275,7 +275,7 @@ def commit_session(
                     wire_agent_opencode(project_root, artifact_file)
 
             # PER-113 (Finding 2): ensure root .gitignore has agent dir entries
-            update_agent_gitignores(project_root)
+            ensure_agent_dirs_gitignored(project_root)
 
     post_sync_wiring_fn = _post_sync_wiring_fn or _default_post_sync_wiring
 

--- a/libs/beacon/src/beacon/domains/artifact/agent.py
+++ b/libs/beacon/src/beacon/domains/artifact/agent.py
@@ -2,6 +2,8 @@
 
 from pathlib import Path
 
+from beacon.core.gitignore import GitignoreManager
+
 _ALL_KNOWN_AGENTS = ["opencode", "claudecode"]
 
 
@@ -45,11 +47,13 @@ def detect_agent_targets(project_root: Path) -> list[str]:
     return targets
 
 
-def update_agent_gitignores(project_root: Path) -> None:
-    """Append .claude/agents/ and .opencode/agents/ entries to the project .gitignore.
+def ensure_agent_dirs_gitignored(project_root: Path) -> None:
+    """Ensure `.claude/agents/` and `.opencode/agents/` are in the project root .gitignore.
 
-    Idempotent: if the entries are already present they are not added again.
-    Creates the .gitignore file if it does not exist.
+    Idempotent. Creates the .gitignore file if it does not exist. Delegates
+    to `GitignoreManager.ensure_entries` so the agent-dir entries are
+    consistent with the rest of Beacon's gitignore management (skill dirs,
+    `.agentic-beacon/artifacts/`, etc.).
 
     Args:
         project_root: Project root directory (must be a directory).
@@ -60,27 +64,31 @@ def update_agent_gitignores(project_root: Path) -> None:
     if not project_root.is_dir():
         raise FileNotFoundError(f"project_root is not a directory: {project_root}")
 
-    gitignore_path = project_root / ".gitignore"
-    entries_to_add = [".claude/agents/", ".opencode/agents/"]
+    GitignoreManager(project_root).ensure_entries(
+        [".claude/agents/", ".opencode/agents/"]
+    )
 
-    if gitignore_path.exists():
-        existing_content = gitignore_path.read_text(encoding="utf-8")
-        existing_lines = set(existing_content.splitlines())
-    else:
-        existing_content = ""
-        existing_lines = set()
 
-    missing = [e for e in entries_to_add if e not in existing_lines]
-    if not missing:
-        return
+def prune_agent_dirs_gitignore_entries(project_root: Path) -> None:
+    """Remove `.claude/agents/` and `.opencode/agents/` entries from the project root .gitignore.
 
-    if existing_content and not existing_content.endswith("\n"):
-        prefix = "\n"
-    else:
-        prefix = ""
+    Used when all agents are removed from beacon.yaml — the entries are
+    pruned so the project's .gitignore stays in sync with the declared
+    artifact set. Idempotent: a no-op if .gitignore is missing or the
+    entries are not present.
 
-    new_content = existing_content + prefix + "\n".join(missing) + "\n"
-    gitignore_path.write_text(new_content, encoding="utf-8")
+    Args:
+        project_root: Project root directory (must be a directory).
+
+    Raises:
+        FileNotFoundError: If project_root is not a directory.
+    """
+    if not project_root.is_dir():
+        raise FileNotFoundError(f"project_root is not a directory: {project_root}")
+
+    GitignoreManager(project_root).remove_entries(
+        [".claude/agents/", ".opencode/agents/"]
+    )
 
 
 def snapshot_agent_path(p: Path) -> tuple[str, Path | None]:

--- a/libs/beacon/src/beacon/domains/distribution/orchestrator.py
+++ b/libs/beacon/src/beacon/domains/distribution/orchestrator.py
@@ -30,7 +30,8 @@ from beacon.core.manifest.beacon import BeaconManifest
 from beacon.domains.adoption.discovery import count_unadopted_since
 from beacon.domains.artifact.agent import (
     detect_agent_targets,
-    update_agent_gitignores,
+    ensure_agent_dirs_gitignored,
+    prune_agent_dirs_gitignore_entries,
 )
 from beacon.domains.artifact.skill import (
     install_bundled_skills_globally,
@@ -511,10 +512,13 @@ def run_sync(
         if opencode_dir.is_dir():
             GitignoreManager(opencode_dir).ensure_entries(["skills/", "command/"])
 
-    # PER-113: gate on declared agents so contexts-only or skills-only projects
-    # don't dirty their .gitignore with unused agent dir entries.
-    if not dry_run and beacon_settings.artifacts.agents:
-        update_agent_gitignores(project_root)
+    # PER-113 / PER-135: keep root .gitignore in sync with declared agents —
+    # ensure entries are present when agents are declared, pruned otherwise.
+    if not dry_run:
+        if beacon_settings.artifacts.agents:
+            ensure_agent_dirs_gitignored(project_root)
+        else:
+            prune_agent_dirs_gitignore_entries(project_root)
 
     if not dry_run:
         bundled_installed, bundled_skipped = install_bundled_skills_globally()

--- a/libs/beacon/tests/integration/test_agent_sync_lifecycle.py
+++ b/libs/beacon/tests/integration/test_agent_sync_lifecycle.py
@@ -302,7 +302,7 @@ def test_sync_with_no_agents_declared_does_not_mutate_gitignore(
 ):
     """A sync with zero declared agents must NOT add agent entries to .gitignore.
 
-    Regression guard for the round-5 over-correction where update_agent_gitignores
+    Regression guard for the round-5 over-correction where ensure_agent_dirs_gitignored
     was hoisted to run on every real sync, dirtying contexts-only and skills-only
     repos with unused .claude/agents/ / .opencode/agents/ entries.
     """
@@ -325,13 +325,50 @@ def test_sync_with_no_agents_declared_does_not_mutate_gitignore(
     post_state = gitignore_path.read_text()
     # The orchestrator's broader gitignore manager may append unrelated
     # .agentic-beacon/* entries; we only assert that THE AGENT-DIR entries
-    # weren't added, since update_agent_gitignores is the gated function.
+    # weren't added, since ensure_agent_dirs_gitignored is the gated function.
     assert ".claude/agents/" not in post_state, (
         f"sync with agents=[] must not add .claude/agents/ to .gitignore: {post_state!r}"
     )
     assert ".opencode/agents/" not in post_state, (
         f"sync with agents=[] must not add .opencode/agents/ to .gitignore: {post_state!r}"
     )
+
+
+def test_sync_with_emptied_agents_prunes_gitignore_entries(
+    project_dir: Path, warehouse: Path, monkeypatch
+):
+    """When agents are removed from beacon.yaml, the prior .gitignore entries are pruned.
+
+    Regression guard for PER-135: previously the .claude/agents/ and
+    .opencode/agents/ entries were never removed once added. Now the
+    orchestrator's prune-on-empty path removes them when artifacts.agents
+    becomes empty.
+    """
+    runner = CliRunner()
+    monkeypatch.chdir(project_dir)
+
+    # Pre-populate the .gitignore with the agent-dir entries (as if a prior
+    # sync with agents declared had added them).
+    gitignore_path = project_dir / ".gitignore"
+    gitignore_path.write_text(
+        "# Existing project content\n__pycache__/\n.claude/agents/\n.opencode/agents/\n"
+    )
+
+    beacon_yaml = project_dir / ".agentic-beacon" / "beacon.yaml"
+    beacon_yaml.write_text("artifacts:\n  contexts: []\n  skills: []\n  agents: []\n")
+
+    r = runner.invoke(main, ["sync", "--skip-git-check"])
+    assert r.exit_code == 0, f"sync failed: {r.output}"
+
+    post = gitignore_path.read_text()
+    assert ".claude/agents/" not in post, (
+        f"sync with agents=[] must prune .claude/agents/: {post!r}"
+    )
+    assert ".opencode/agents/" not in post, (
+        f"sync with agents=[] must prune .opencode/agents/: {post!r}"
+    )
+    # User's other content must be preserved.
+    assert "__pycache__/" in post, "pre-existing user entries must survive prune"
 
 
 def test_sync_with_no_skills_declared_writes_skill_gitignore_entries(

--- a/libs/beacon/tests/integration/test_sync_wiring.py
+++ b/libs/beacon/tests/integration/test_sync_wiring.py
@@ -15,7 +15,7 @@ from unittest.mock import patch
 
 import pytest
 from beacon.cli.main import main
-from beacon.domains.artifact.agent import update_agent_gitignores
+from beacon.domains.artifact.agent import ensure_agent_dirs_gitignored
 from beacon.domains.artifact.skill import (
     normalize_skill_entry,
     skill_name_from_entry,
@@ -308,44 +308,44 @@ def test_wire_skills_post_sync_reinstalls_when_content_changes(project_with_skil
 
 
 # ---------------------------------------------------------------------------
-# Unit tests: update_agent_gitignores
+# Unit tests: ensure_agent_dirs_gitignored
 # ---------------------------------------------------------------------------
 
 
-def test_update_agent_gitignores_creates_claude_gitignore(tmp_path):
-    """PER-113: update_agent_gitignores now writes to project root .gitignore."""
-    update_agent_gitignores(tmp_path)
+def test_ensure_agent_dirs_gitignored_creates_claude_gitignore(tmp_path):
+    """PER-113: ensure_agent_dirs_gitignored writes to project root .gitignore."""
+    ensure_agent_dirs_gitignored(tmp_path)
     content = (tmp_path / ".gitignore").read_text()
     assert ".claude/agents/" in content
 
 
-def test_update_agent_gitignores_creates_opencode_gitignore(tmp_path):
+def test_ensure_agent_dirs_gitignored_creates_opencode_gitignore(tmp_path):
     """PER-113: project .gitignore gets .opencode/agents/ entry."""
-    update_agent_gitignores(tmp_path)
+    ensure_agent_dirs_gitignored(tmp_path)
     content = (tmp_path / ".gitignore").read_text()
     assert ".opencode/agents/" in content
 
 
-def test_update_agent_gitignores_skips_when_no_agent_dirs(tmp_path):
-    """update_agent_gitignores always writes to project root .gitignore."""
-    update_agent_gitignores(tmp_path)
+def test_ensure_agent_dirs_gitignored_skips_when_no_agent_dirs(tmp_path):
+    """ensure_agent_dirs_gitignored always writes to project root .gitignore."""
+    ensure_agent_dirs_gitignored(tmp_path)
     # Now writes to root .gitignore regardless of whether .claude/ / .opencode/ exist
     assert (tmp_path / ".gitignore").exists()
 
 
-def test_update_agent_gitignores_idempotent(tmp_path):
-    """update_agent_gitignores is idempotent on repeated calls."""
-    update_agent_gitignores(tmp_path)
-    update_agent_gitignores(tmp_path)
+def test_ensure_agent_dirs_gitignored_idempotent(tmp_path):
+    """ensure_agent_dirs_gitignored is idempotent on repeated calls."""
+    ensure_agent_dirs_gitignored(tmp_path)
+    ensure_agent_dirs_gitignored(tmp_path)
     content = (tmp_path / ".gitignore").read_text()
     assert content.count(".claude/agents/") == 1
     assert content.count(".opencode/agents/") == 1
 
 
-def test_update_agent_gitignores_appends_to_existing_gitignore(tmp_path):
-    """update_agent_gitignores appends to an existing project .gitignore."""
+def test_ensure_agent_dirs_gitignored_appends_to_existing_gitignore(tmp_path):
+    """ensure_agent_dirs_gitignored appends to an existing project .gitignore."""
     (tmp_path / ".gitignore").write_text("settings.local.json\n")
-    update_agent_gitignores(tmp_path)
+    ensure_agent_dirs_gitignored(tmp_path)
     content = (tmp_path / ".gitignore").read_text()
     assert "settings.local.json" in content
     assert ".claude/agents/" in content

--- a/libs/beacon/tests/unit/test_agent_gitignore.py
+++ b/libs/beacon/tests/unit/test_agent_gitignore.py
@@ -1,21 +1,24 @@
-"""Unit tests for the repurposed update_agent_gitignores function.
+"""Unit tests for ensure_agent_dirs_gitignored and prune_agent_dirs_gitignore_entries.
 
 Covers TC1-TC5 from task 2.2.
 """
 
 import pytest
-from beacon.domains.artifact.agent import update_agent_gitignores
+from beacon.domains.artifact.agent import (
+    ensure_agent_dirs_gitignored,
+    prune_agent_dirs_gitignore_entries,
+)
 
 EXPECTED_ENTRIES = [".claude/agents/", ".opencode/agents/"]
 
 
-class TestUpdateAgentGitignores:
+class TestEnsureAgentDirsGitignored:
     def test_tc1_no_gitignore_creates_with_both_entries(self, tmp_path):
         """TC1: no .gitignore exists → file is created with both entries."""
         project = tmp_path / "proj"
         project.mkdir()
 
-        update_agent_gitignores(project)
+        ensure_agent_dirs_gitignored(project)
 
         gitignore = project / ".gitignore"
         assert gitignore.exists()
@@ -31,7 +34,7 @@ class TestUpdateAgentGitignores:
         original = "__pycache__/\n*.pyc\n"
         gitignore.write_text(original)
 
-        update_agent_gitignores(project)
+        ensure_agent_dirs_gitignored(project)
 
         content = gitignore.read_text()
         assert "__pycache__/" in content
@@ -46,7 +49,7 @@ class TestUpdateAgentGitignores:
         gitignore = project / ".gitignore"
         gitignore.write_text(".claude/agents/\n")
 
-        update_agent_gitignores(project)
+        ensure_agent_dirs_gitignored(project)
 
         content_lines = gitignore.read_text().splitlines()
         assert content_lines.count(".claude/agents/") == 1
@@ -60,7 +63,7 @@ class TestUpdateAgentGitignores:
         original = ".claude/agents/\n.opencode/agents/\n"
         gitignore.write_text(original)
 
-        update_agent_gitignores(project)
+        ensure_agent_dirs_gitignored(project)
 
         # File should be byte-identical
         assert gitignore.read_text() == original
@@ -75,17 +78,96 @@ class TestUpdateAgentGitignores:
         non_dir.write_text("I am a file")
 
         with pytest.raises(FileNotFoundError):
-            update_agent_gitignores(non_dir)
+            ensure_agent_dirs_gitignored(non_dir)
 
     def test_idempotent_multiple_calls(self, tmp_path):
-        """Calling update_agent_gitignores multiple times produces no duplicates."""
+        """Calling ensure_agent_dirs_gitignored multiple times produces no duplicates."""
         project = tmp_path / "proj"
         project.mkdir()
 
-        update_agent_gitignores(project)
-        update_agent_gitignores(project)
-        update_agent_gitignores(project)
+        ensure_agent_dirs_gitignored(project)
+        ensure_agent_dirs_gitignored(project)
+        ensure_agent_dirs_gitignored(project)
 
         content_lines = (project / ".gitignore").read_text().splitlines()
         assert content_lines.count(".claude/agents/") == 1
         assert content_lines.count(".opencode/agents/") == 1
+
+
+class TestPruneAgentDirsGitignoreEntries:
+    def test_tc1_missing_gitignore_no_op(self, tmp_path):
+        """TC1: .gitignore missing → no-op, no file created."""
+        project = tmp_path / "proj"
+        project.mkdir()
+
+        prune_agent_dirs_gitignore_entries(project)
+
+        assert not (project / ".gitignore").exists()
+
+    def test_tc2_both_entries_present_removes_them(self, tmp_path):
+        """TC2: gitignore exists with both entries → both removed, other lines preserved."""
+        project = tmp_path / "proj"
+        project.mkdir()
+        gitignore = project / ".gitignore"
+        gitignore.write_text(
+            "__pycache__/\n.claude/agents/\n.opencode/agents/\n*.pyc\n"
+        )
+
+        prune_agent_dirs_gitignore_entries(project)
+
+        content_lines = gitignore.read_text().splitlines()
+        assert ".claude/agents/" not in content_lines
+        assert ".opencode/agents/" not in content_lines
+        assert "__pycache__/" in content_lines
+        assert "*.pyc" in content_lines
+
+    def test_tc3_entries_absent_no_op(self, tmp_path):
+        """TC3: gitignore exists without the entries → no-op (no modification)."""
+        project = tmp_path / "proj"
+        project.mkdir()
+        gitignore = project / ".gitignore"
+        original = "*.pyc\n__pycache__/\n"
+        gitignore.write_text(original)
+
+        prune_agent_dirs_gitignore_entries(project)
+
+        assert gitignore.read_text() == original
+
+    def test_tc4_only_one_entry_present(self, tmp_path):
+        """TC4: only one of the two entries present → only that one is removed."""
+        project = tmp_path / "proj"
+        project.mkdir()
+        gitignore = project / ".gitignore"
+        gitignore.write_text("*.pyc\n.claude/agents/\n")
+
+        prune_agent_dirs_gitignore_entries(project)
+
+        content_lines = gitignore.read_text().splitlines()
+        assert ".claude/agents/" not in content_lines
+        assert ".opencode/agents/" not in content_lines
+        assert "*.pyc" in content_lines
+
+    def test_tc5_nonexistent_project_root_raises(self, tmp_path):
+        """TC5: project_root is not a directory → raises FileNotFoundError."""
+        non_dir = tmp_path / "not-a-dir.txt"
+        non_dir.write_text("I am a file")
+
+        with pytest.raises(FileNotFoundError):
+            prune_agent_dirs_gitignore_entries(non_dir)
+
+    def test_tc6_idempotent(self, tmp_path):
+        """TC6: pruning twice produces the same result as pruning once."""
+        project = tmp_path / "proj"
+        project.mkdir()
+        gitignore = project / ".gitignore"
+        gitignore.write_text("__pycache__/\n.claude/agents/\n.opencode/agents/\n")
+
+        prune_agent_dirs_gitignore_entries(project)
+        content_after_first = gitignore.read_text()
+
+        prune_agent_dirs_gitignore_entries(project)
+        content_after_second = gitignore.read_text()
+
+        assert content_after_first == content_after_second
+        assert ".claude/agents/" not in content_after_second
+        assert ".opencode/agents/" not in content_after_second

--- a/libs/beacon/tests/unit/test_gitignore_manager.py
+++ b/libs/beacon/tests/unit/test_gitignore_manager.py
@@ -1,0 +1,74 @@
+"""Unit tests for GitignoreManager.remove_entries."""
+
+from beacon.core.gitignore import GitignoreManager
+
+
+class TestRemoveEntries:
+    def test_remove_entries_no_file_returns_false(self, tmp_path):
+        """gitignore missing → returns False, no file created."""
+        mgr = GitignoreManager(tmp_path)
+        result = mgr.remove_entries([".claude/agents/"])
+        assert result is False
+        assert not (tmp_path / ".gitignore").exists()
+
+    def test_remove_entries_removes_only_matching_lines(self, tmp_path):
+        """Preserves comments and unmatched entries; removes only exact matches."""
+        gitignore = tmp_path / ".gitignore"
+        gitignore.write_text(
+            "# Agentic Beacon\n"
+            "__pycache__/\n"
+            ".claude/agents/\n"
+            ".opencode/agents/\n"
+            "*.pyc\n"
+        )
+        mgr = GitignoreManager(tmp_path)
+        result = mgr.remove_entries([".claude/agents/", ".opencode/agents/"])
+        assert result is True
+        lines = gitignore.read_text().splitlines()
+        assert ".claude/agents/" not in lines
+        assert ".opencode/agents/" not in lines
+        assert "# Agentic Beacon" in lines
+        assert "__pycache__/" in lines
+        assert "*.pyc" in lines
+
+    def test_remove_entries_idempotent(self, tmp_path):
+        """Running remove_entries twice produces the same result as once."""
+        gitignore = tmp_path / ".gitignore"
+        gitignore.write_text("__pycache__/\n.claude/agents/\n.opencode/agents/\n")
+        mgr = GitignoreManager(tmp_path)
+        mgr.remove_entries([".claude/agents/", ".opencode/agents/"])
+        content_first = gitignore.read_text()
+
+        result_second = mgr.remove_entries([".claude/agents/", ".opencode/agents/"])
+        assert result_second is False  # nothing to remove the second time
+        assert gitignore.read_text() == content_first
+
+    def test_remove_entries_preserves_trailing_newline_when_present(self, tmp_path):
+        """File with trailing newline keeps it after removal."""
+        gitignore = tmp_path / ".gitignore"
+        gitignore.write_text("__pycache__/\n.claude/agents/\n")
+        mgr = GitignoreManager(tmp_path)
+        mgr.remove_entries([".claude/agents/"])
+        content = gitignore.read_text()
+        assert content.endswith("\n")
+        assert "__pycache__/" in content
+
+    def test_remove_entries_no_trailing_newline_preserved(self, tmp_path):
+        """File without trailing newline does not gain one after removal."""
+        gitignore = tmp_path / ".gitignore"
+        gitignore.write_text("__pycache__/\n.claude/agents/")
+        mgr = GitignoreManager(tmp_path)
+        mgr.remove_entries([".claude/agents/"])
+        content = gitignore.read_text()
+        assert not content.endswith("\n")
+        assert "__pycache__/" in content
+
+    def test_remove_entries_no_match_returns_false(self, tmp_path):
+        """When no lines match, returns False and file is unchanged."""
+        gitignore = tmp_path / ".gitignore"
+        original = "*.pyc\n__pycache__/\n"
+        gitignore.write_text(original)
+        mgr = GitignoreManager(tmp_path)
+        result = mgr.remove_entries([".claude/agents/"])
+        assert result is False
+        assert gitignore.read_text() == original


### PR DESCRIPTION
## Summary

Single PR addressing three related Linear tickets that share the same function. Each is small on its own; together they make a coherent unit because they all touch `update_agent_gitignores`.

- **PER-130** (trunk): replace raw `.gitignore` read/write with `GitignoreManager.ensure_entries`. The agent-dir gitignore management is now consistent with the rest of Beacon's gitignore handling, including the `# Agentic Beacon` section header that `GitignoreManager` adds.
- **PER-138** (absorbed): rename `update_agent_gitignores` → `ensure_agent_dirs_gitignored` to reflect the post-PR-113 contract (writes to PROJECT ROOT `.gitignore`, not per-tool `.gitignore` files). 4 production call sites + ~25 test references updated.
- **PER-135** (absorbed): add `GitignoreManager.remove_entries` + new `prune_agent_dirs_gitignore_entries`. Wire in `orchestrator.py` so the entries are pruned when `artifacts.agents` becomes empty after a sync.

`apply.py` is rename-only — the adopt-time prune semantics ("if I unadopt the last agent, should beacon prune?") are a separate design question. The orchestrator's prune-on-empty handles the simple case (next sync after agents are gone from `beacon.yaml`).

Closes [PER-130](https://linear.app/personal-syk950527/issue/PER-130), [PER-138](https://linear.app/personal-syk950527/issue/PER-138), [PER-135](https://linear.app/personal-syk950527/issue/PER-135).

## Behaviour change

`GitignoreManager.ensure_entries` adds a `# Agentic Beacon` section header to the project root `.gitignore` (delegated from `update_agent_gitignores` → `ensure_agent_dirs_gitignored`). Existing tests pass — none asserted byte-identity outside the no-mutation TC4 case.

## Test plan

- [x] Acceptance grep `update_agent_gitignores`: 0 matches in `libs/beacon/`.
- [x] `test_agent_gitignore.py` (renamed `TestEnsureAgentDirsGitignored` + new `TestPruneAgentDirsGitignoreEntries`): 18 tests pass.
- [x] `test_sync_wiring.py` (renamed test functions): 72 tests pass.
- [x] `test_agent_sync_lifecycle.py` (new `test_sync_with_emptied_agents_prunes_gitignore_entries`): 7 tests pass; verified red-without-fix.
- [x] New `test_gitignore_manager.py` (`TestRemoveEntries`): 6 tests pass.
- [x] Full unit (753 passed, 5 pre-existing git-identity) + integration (281 passed, 2 pre-existing) — same 7 fixture failures as `main`, zero new.
- [x] `abc --version` + `sync --help` load cleanly.
- [x] Implicit-gate preserved: `if not dry_run:` wraps the new ensure/prune branch — no dry-run side-effect.
- [ ] CI green
- [ ] opencode-review bot clean

## Out of scope

- `apply.py` adopt-flow prune semantics (when agents are unadopted in the same session as removal).
- Migrating other gitignore-touching code paths.
- Adding new gitignore entries beyond the existing `.claude/agents/` and `.opencode/agents/`.