### PR TITLE
fix(beacon): unwire only Beacon-owned tool symlinks; preserve user symlinks (PER-132)

### DIFF
--- a/libs/beacon/src/beacon/domains/setup/wiring.py
+++ b/libs/beacon/src/beacon/domains/setup/wiring.py
@@ -555,15 +555,32 @@ def wire_agents_atomically(
         raise
 
 
+def _is_beacon_symlink(dest: Path, expected_artifact: Path) -> bool:
+    """Return True if dest is a symlink whose resolved target matches expected_artifact.
+
+    Handles both absolute and relative symlink targets. Returns False on any
+    OSError (e.g. permission denied reading the link), treating the path as
+    user-owned in that case.
+    """
+    try:
+        raw_target = dest.readlink()
+    except OSError:
+        return False
+    if not raw_target.is_absolute():
+        raw_target = dest.parent / raw_target
+    return raw_target.resolve(strict=False) == expected_artifact
+
+
 def unwire_agent(project_root: Path, agent_name: str) -> None:
     """Remove project-local agent symlinks for the given agent.
 
-    Only Beacon-created symlinks are removed. A regular file at the agent path
-    is user-owned content and is left untouched with a warning logged.
+    Only symlinks whose target resolves to .agentic-beacon/artifacts/agents/<name>.md
+    are removed. Symlinks pointing elsewhere are preserved with a warning (treated as
+    user-owned content). A regular file at the agent path is also left untouched.
 
     Removes both .claude/agents/<agent_name>.md and
-    .opencode/agents/<agent_name>.md if they are Beacon symlinks. Missing files
-    are silently skipped. Does not traverse subdirectories.
+    .opencode/agents/<agent_name>.md if they are Beacon-owned symlinks. Missing
+    files are silently skipped. Does not traverse subdirectories.
 
     Args:
         project_root: Project root directory.
@@ -575,11 +592,22 @@ def unwire_agent(project_root: Path, agent_name: str) -> None:
     if not leaf.endswith(".md"):
         leaf = leaf + ".md"
 
+    expected_artifact = (
+        project_root / ".agentic-beacon" / "artifacts" / "agents" / leaf
+    ).resolve(strict=False)
+
     for dest in (
         project_root / ".claude" / "agents" / leaf,
         project_root / ".opencode" / "agents" / leaf,
     ):
         if dest.is_symlink():
+            if not _is_beacon_symlink(dest, expected_artifact):
+                logger.warning(
+                    "Skipping unwire of {}: symlink points outside "
+                    ".agentic-beacon/artifacts/agents/; treating as user-owned.",
+                    dest,
+                )
+                continue
             dest.unlink()
             logger.debug("Unwired agent: {}", dest)
         elif dest.exists():
@@ -595,11 +623,13 @@ def unwire_agent_with_undo(
 ) -> list[tuple[Path, Path]]:
     """Remove project-local agent symlinks, returning (path, target) pairs for rollback.
 
-    Only Beacon-created symlinks are removed and recorded. A regular file at the
-    agent path is user-owned content and is left untouched with a warning logged.
+    Only symlinks whose target resolves to .agentic-beacon/artifacts/agents/<name>.md
+    are removed and recorded. Symlinks pointing elsewhere are preserved with a warning
+    (treated as user-owned). A regular file at the agent path is also left untouched.
 
     Like unwire_agent but returns a list of (removed_path, original_target) tuples
     for each symlink removed, enabling callers to reconstruct them on rollback.
+    User-owned symlinks that are skipped are NOT included in the returned list.
 
     Args:
         project_root: Project root directory.
@@ -607,11 +637,15 @@ def unwire_agent_with_undo(
 
     Returns:
         List of (path, target) pairs for each symlink successfully removed.
-        Regular files at the agent paths are not included (they are not removed).
+        User-owned symlinks and regular files at the agent paths are not included.
     """
     leaf = Path(agent_name).name
     if not leaf.endswith(".md"):
         leaf = leaf + ".md"
+
+    expected_artifact = (
+        project_root / ".agentic-beacon" / "artifacts" / "agents" / leaf
+    ).resolve(strict=False)
 
     removed: list[tuple[Path, Path]] = []
     for dest in (
@@ -619,6 +653,13 @@ def unwire_agent_with_undo(
         project_root / ".opencode" / "agents" / leaf,
     ):
         if dest.is_symlink():
+            if not _is_beacon_symlink(dest, expected_artifact):
+                logger.warning(
+                    "Skipping unwire of {}: symlink points outside "
+                    ".agentic-beacon/artifacts/agents/; treating as user-owned.",
+                    dest,
+                )
+                continue
             target = dest.readlink()
             dest.unlink()
             removed.append((dest, target))

--- a/libs/beacon/tests/unit/test_wire_agents.py
+++ b/libs/beacon/tests/unit/test_wire_agents.py
@@ -389,8 +389,36 @@ def test_unwire_agent_removes_beacon_owned_symlink(tmp_path):
     assert not dest.exists() and not dest.is_symlink()
 
 
+def test_unwire_agent_relative_symlink_target_resolves_correctly(tmp_path):
+    """(c) Beacon-owned symlink stored with a *relative* readlink target is identified and removed.
+
+    Pins the `dest.parent / raw_target` resolution branch in `_is_beacon_symlink`
+    that absolute-target tests don't exercise.
+    """
+    artifact = tmp_path / ".agentic-beacon" / "artifacts" / "agents" / "foo.md"
+    artifact.parent.mkdir(parents=True, exist_ok=True)
+    artifact.write_text("beacon artifact")
+
+    dest_parent = tmp_path / ".claude" / "agents"
+    dest_parent.mkdir(parents=True, exist_ok=True)
+    dest = dest_parent / "foo.md"
+
+    # Relative target: from .claude/agents/ up to project root, then into the artifact
+    rel_target = (
+        Path("..") / ".." / ".agentic-beacon" / "artifacts" / "agents" / "foo.md"
+    )
+    dest.symlink_to(rel_target)
+    # Sanity: readlink really is relative, not absolute
+    assert not dest.readlink().is_absolute()
+
+    unwire_agent(tmp_path, "foo")
+
+    # The relative-target Beacon-owned symlink should be removed
+    assert not dest.exists() and not dest.is_symlink()
+
+
 def test_unwire_agent_with_undo_excludes_user_owned_symlink(tmp_path):
-    """(c) unwire_agent_with_undo returns empty list when only symlink is user-owned."""
+    """(d) unwire_agent_with_undo returns empty list when only symlink is user-owned."""
     user_file = tmp_path / "elsewhere.md"
     user_file.write_text("user content")
 
@@ -406,7 +434,7 @@ def test_unwire_agent_with_undo_excludes_user_owned_symlink(tmp_path):
 
 
 def test_unwire_agent_mixed_beacon_and_user_symlinks(tmp_path):
-    """(c) unwire_agent_with_undo records Beacon-owned but skips user-owned."""
+    """(e) unwire_agent_with_undo records Beacon-owned but skips user-owned."""
     artifact = tmp_path / ".agentic-beacon" / "artifacts" / "agents" / "foo.md"
     artifact.parent.mkdir(parents=True, exist_ok=True)
     artifact.write_text("beacon artifact")
@@ -433,7 +461,7 @@ def test_unwire_agent_mixed_beacon_and_user_symlinks(tmp_path):
 
 
 def test_unwire_agent_dangling_user_symlink_preserved(tmp_path):
-    """(d) dangling symlink pointing outside .agentic-beacon/artifacts/agents/ → preserved."""
+    """(f) dangling symlink pointing outside .agentic-beacon/artifacts/agents/ → preserved."""
     # Create a symlink to a nonexistent path that is NOT in .agentic-beacon/artifacts/agents/
     dest = tmp_path / ".claude" / "agents" / "foo.md"
     dest.parent.mkdir(parents=True, exist_ok=True)

--- a/libs/beacon/tests/unit/test_wire_agents.py
+++ b/libs/beacon/tests/unit/test_wire_agents.py
@@ -173,18 +173,28 @@ class TestWireAgentOpencode:
 
 
 class TestUnwireAgent:
+    def _make_beacon_artifact(self, project: Path, agent_name: str) -> Path:
+        """Create the expected Beacon artifact file and return its path."""
+        artifact = (
+            project / ".agentic-beacon" / "artifacts" / "agents" / f"{agent_name}.md"
+        )
+        artifact.parent.mkdir(parents=True, exist_ok=True)
+        artifact.write_text("beacon artifact")
+        return artifact
+
     def _make_symlinks(self, project: Path, agent_name: str) -> tuple[Path, Path]:
-        """Helper to create both agent symlinks."""
+        """Helper to create both Beacon-owned agent symlinks."""
+        artifact = self._make_beacon_artifact(project, agent_name)
         claude_dest = project / ".claude" / "agents" / f"{agent_name}.md"
         opencode_dest = project / ".opencode" / "agents" / f"{agent_name}.md"
         claude_dest.parent.mkdir(parents=True, exist_ok=True)
         opencode_dest.parent.mkdir(parents=True, exist_ok=True)
-        claude_dest.symlink_to("/tmp/fake.md")
-        opencode_dest.symlink_to("/tmp/fake.md")
+        claude_dest.symlink_to(artifact)
+        opencode_dest.symlink_to(artifact)
         return claude_dest, opencode_dest
 
     def test_tc1_both_symlinks_removed(self, tmp_path):
-        """TC1: both symlinks present → both removed."""
+        """TC1: both Beacon-owned symlinks present → both removed."""
         project = tmp_path / "proj"
         project.mkdir()
         claude_dest, opencode_dest = self._make_symlinks(project, "spec-planner")
@@ -198,9 +208,10 @@ class TestUnwireAgent:
         """TC2: only Claude symlink present → it is removed; OpenCode absence is not an error."""
         project = tmp_path / "proj"
         project.mkdir()
+        artifact = self._make_beacon_artifact(project, "spec-planner")
         claude_dest = project / ".claude" / "agents" / "spec-planner.md"
         claude_dest.parent.mkdir(parents=True)
-        claude_dest.symlink_to("/tmp/fake.md")
+        claude_dest.symlink_to(artifact)
 
         # Should not raise
         unwire_agent(project, "spec-planner")
@@ -220,12 +231,13 @@ class TestUnwireAgent:
         project = tmp_path / "proj"
         project.mkdir()
 
-        # Wire a real symlink at the expected leaf location
+        # Wire a Beacon-owned symlink at the expected leaf location
         agent_name = "team/reviewer"
         leaf = "reviewer"
+        artifact = self._make_beacon_artifact(project, leaf)
         dest = project / ".claude" / "agents" / f"{leaf}.md"
         dest.parent.mkdir(parents=True)
-        dest.symlink_to("/tmp/fake.md")
+        dest.symlink_to(artifact)
 
         unwire_agent(project, agent_name)
 
@@ -239,9 +251,10 @@ class TestUnwireAgent:
         """agent_name without .md extension is accepted."""
         project = tmp_path / "proj"
         project.mkdir()
+        artifact = self._make_beacon_artifact(project, "my-agent")
         dest = project / ".claude" / "agents" / "my-agent.md"
         dest.parent.mkdir(parents=True)
-        dest.symlink_to("/tmp/fake.md")
+        dest.symlink_to(artifact)
 
         unwire_agent(project, "my-agent")
 
@@ -251,9 +264,10 @@ class TestUnwireAgent:
         """agent_name with .md extension is also accepted."""
         project = tmp_path / "proj"
         project.mkdir()
+        artifact = self._make_beacon_artifact(project, "my-agent")
         dest = project / ".claude" / "agents" / "my-agent.md"
         dest.parent.mkdir(parents=True)
-        dest.symlink_to("/tmp/fake.md")
+        dest.symlink_to(artifact)
 
         unwire_agent(project, "my-agent.md")
 
@@ -266,6 +280,18 @@ class TestUnwireAgent:
 
 
 class TestUnwirePrunedArtifactsAgents:
+    def _make_beacon_symlink(
+        self, project: Path, artifacts_dir: Path, agent_name: str
+    ) -> Path:
+        """Create the beacon artifact and a wired Claude symlink pointing at it."""
+        artifact = artifacts_dir / "agents" / f"{agent_name}.md"
+        artifact.parent.mkdir(parents=True, exist_ok=True)
+        artifact.write_text("beacon artifact")
+        dest = project / ".claude" / "agents" / f"{agent_name}.md"
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.symlink_to(artifact)
+        return dest
+
     def test_tc_agents_path_calls_unwire_agent(self, tmp_path):
         """unwire_pruned_artifacts with agents/ path calls unwire_agent."""
         project = tmp_path / "proj"
@@ -273,10 +299,7 @@ class TestUnwirePrunedArtifactsAgents:
         artifacts_dir = project / ".agentic-beacon" / "artifacts"
         artifacts_dir.mkdir(parents=True)
 
-        # Create a wired agent symlink
-        dest = project / ".claude" / "agents" / "spec-planner.md"
-        dest.parent.mkdir(parents=True)
-        dest.symlink_to("/tmp/fake.md")
+        dest = self._make_beacon_symlink(project, artifacts_dir, "spec-planner")
 
         unwire_pruned_artifacts(project, ["agents/spec-planner.md"], artifacts_dir)
 
@@ -289,9 +312,7 @@ class TestUnwirePrunedArtifactsAgents:
         artifacts_dir = project / ".agentic-beacon" / "artifacts"
         artifacts_dir.mkdir(parents=True)
 
-        agent_dest = project / ".claude" / "agents" / "code-reviewer.md"
-        agent_dest.parent.mkdir(parents=True)
-        agent_dest.symlink_to("/tmp/fake.md")
+        agent_dest = self._make_beacon_symlink(project, artifacts_dir, "code-reviewer")
 
         # Skills are handled separately — just verify no error thrown
         unwire_pruned_artifacts(
@@ -330,6 +351,98 @@ def test_unwire_agent_with_undo_preserves_regular_file(tmp_path):
 
     assert target.exists() and target.read_text() == "user-authored content"
     assert removed == []  # nothing removed → nothing to roll back
+
+
+# ---------------------------------------------------------------------------
+# PER-132: unwire only Beacon-owned tool symlinks
+# ---------------------------------------------------------------------------
+
+
+def test_unwire_agent_skips_symlink_pointing_outside_beacon(tmp_path):
+    """(a) symlink target outside .agentic-beacon/artifacts/agents/ → preserved with warning."""
+    user_file = tmp_path / "my-own-definition.md"
+    user_file.write_text("user definition")
+
+    dest = tmp_path / ".claude" / "agents" / "foo.md"
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.symlink_to(user_file)
+
+    unwire_agent(tmp_path, "foo")
+
+    # User-owned symlink must survive
+    assert dest.is_symlink()
+    assert dest.readlink() == user_file
+
+
+def test_unwire_agent_removes_beacon_owned_symlink(tmp_path):
+    """(b) regression: Beacon-owned symlink is still removed correctly."""
+    artifact = tmp_path / ".agentic-beacon" / "artifacts" / "agents" / "foo.md"
+    artifact.parent.mkdir(parents=True, exist_ok=True)
+    artifact.write_text("beacon artifact")
+
+    dest = tmp_path / ".claude" / "agents" / "foo.md"
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.symlink_to(artifact)
+
+    unwire_agent(tmp_path, "foo")
+
+    assert not dest.exists() and not dest.is_symlink()
+
+
+def test_unwire_agent_with_undo_excludes_user_owned_symlink(tmp_path):
+    """(c) unwire_agent_with_undo returns empty list when only symlink is user-owned."""
+    user_file = tmp_path / "elsewhere.md"
+    user_file.write_text("user content")
+
+    dest = tmp_path / ".claude" / "agents" / "foo.md"
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.symlink_to(user_file)
+
+    removed = unwire_agent_with_undo(tmp_path, "foo")
+
+    # User-owned entry must NOT be in the removed list
+    assert removed == []
+    assert dest.is_symlink()
+
+
+def test_unwire_agent_mixed_beacon_and_user_symlinks(tmp_path):
+    """(c) unwire_agent_with_undo records Beacon-owned but skips user-owned."""
+    artifact = tmp_path / ".agentic-beacon" / "artifacts" / "agents" / "foo.md"
+    artifact.parent.mkdir(parents=True, exist_ok=True)
+    artifact.write_text("beacon artifact")
+
+    user_file = tmp_path / "user-def.md"
+    user_file.write_text("user content")
+
+    # Claude dest → Beacon-owned; OpenCode dest → user-owned
+    cc_dest = tmp_path / ".claude" / "agents" / "foo.md"
+    cc_dest.parent.mkdir(parents=True, exist_ok=True)
+    cc_dest.symlink_to(artifact)
+
+    oc_dest = tmp_path / ".opencode" / "agents" / "foo.md"
+    oc_dest.parent.mkdir(parents=True, exist_ok=True)
+    oc_dest.symlink_to(user_file)
+
+    removed = unwire_agent_with_undo(tmp_path, "foo")
+
+    # Only the Beacon-owned Claude symlink is in the list
+    assert len(removed) == 1
+    assert removed[0][0] == cc_dest
+    # User-owned OpenCode symlink must survive
+    assert oc_dest.is_symlink()
+
+
+def test_unwire_agent_dangling_user_symlink_preserved(tmp_path):
+    """(d) dangling symlink pointing outside .agentic-beacon/artifacts/agents/ → preserved."""
+    # Create a symlink to a nonexistent path that is NOT in .agentic-beacon/artifacts/agents/
+    dest = tmp_path / ".claude" / "agents" / "foo.md"
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.symlink_to(tmp_path / "nonexistent" / "foo.md")  # dangling, outside beacon dir
+
+    unwire_agent(tmp_path, "foo")
+
+    # The dangling symlink must survive (user-owned, outside expected artifact path)
+    assert dest.is_symlink()
 
 
 # ---------------------------------------------------------------------------

--- a/openspec/specs/project-agent-wiring/spec.md
+++ b/openspec/specs/project-agent-wiring/spec.md
@@ -25,9 +25,23 @@ During `abc sync`, after symlinking declared agents from `<warehouse>/agents/<na
 - **WHEN** wiring an agent and the target tool directory (`.claude/agents/` or `.opencode/agents/`) does not yet exist
 - **THEN** the directory is created automatically before the symlink is written
 
+### Requirement: Unwire only Beacon-owned tool symlinks
+
+When the system removes a project-local tool symlink at `.claude/agents/<name>.md` or `.opencode/agents/<name>.md` (during sync-unwire, adopt-reject, or any other unwire path), it SHALL first verify that the symlink target resolves to the corresponding `.agentic-beacon/artifacts/agents/<name>.md` artifact. Symlinks pointing elsewhere SHALL be preserved as user-owned content with a warning logged. Regular files at the target path retain their existing preservation policy.
+
+#### Scenario: User-created symlink at agent leaf is preserved on unwire
+- **GIVEN** the user has manually created `.claude/agents/foo.md` as a symlink pointing at their own definition file (outside `.agentic-beacon/artifacts/agents/`)
+- **WHEN** `abc sync` prunes a Beacon-managed agent named `foo`, OR `abc adopt reject foo` runs
+- **THEN** the user's symlink is left untouched; a warning is logged; the artifact symlink at `.agentic-beacon/artifacts/agents/foo.md` is removed normally
+
+#### Scenario: Beacon-owned symlink is removed on unwire
+- **GIVEN** `.claude/agents/foo.md` is a Beacon-created symlink pointing at `.agentic-beacon/artifacts/agents/foo.md`
+- **WHEN** `abc sync` prunes the agent, OR `abc adopt reject foo` runs
+- **THEN** the symlink is removed
+
 ### Requirement: Sync unwires pruned agents
 
-During `abc sync`, when an agent is no longer declared in `beacon.yaml.artifacts.agents` (i.e., the entry was removed since the previous sync), the system SHALL remove the project-local symlinks at `.claude/agents/<name>.md` and `.opencode/agents/<name>.md`, in addition to removing the artifact symlink at `.agentic-beacon/artifacts/agents/<name>.md`. The `unwire_pruned_artifacts` mechanism SHALL be extended to handle `artifact_type == "agents"`.
+During `abc sync`, when an agent is no longer declared in `beacon.yaml.artifacts.agents` (i.e., the entry was removed since the previous sync), the system SHALL remove the project-local Beacon-owned symlinks at `.claude/agents/<name>.md` and `.opencode/agents/<name>.md`, in addition to removing the artifact symlink at `.agentic-beacon/artifacts/agents/<name>.md`. The `unwire_pruned_artifacts` mechanism SHALL be extended to handle `artifact_type == "agents"`.
 
 #### Scenario: Agent removed from beacon.yaml
 - **WHEN** `beacon.yaml.artifacts.agents` previously contained `agents/spec-planner.md` and the entry is removed AND `abc sync` is run
@@ -51,7 +65,7 @@ When `abc adopt` accepts an agent (action: `accept`), the system SHALL append th
 
 ### Requirement: Adoption reject unwires agents immediately
 
-When `abc adopt` rejects an agent (action: `reject`), the system SHALL remove the entry from `beacon.yaml.artifacts.agents` (if present), remove the artifact symlink at `.agentic-beacon/artifacts/agents/<name>.md`, AND remove the project-local symlinks at `.claude/agents/<name>.md` and `.opencode/agents/<name>.md`, as part of the atomic adopt commit. Reject SHALL NOT mutate any file in `~/.claude/agents/` or `~/.config/opencode/agents/`.
+When `abc adopt` rejects an agent (action: `reject`), the system SHALL remove the entry from `beacon.yaml.artifacts.agents` (if present), remove the artifact symlink at `.agentic-beacon/artifacts/agents/<name>.md`, AND remove the Beacon-owned project-local symlinks at `.claude/agents/<name>.md` and `.opencode/agents/<name>.md` (symlinks pointing elsewhere are preserved per the "Unwire only Beacon-owned tool symlinks" requirement), as part of the atomic adopt commit. Reject SHALL NOT mutate any file in `~/.claude/agents/` or `~/.config/opencode/agents/`.
 
 #### Scenario: Reject removes wiring
 - **WHEN** the user marks an already-wired `agents/spec-planner.md` as `reject` in `abc adopt` and confirms


### PR DESCRIPTION
## Summary

- `unwire_agent` / `unwire_agent_with_undo` now verify the symlink target resolves to `.agentic-beacon/artifacts/agents/<name>.md` before unlinking
- User-created symlinks at the same leaf path are preserved with a warning (mirrors PR #109 round-5 regular-file policy)
- Spec: new "Unwire only Beacon-owned tool symlinks" requirement with two scenarios
- Tests: 6 new cases covering user-symlink-elsewhere, dangling-symlink, mixed, and undo-list filtering

Closes PER-132.

## Why

Bot Medium finding on PR #109 round 7. The unwire functions documented "Only Beacon-created symlinks are removed" but the code unlinked any symlink at the agent leaf — silently destroying user-owned symlinks if the user happened to put one at `.claude/agents/foo.md`. PR #109 round 5 fixed the symmetric *regular-file* case; this is the symlink-pointing-elsewhere variant.

Decision: Option (a) per the ticket — update the spec + the code (safer than just patching the docstring).

## Test plan

- [x] `pytest -k unwire` → 16/16 passing (10 existing + 6 new)
- [x] Out-of-scope guardrails clean (no changes to wire_agent_*, legacy_cleanup, orchestrator)
- [x] ruff clean
- [x] Old "Only Beacon-created symlinks are removed" docstring removed
- [ ] CI green
- [ ] opencode-review bot clean

## Out of scope (intentional)

- `wire_agent_claudecode` / `wire_agent_opencode` — owned by PER-134
- `cleanup_legacy_global_agent_symlinks` — owned by PER-133