### PR TITLE
feat(beacon): structured regular-file-conflict UX for agent wiring (PER-127)

### DIFF
--- a/libs/beacon/src/beacon/cli/adoption.py
+++ b/libs/beacon/src/beacon/cli/adoption.py
@@ -161,9 +161,6 @@ def adopt(*, dry_run: bool) -> None:
             artifacts_path=artifacts_dir,
             beacon_yaml_path=beacon_yaml,
         )
-    except RegularFileConflictError as e:
-        console.print(format_regular_file_conflict(e.conflicts))
-        sys.exit(1)
     except CommitError as e:
         if isinstance(e.__cause__, RegularFileConflictError):
             console.print(format_regular_file_conflict(e.__cause__.conflicts))

--- a/libs/beacon/src/beacon/cli/adoption.py
+++ b/libs/beacon/src/beacon/cli/adoption.py
@@ -7,15 +7,17 @@ import click
 from rich.console import Console
 from rich.table import Table
 
+from beacon.core.exceptions import RegularFileConflictError
 from beacon.core.manifest.beacon import BeaconManifest
 from beacon.core.manifest.workspace import WorkspaceConfig
 from beacon.domains.adoption.apply import (
+    CommitError,
     cleanup_unadopted_artifacts,
     commit_session,
 )
 from beacon.domains.adoption.discovery import discover_adoptable, discover_pending
 from beacon.domains.adoption.tui import AdoptApp
-from beacon.utils.display import is_interactive
+from beacon.utils.display import format_regular_file_conflict, is_interactive
 from beacon.utils.git import find_project_root
 
 console = Console()
@@ -146,18 +148,28 @@ def adopt(*, dry_run: bool) -> None:
         console.print("[dim]No changes made.[/dim]")
         return
 
-    commit_session(
-        to_adopt=result.to_adopt,
-        to_unadopt=result.to_unadopt,
-        pending_accept=result.pending_accept,
-        pending_reject=result.pending_reject,
-        candidates=candidates,
-        pending_entries=pending_entries,
-        project_root=project_root,
-        warehouse_path=warehouse_path,
-        artifacts_path=artifacts_dir,
-        beacon_yaml_path=beacon_yaml,
-    )
+    try:
+        commit_session(
+            to_adopt=result.to_adopt,
+            to_unadopt=result.to_unadopt,
+            pending_accept=result.pending_accept,
+            pending_reject=result.pending_reject,
+            candidates=candidates,
+            pending_entries=pending_entries,
+            project_root=project_root,
+            warehouse_path=warehouse_path,
+            artifacts_path=artifacts_dir,
+            beacon_yaml_path=beacon_yaml,
+        )
+    except RegularFileConflictError as e:
+        console.print(format_regular_file_conflict(e.conflicts))
+        sys.exit(1)
+    except CommitError as e:
+        if isinstance(e.__cause__, RegularFileConflictError):
+            console.print(format_regular_file_conflict(e.__cause__.conflicts))
+        else:
+            console.print(f"[red]Error:[/red] {e}")
+        sys.exit(1)
 
     accepted_paths = result.to_adopt + result.pending_accept
     accepted_non_agents = [p for p in accepted_paths if not p.startswith("agents/")]

--- a/libs/beacon/src/beacon/cli/sync.py
+++ b/libs/beacon/src/beacon/cli/sync.py
@@ -7,7 +7,12 @@ import click
 from loguru import logger
 from rich.console import Console
 
