### PR TITLE
refactor(beacon): drop unused validate_requires_against_warehouse helper (PER-139)

### DIFF
--- a/libs/beacon/src/beacon/core/dependencies/frontmatter.py
+++ b/libs/beacon/src/beacon/core/dependencies/frontmatter.py
@@ -113,26 +113,3 @@ def parse_frontmatter(path: Path) -> FrontmatterResult:
         )
 
     return FrontmatterResult(success=True, data=data)
-
-
-def validate_requires_against_warehouse(
-    frontmatter: SkillFrontmatter, warehouse_path: Path
-) -> list[str]:
-    """Validate that every name in frontmatter.requires resolves to an existing warehouse file.
-
-    Args:
-        frontmatter: Parsed and validated skill frontmatter.
-        warehouse_path: Root of the warehouse clone.
-
-    Returns:
-        List of human-readable error strings; empty on success.
-    """
-    errors: list[str] = []
-    req = frontmatter.requires
-
-    for ctx_name in req.contexts:
-        expected = warehouse_path / "contexts" / f"{ctx_name}.md"
-        if not expected.exists():
-            errors.append(f"Missing context '{ctx_name}': expected {expected}")
-
-    return errors

--- a/libs/beacon/tests/unit/core/dependencies/test_frontmatter.py
+++ b/libs/beacon/tests/unit/core/dependencies/test_frontmatter.py
@@ -3,14 +3,11 @@
 Covers tasks 4.1–4.6 from auto-pull-artifact-dependencies OpenSpec change.
 """
 
-from pathlib import Path
-
 import pytest
 from beacon.core.dependencies.frontmatter import (
     FrontmatterResult,
     SkillFrontmatter,
     parse_frontmatter,
-    validate_requires_against_warehouse,
 )
 from pydantic import ValidationError
 
@@ -117,43 +114,3 @@ class TestSkillFrontmatter:
         with pytest.raises(ValidationError) as exc_info:
             SkillFrontmatter.model_validate({"requires": {}})
         assert "contexts" in str(exc_info.value).lower()
-
-
-class TestValidateRequiresAgainstWarehouse:
-    """Task 4.5: validate_requires_against_warehouse — TDD test cases."""
-
-    def _make_warehouse(self, tmp_path: Path) -> Path:
-        wh = tmp_path / "warehouse"
-        wh.mkdir()
-        (wh / "contexts").mkdir()
-        (wh / "skills").mkdir()
-        return wh
-
-    def test_tc1_skill_contexts_exist(self, tmp_path):
-        """TC1: Skill requires.contexts all resolve → empty error list."""
-        wh = self._make_warehouse(tmp_path)
-        (wh / "contexts" / "python-standards.md").write_text("# Context")
-        (wh / "contexts" / "testing.md").write_text("# Context")
-        skill = SkillFrontmatter.model_validate(
-            {"requires": {"contexts": ["python-standards", "testing"]}}
-        )
-        errors = validate_requires_against_warehouse(skill, wh)
-        assert errors == []
-
-    def test_tc4_skill_with_missing_context(self, tmp_path):
-        """TC4: Skill requires.contexts with one missing → single error."""
-        wh = self._make_warehouse(tmp_path)
-        (wh / "contexts" / "python-standards.md").write_text("# Context")
-        skill = SkillFrontmatter.model_validate(
-            {"requires": {"contexts": ["python-standards", "testing"]}}
-        )
-        errors = validate_requires_against_warehouse(skill, wh)
-        assert len(errors) == 1
-        assert "testing" in errors[0]
-
-    def test_tc5_skill_empty_requires(self, tmp_path):
-        """TC5: Skill with empty requires.contexts → empty error list."""
-        wh = self._make_warehouse(tmp_path)
-        skill = SkillFrontmatter.model_validate({"requires": {"contexts": []}})
-        errors = validate_requires_against_warehouse(skill, wh)
-        assert errors == []


### PR DESCRIPTION
## Summary

- Delete `validate_requires_against_warehouse` from `libs/beacon/src/beacon/core/dependencies/frontmatter.py`
- Delete `TestValidateRequiresAgainstWarehouse` (3 tests) from `tests/unit/core/dependencies/test_frontmatter.py`
- Drop now-unused `Path` import + symbol from `from beacon.core.dependencies.frontmatter import (...)`

Closes PER-139.

## Why

Surfaced as a Low finding by opencode-review on PR #111 (PER-117): the function had **zero production callers**. The production resolver at `core/dependencies/resolver.py:200–225` already implements its own inline warehouse validation as Phase 3, so this helper was dead code from creation. Decision per PER-139: Option A (delete) — YAGNI choice, no near-term need cited for keeping it as a reusable helper.

If future work wants a single source of truth for `requires:`-to-warehouse validation, that's the right time to extract — not before.

## Test plan

- [x] `rg validate_requires_against_warehouse libs/beacon` → 0 matches
- [x] `pytest test_frontmatter.py` → 11 passed (was 14; -3 from deleted class)
- [x] `pytest libs/beacon/tests/` → 1038 passed, 9 skipped, same 7 pre-existing git-identity failures (unrelated)
- [x] `ruff check frontmatter.py` → clean
- [ ] CI green
- [ ] opencode-review bot clean

## Out of scope (intentional)

- `resolver.py` inline validation untouched
- No refactor of surrounding `frontmatter.py`