-from beacon.core.exceptions import BeaconSyncError, DependencyError, ResetError
+from beacon.core.exceptions import (
+    BeaconSyncError,
+    DependencyError,
+    RegularFileConflictError,
+    ResetError,
+)
 from beacon.core.manifest.beacon import BeaconManifest
 from beacon.core.manifest.workspace import WorkspaceConfig
 from beacon.domains.artifact.skill import (
@@ -26,7 +31,7 @@ from beacon.domains.setup.wiring import (
     wire_contexts_claudecode,
     wire_contexts_opencode,
 )
-from beacon.utils.display import is_interactive
+from beacon.utils.display import format_regular_file_conflict, is_interactive
 from beacon.utils.git import find_project_root
 
 console = Console()
@@ -150,6 +155,9 @@ def sync(
         )
     except DependencyError as e:
         console.print(f"[red]Error:[/red] {e}")
+        sys.exit(1)
+    except RegularFileConflictError as e:
+        console.print(format_regular_file_conflict(e.conflicts))
         sys.exit(1)
     except BeaconSyncError as e:
         console.print(f"[red]Error:[/red] {e}")

--- a/libs/beacon/src/beacon/core/exceptions.py
+++ b/libs/beacon/src/beacon/core/exceptions.py
@@ -79,10 +79,11 @@ class RegularFileConflictError(BeaconSyncError):
         self.conflicts = tuple(conflicts)
         n = len(self.conflicts)
         s = "s" if n != 1 else ""
-        message = f"Cannot wire {n} agent{s}: regular file conflict."
+        message = f"Cannot wire {n} agent{s}: regular file conflict ({n} blocked destination{s})."
         hint = (
-            f"{n} regular file{s} block agent wiring. "
-            "Run abc sync or abc adopt to see a structured remediation guide."
+            "This error should normally be caught by the abc CLI and rendered as a "
+            "structured remediation guide. If you are seeing this raw exception, please "
+            "file a bug — the conflict list is available on `e.conflicts`."
         )
         super().__init__(message, hint=hint)
 

--- a/libs/beacon/src/beacon/core/exceptions.py
+++ b/libs/beacon/src/beacon/core/exceptions.py
@@ -1,5 +1,18 @@
 """Custom exceptions for Agentic Beacon."""
 
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class AgentWireConflict:
+    """Describes a single regular-file conflict blocking agent wiring."""
+
+    dest: Path
+    agent_name: str
+    tool: str
+
 
 class BeaconError(Exception):
     """Base class for all Beacon errors."""
@@ -55,6 +68,23 @@ class BeaconSyncError(BeaconError):
     def __init__(self, message: str, hint: str | None = None) -> None:
         super().__init__(message)
         self.hint = hint
+
+
+class RegularFileConflictError(BeaconSyncError):
+    """Raised when one or more agent destinations are regular (non-symlink) files."""
+
+    def __init__(self, conflicts: Sequence[AgentWireConflict]) -> None:
+        if not conflicts:
+            raise ValueError("RegularFileConflictError requires at least one conflict")
+        self.conflicts = tuple(conflicts)
+        n = len(self.conflicts)
+        s = "s" if n != 1 else ""
+        message = f"Cannot wire {n} agent{s}: regular file conflict."
+        hint = (
+            f"{n} regular file{s} block agent wiring. "
+            "Run abc sync or abc adopt to see a structured remediation guide."
+        )
+        super().__init__(message, hint=hint)
 
 
 class ContributeError(BeaconError):

--- a/libs/beacon/src/beacon/domains/setup/wiring.py
+++ b/libs/beacon/src/beacon/domains/setup/wiring.py
@@ -339,7 +339,8 @@ def wire_agent_claudecode(project_root: Path, artifact_file: Path) -> Path:
     The parent directory is created if it does not exist.
 
     A regular file at the destination is user-owned content. Beacon will not
-    overwrite it; a BeaconSyncError is raised with an actionable hint instead.
+    overwrite it; a RegularFileConflictError (BeaconSyncError subclass) is
+    raised with the conflicting destination attached.
 
     Args:
         project_root: Project root directory.
@@ -349,7 +350,8 @@ def wire_agent_claudecode(project_root: Path, artifact_file: Path) -> Path:
         Path to the created (or existing) symlink.
 
     Raises:
-        BeaconSyncError: If a regular file already exists at the destination.
+        RegularFileConflictError: If a regular file already exists at the
+            destination. Subclass of BeaconSyncError.
         OSError: If the parent directory cannot be created or the symlink
             cannot be written.
     """
@@ -387,7 +389,8 @@ def wire_agent_opencode(project_root: Path, artifact_file: Path) -> Path:
     The parent directory is created if it does not exist.
 
     A regular file at the destination is user-owned content. Beacon will not
-    overwrite it; a BeaconSyncError is raised with an actionable hint instead.
+    overwrite it; a RegularFileConflictError (BeaconSyncError subclass) is
+    raised with the conflicting destination attached.
 
     Args:
         project_root: Project root directory.
@@ -397,7 +400,8 @@ def wire_agent_opencode(project_root: Path, artifact_file: Path) -> Path:
         Path to the created (or existing) symlink.
 
     Raises:
-        BeaconSyncError: If a regular file already exists at the destination.
+        RegularFileConflictError: If a regular file already exists at the
+            destination. Subclass of BeaconSyncError.
         OSError: If the parent directory cannot be created or the symlink
             cannot be written.
     """
@@ -450,7 +454,7 @@ def wire_agents_atomically(
 
     Raises:
         Whatever `wire_agent_claudecode` / `wire_agent_opencode` raise
-        (typically BeaconSyncError) — re-raised AFTER rollback.
+        (typically RegularFileConflictError or BeaconSyncError) — re-raised AFTER rollback.
 
     Note:
         This helper covers ONLY the per-tool agent paths. It does not

--- a/libs/beacon/src/beacon/domains/setup/wiring.py
+++ b/libs/beacon/src/beacon/domains/setup/wiring.py
@@ -477,12 +477,15 @@ def wire_agents_atomically(
     # Pre-flight: collect ALL regular-file conflicts before touching anything.
     # Aborts with a structured error so the caller can present every blocked
     # destination in one pass rather than failing on the first one found.
+    # Use is_file() rather than exists() so a directory (or FIFO/socket) at the
+    # dest path is left to surface as a different error class — the rm/mv
+    # remediation commands shown in the conflict guide assume regular files.
     pre_conflicts: list[AgentWireConflict] = []
     for artifact_file in agent_artifact_files:
         leaf = artifact_file.name
         if "claudecode" in detected_tools:
             cc_dest = project_root / ".claude" / "agents" / leaf
-            if cc_dest.exists() and not cc_dest.is_symlink():
+            if cc_dest.is_file() and not cc_dest.is_symlink():
                 pre_conflicts.append(
                     AgentWireConflict(
                         dest=cc_dest,
@@ -492,7 +495,7 @@ def wire_agents_atomically(
                 )
         if "opencode" in detected_tools:
             oc_dest = project_root / ".opencode" / "agents" / leaf
-            if oc_dest.exists() and not oc_dest.is_symlink():
+            if oc_dest.is_file() and not oc_dest.is_symlink():
                 pre_conflicts.append(
                     AgentWireConflict(
                         dest=oc_dest,

--- a/libs/beacon/src/beacon/domains/setup/wiring.py
+++ b/libs/beacon/src/beacon/domains/setup/wiring.py
@@ -9,7 +9,10 @@ import click
 from loguru import logger
 from rich.console import Console
 
-from beacon.core.exceptions import BeaconSyncError
+from beacon.core.exceptions import (
+    AgentWireConflict,
+    RegularFileConflictError,
+)
 from beacon.domains.artifact.agent import snapshot_agent_path
 
 console = Console()
@@ -361,13 +364,14 @@ def wire_agent_claudecode(project_root: Path, artifact_file: Path) -> Path:
             pass
         dest.unlink()
     elif dest.exists():
-        raise BeaconSyncError(
-            f"Cannot wire agent: {dest} exists as a regular file (not a Beacon symlink).",
-            hint=(
-                f"Beacon will not overwrite user-authored content. "
-                f"Either remove or rename {dest}, or remove "
-                f"'agents/{artifact_file.stem}' from beacon.yaml.artifacts.agents."
-            ),
+        raise RegularFileConflictError(
+            conflicts=[
+                AgentWireConflict(
+                    dest=dest,
+                    agent_name=artifact_file.stem,
+                    tool="claudecode",
+                ),
+            ],
         )
 
     dest.symlink_to(artifact_file)
@@ -408,13 +412,14 @@ def wire_agent_opencode(project_root: Path, artifact_file: Path) -> Path:
             pass
         dest.unlink()
     elif dest.exists():
-        raise BeaconSyncError(
-            f"Cannot wire agent: {dest} exists as a regular file (not a Beacon symlink).",
-            hint=(
-                f"Beacon will not overwrite user-authored content. "
-                f"Either remove or rename {dest}, or remove "
-                f"'agents/{artifact_file.stem}' from beacon.yaml.artifacts.agents."
-            ),
+        raise RegularFileConflictError(
+            conflicts=[
+                AgentWireConflict(
+                    dest=dest,
+                    agent_name=artifact_file.stem,
+                    tool="opencode",
+                ),
+            ],
         )
 
     dest.symlink_to(artifact_file)
@@ -465,6 +470,35 @@ def wire_agents_atomically(
         operates at a tighter atomic boundary (single session commit) where
         any partial restore is itself a correctness concern worth raising.
     """
+    # Pre-flight: collect ALL regular-file conflicts before touching anything.
+    # Aborts with a structured error so the caller can present every blocked
+    # destination in one pass rather than failing on the first one found.
+    pre_conflicts: list[AgentWireConflict] = []
+    for artifact_file in agent_artifact_files:
+        leaf = artifact_file.name
+        if "claudecode" in detected_tools:
+            cc_dest = project_root / ".claude" / "agents" / leaf
+            if cc_dest.exists() and not cc_dest.is_symlink():
+                pre_conflicts.append(
+                    AgentWireConflict(
+                        dest=cc_dest,
+                        agent_name=artifact_file.stem,
+                        tool="claudecode",
+                    )
+                )
+        if "opencode" in detected_tools:
+            oc_dest = project_root / ".opencode" / "agents" / leaf
+            if oc_dest.exists() and not oc_dest.is_symlink():
+                pre_conflicts.append(
+                    AgentWireConflict(
+                        dest=oc_dest,
+                        agent_name=artifact_file.stem,
+                        tool="opencode",
+                    )
+                )
+    if pre_conflicts:
+        raise RegularFileConflictError(conflicts=pre_conflicts)
+
     snapshots: list[tuple[Path, str, Path | None]] = []
 
     def _rollback() -> None:

--- a/libs/beacon/src/beacon/utils/display.py
+++ b/libs/beacon/src/beacon/utils/display.py
@@ -1,6 +1,9 @@
 """Display utility functions for Beacon CLI."""
 
+import os
 import sys
+from collections.abc import Sequence
+from pathlib import Path
 
 from rich.console import Console
 
@@ -10,6 +13,47 @@ console = Console()
 def is_interactive() -> bool:
     """Return True if running in an interactive terminal."""
     return sys.stdin.isatty()
+
+
+def format_regular_file_conflict(conflicts: Sequence) -> str:
+    """Return a Rich-markup string listing all conflicting paths with remediation steps.
+
+    Each element must expose .dest (Path), .agent_name (str), .tool (str).
+    Pure function — no I/O, no side effects.
+    """
+
+    def _rel(dest: Path) -> Path:
+        try:
+            rel = Path(os.path.relpath(dest))
+            if str(rel).startswith(".."):
+                return dest
+            return rel
+        except ValueError:
+            return dest
+
+    n = len(conflicts)
+    s = "s" if n != 1 else ""
+    rel_dests = [_rel(c.dest) for c in conflicts]
+
+    lines: list[str] = [
+        f"[red]✗ Cannot wire {n} agent{s} (regular file conflict):[/red]",
+    ]
+    for rel in rel_dests:
+        lines.append(f"  • {rel} (project-local content)")
+
+    lines.append("")
+    lines.append("Resolution options (pick one):")
+    lines.append("  1) Remove the local file:")
+    for rel in rel_dests:
+        lines.append(f"       rm {rel}")
+    lines.append("  2) Back up and let Beacon manage it:")
+    for rel in rel_dests:
+        user_md = rel.parent / f"{rel.stem}.user.md"
+        lines.append(f"       mv {rel} {user_md}")
+    lines.append("  3) Drop the agent from beacon.yaml.artifacts.agents and re-run:")
+    lines.append("       abc adopt    # then 'reject' the listed agent(s)")
+
+    return "\n".join(lines)
 
 
 def print_doctor_summary(issues: list[str], fixes_applied: list[str]) -> None:

--- a/libs/beacon/tests/unit/cli/test_adoption_conflict.py
+++ b/libs/beacon/tests/unit/cli/test_adoption_conflict.py
@@ -69,5 +69,10 @@ def test_adopt_commit_error_with_regular_file_conflict_cause(tmp_path):
         result = runner.invoke(adopt)
 
     assert result.exit_code == 1
-    assert str(dest) in result.output or "spec-planner" in result.output
     assert "Cannot wire 1 agent" in result.output
+    # Rich wraps long paths at terminal width on CI (no TTY). Normalize whitespace
+    # before substring search so wrap-induced breaks don't split the path.
+    import re
+
+    flat = re.sub(r"\s+", "", result.output)
+    assert "spec-planner.md" in flat

--- a/libs/beacon/tests/unit/cli/test_adoption_conflict.py
+++ b/libs/beacon/tests/unit/cli/test_adoption_conflict.py
@@ -1,0 +1,73 @@
+"""Unit test for CommitError → RegularFileConflictError unwrap path in adopt CLI."""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from beacon.core.exceptions import AgentWireConflict, RegularFileConflictError
+from beacon.domains.adoption.apply import CommitError
+from click.testing import CliRunner
+
+
+def _make_commit_error_wrapping_conflict(dest: Path) -> CommitError:
+    conflict = AgentWireConflict(
+        dest=dest, agent_name="spec-planner", tool="claudecode"
+    )
+    cause = RegularFileConflictError(conflicts=[conflict])
+    err = CommitError("commit failed")
+    err.__cause__ = cause
+    return err
+
+
+def test_adopt_commit_error_with_regular_file_conflict_cause(tmp_path):
+    """adopt exits 1 and renders the conflict path when CommitError wraps RegularFileConflictError."""
+    from beacon.cli.adoption import adopt
+
+    dest = tmp_path / ".claude" / "agents" / "spec-planner.md"
+    commit_err = _make_commit_error_wrapping_conflict(dest)
+
+    # Create required dirs so the early existence checks pass
+    beacon_dir = tmp_path / ".agentic-beacon"
+    beacon_dir.mkdir(parents=True)
+    (beacon_dir / "beacon.yaml").write_text("")
+
+    # Build a fake candidate so the code doesn't short-circuit at "Nothing to adopt"
+    fake_candidate = MagicMock()
+    fake_candidate.artifact_type = "agent"
+    fake_candidate.path = "agents/spec-planner.md"
+    fake_candidate.description = "spec-planner agent"
+    fake_candidate.commits_ago = None
+
+    mock_result = MagicMock()
+    mock_result.to_adopt = ["agents/spec-planner.md"]
+    mock_result.to_unadopt = []
+    mock_result.pending_accept = []
+    mock_result.pending_reject = []
+
+    runner = CliRunner()
+    with (
+        patch("beacon.cli.adoption.find_project_root", return_value=tmp_path),
+        patch("beacon.cli.adoption.WorkspaceConfig") as mock_ws_cfg,
+        patch("beacon.cli.adoption.BeaconManifest.from_yaml") as mock_manifest,
+        patch("beacon.cli.adoption.discover_pending", return_value=[]),
+        patch(
+            "beacon.cli.adoption.discover_adoptable",
+            return_value=([fake_candidate], []),
+        ),
+        patch("beacon.cli.adoption.is_interactive", return_value=True),
+        patch("beacon.cli.adoption.AdoptApp") as mock_app_cls,
+        patch("beacon.cli.adoption.commit_session", side_effect=commit_err),
+    ):
+        mock_ws_cfg.return_value.warehouse.local_path = str(tmp_path / "warehouse")
+
+        mock_bm = mock_manifest.return_value
+        mock_bm.artifacts.contexts = []
+        mock_bm.artifacts.skills = []
+        mock_bm.artifacts.agents = []
+
+        mock_app_cls.return_value.run.return_value = mock_result
+
+        result = runner.invoke(adopt)
+
+    assert result.exit_code == 1
+    assert str(dest) in result.output or "spec-planner" in result.output
+    assert "Cannot wire 1 agent" in result.output

--- a/libs/beacon/tests/unit/cli/test_sync_conflict.py
+++ b/libs/beacon/tests/unit/cli/test_sync_conflict.py
@@ -1,0 +1,33 @@
+"""Unit test for RegularFileConflictError handler in the sync CLI."""
+
+import re
+from pathlib import Path
+from unittest.mock import patch
+
+from beacon.core.exceptions import AgentWireConflict, RegularFileConflictError
+from click.testing import CliRunner
+
+
+def test_sync_regular_file_conflict_exits_1(tmp_path: Path) -> None:
+    """sync exits 1 and renders the conflict path when run_sync raises RegularFileConflictError."""
+    from beacon.cli.sync import sync
+
+    dest = tmp_path / ".claude" / "agents" / "spec-planner.md"
+    conflict = AgentWireConflict(
+        dest=dest, agent_name="spec-planner", tool="claudecode"
+    )
+    error = RegularFileConflictError(conflicts=[conflict])
+
+    runner = CliRunner()
+    with patch(
+        "beacon.cli.sync.run_sync",
+        side_effect=error,
+    ):
+        result = runner.invoke(sync)
+
+    assert result.exit_code == 1
+    assert "Cannot wire 1 agent" in result.output
+    # Rich wraps long paths at terminal width on CI (no TTY). Normalize whitespace
+    # before substring search so wrap-induced breaks don't split the path.
+    flat = re.sub(r"\s+", "", result.output)
+    assert "spec-planner.md" in flat

--- a/libs/beacon/tests/unit/test_display.py
+++ b/libs/beacon/tests/unit/test_display.py
@@ -1,0 +1,56 @@
+"""Unit tests for beacon.utils.display.format_regular_file_conflict."""
+
+from beacon.core.exceptions import AgentWireConflict
+from beacon.utils.display import format_regular_file_conflict
+
+
+def test_format_regular_file_conflict_singular(tmp_path):
+    """Single conflict: output mentions '1 agent', rm command, mv command, abc adopt."""
+    dest = tmp_path / ".claude" / "agents" / "spec-planner.md"
+    conflicts = [
+        AgentWireConflict(dest=dest, agent_name="spec-planner", tool="claudecode")
+    ]
+
+    output = format_regular_file_conflict(conflicts)
+
+    assert "Cannot wire 1 agent" in output
+    assert "rm " in output
+    assert "mv " in output
+    assert "abc adopt" in output
+    assert "spec-planner.user.md" in output
+
+
+def test_format_regular_file_conflict_plural(tmp_path):
+    """Three conflicts: output mentions '3 agents', three rm lines, three mv lines."""
+    conflicts = [
+        AgentWireConflict(
+            dest=tmp_path / ".claude" / "agents" / f"agent-{i}.md",
+            agent_name=f"agent-{i}",
+            tool="claudecode",
+        )
+        for i in range(3)
+    ]
+
+    output = format_regular_file_conflict(conflicts)
+
+    assert "Cannot wire 3 agents" in output
+    assert output.count("rm ") == 3
+    assert output.count("mv ") == 3
+
+
+def test_format_regular_file_conflict_uses_relative_paths_when_possible(
+    tmp_path, monkeypatch
+):
+    """When dest is under CWD, output shows the relative path, not the absolute one."""
+    monkeypatch.chdir(tmp_path)
+    dest = tmp_path / ".claude" / "agents" / "spec-planner.md"
+    conflicts = [
+        AgentWireConflict(dest=dest, agent_name="spec-planner", tool="claudecode")
+    ]
+
+    output = format_regular_file_conflict(conflicts)
+
+    # Relative path present
+    assert ".claude/agents/spec-planner.md" in output
+    # Absolute prefix absent
+    assert str(tmp_path) not in output

--- a/libs/beacon/tests/unit/test_wire_agents.py
+++ b/libs/beacon/tests/unit/test_wire_agents.py
@@ -6,7 +6,10 @@ Covers TC1-TC5 from tasks 1.1, TC1-TC3 from task 1.2, and TC1-TC4 from task 1.3.
 from pathlib import Path
 
 import pytest
-from beacon.core.exceptions import BeaconSyncError
+from beacon.core.exceptions import (
+    BeaconSyncError,
+    RegularFileConflictError,
+)
 from beacon.domains.artifact.agent import snapshot_agent_path
 from beacon.domains.setup.wiring import (
     unwire_agent,
@@ -557,3 +560,68 @@ class TestWireAgentsAtomically:
         # Only claudecode wired; future-tool was ignored.
         assert (project / ".claude" / "agents" / "spec-planner.md").is_symlink()
         assert not (project / ".future-tool").exists()
+
+
+# ---------------------------------------------------------------------------
+# PER-127: pre-flight scan in wire_agents_atomically
+# ---------------------------------------------------------------------------
+
+
+def test_wire_agents_atomically_collects_multiple_regular_file_conflicts(tmp_path):
+    """Pre-flight collects ALL conflicts across different agents and tools."""
+    project = tmp_path / "proj"
+    project.mkdir()
+
+    foo = _make_artifact(tmp_path / "warehouse", "foo.md")
+    bar = _make_artifact(tmp_path / "warehouse", "bar.md")
+
+    # Regular file at foo's claudecode dest
+    foo_cc = project / ".claude" / "agents" / "foo.md"
+    foo_cc.parent.mkdir(parents=True, exist_ok=True)
+    foo_cc.write_text("user foo cc")
+
+    # Regular file at bar's opencode dest
+    bar_oc = project / ".opencode" / "agents" / "bar.md"
+    bar_oc.parent.mkdir(parents=True, exist_ok=True)
+    bar_oc.write_text("user bar oc")
+
+    with pytest.raises(RegularFileConflictError) as exc:
+        wire_agents_atomically(project, [foo, bar], {"claudecode", "opencode"})
+
+    assert len(exc.value.conflicts) >= 2
+
+    # No symlinks created
+    assert not (project / ".claude" / "agents" / "foo.md").is_symlink()
+    assert not (project / ".opencode" / "agents" / "bar.md").is_symlink()
+
+
+def test_wire_agents_atomically_no_partial_wiring_on_conflict(tmp_path):
+    """Pre-flight aborts before any wiring — clean agent is never symlinked."""
+    project = tmp_path / "proj"
+    project.mkdir()
+
+    clean = _make_artifact(tmp_path / "warehouse", "clean.md")
+    conflicting = _make_artifact(tmp_path / "warehouse", "conflicting.md")
+
+    # Regular file only at conflicting agent's claudecode dest
+    blocker = project / ".claude" / "agents" / "conflicting.md"
+    blocker.parent.mkdir(parents=True, exist_ok=True)
+    blocker.write_text("user content")
+
+    with pytest.raises(RegularFileConflictError):
+        wire_agents_atomically(project, [clean, conflicting], {"claudecode"})
+
+    # clean.md must never have been symlinked anywhere
+    assert not (project / ".claude" / "agents" / "clean.md").is_symlink()
+    assert not (project / ".claude" / "agents" / "clean.md").exists()
+
+
+def test_regular_file_conflict_error_empty_conflicts_raises_value_error():
+    """Constructing RegularFileConflictError with empty list raises ValueError."""
+    with pytest.raises(ValueError):
+        RegularFileConflictError(conflicts=[])
+
+
+def test_regular_file_conflict_error_is_beacon_sync_error_subclass():
+    """RegularFileConflictError must be a subclass of BeaconSyncError."""
+    assert issubclass(RegularFileConflictError, BeaconSyncError)

--- a/libs/beacon/tests/unit/test_wire_agents.py
+++ b/libs/beacon/tests/unit/test_wire_agents.py
@@ -338,9 +338,7 @@ def test_unwire_agent_with_undo_preserves_regular_file(tmp_path):
 
 
 def test_wire_agent_claudecode_refuses_to_overwrite_regular_file(tmp_path):
-    """Regular file at dest must cause BeaconSyncError, not FileExistsError or silent overwrite."""
-    from beacon.core.exceptions import BeaconSyncError
-
+    """Regular file at dest must cause RegularFileConflictError, not FileExistsError or silent overwrite."""
     target = tmp_path / ".claude" / "agents" / "spec-planner.md"
     target.parent.mkdir(parents=True)
     target.write_text("user-authored content")
@@ -349,16 +347,15 @@ def test_wire_agent_claudecode_refuses_to_overwrite_regular_file(tmp_path):
     artifact_file.parent.mkdir(parents=True)
     artifact_file.write_text("warehouse content")
 
-    with pytest.raises(BeaconSyncError) as exc:
+    with pytest.raises(RegularFileConflictError) as excinfo:
         wire_agent_claudecode(tmp_path, artifact_file)
-    assert "regular file" in str(exc.value)
+    assert len(excinfo.value.conflicts) == 1
+    assert excinfo.value.conflicts[0].dest == target
     assert target.read_text() == "user-authored content"  # not overwritten
 
 
 def test_wire_agent_opencode_refuses_to_overwrite_regular_file(tmp_path):
     """Same as above but for opencode side."""
-    from beacon.core.exceptions import BeaconSyncError
-
     target = tmp_path / ".opencode" / "agents" / "spec-planner.md"
     target.parent.mkdir(parents=True)
     target.write_text("user-authored content")
@@ -367,9 +364,10 @@ def test_wire_agent_opencode_refuses_to_overwrite_regular_file(tmp_path):
     artifact_file.parent.mkdir(parents=True)
     artifact_file.write_text("warehouse content")
 
-    with pytest.raises(BeaconSyncError) as exc:
+    with pytest.raises(RegularFileConflictError) as excinfo:
         wire_agent_opencode(tmp_path, artifact_file)
-    assert "regular file" in str(exc.value)
+    assert len(excinfo.value.conflicts) == 1
+    assert excinfo.value.conflicts[0].dest == target
     assert target.read_text() == "user-authored content"
 
 

--- a/libs/beacon/tests/unit/test_wire_agents.py
+++ b/libs/beacon/tests/unit/test_wire_agents.py
@@ -586,7 +586,7 @@ def test_wire_agents_atomically_collects_multiple_regular_file_conflicts(tmp_pat
     with pytest.raises(RegularFileConflictError) as exc:
         wire_agents_atomically(project, [foo, bar], {"claudecode", "opencode"})
 
-    assert len(exc.value.conflicts) >= 2
+    assert len(exc.value.conflicts) == 2
 
     # No symlinks created
     assert not (project / ".claude" / "agents" / "foo.md").is_symlink()


### PR DESCRIPTION
## Summary

- Replaces single-conflict `BeaconSyncError` in `wire_agent_claudecode` / `wire_agent_opencode` with a structured `RegularFileConflictError` carrying a list of `AgentWireConflict` records.
- Adds atomic pre-flight in `wire_agents_atomically` that collects **all** regular-file conflicts before any wiring takes place, so the user sees every blocked destination in one error rather than failing on the first.
- Surfaces the structured error in `cli/sync.py` and `cli/adoption.py` via a new `format_regular_file_conflict` Rich-markup helper showing relative paths and three remediation options (remove file / back up as `.user.md` / drop from beacon.yaml).
- Adoption path also catches `CommitError` whose `__cause__` is `RegularFileConflictError`, since `apply.py::commit_session` wraps non-`CommitError` exceptions and apply.py was out of scope.

Implements **option (a) only** of PER-127. Options (b) `--force` flag and (c) docs are explicitly out of scope.

## Test plan

- [x] `tests/unit/test_wire_agents.py` — atomic pre-flight collects multiple conflicts; no partial wiring on conflict; `RegularFileConflictError` is a `BeaconSyncError` subclass; refuses empty conflicts list
- [x] `tests/unit/test_display.py` — singular/plural formatting; relative-path conversion fallback
- [x] Existing `test_wire_agent_*_refuses_to_overwrite_regular_file` still pass against the new exception type
- [x] Existing rollback tests still pass — pre-flight scan fires before any wiring, so post-abort state assertions are unchanged
- [x] Full beacon unit suite: 760 pass, 5 pre-existing failures (missing `git config user.email`, reproduce on base branch — unrelated)
- [x] ruff clean on all 5 touched src files
- [x] TC4 architecture honored: `utils/` does not import from `beacon.core.*` (verified by AST/grep)

## Notes

- TC4 forced `format_regular_file_conflict(conflicts: Sequence)` to use unparameterized `Sequence` with a duck-typed docstring instead of `Sequence[AgentWireConflict]`. A future refactor could relocate `AgentWireConflict` outside `core/` to enable proper typing.