### PR TITLE
perf(beacon): one-shot marker for legacy global-agent cleanup (PER-133)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ uv.lock
 .agentic-beacon/artifacts/
 .agentic-beacon/warehouse-catalog.md
 .agentic-beacon/pending.yaml
+.agentic-beacon/.legacy-migrated
 
 # Local sample-warehouse checkout (developer convenience; never a submodule)
 sample-warehouse/

--- a/libs/beacon/src/beacon/domains/distribution/legacy_cleanup.py
+++ b/libs/beacon/src/beacon/domains/distribution/legacy_cleanup.py
@@ -1,33 +1,51 @@
 """Legacy global-agent symlink cleanup for the distribution domain.
 
 PER-113 migration: scans `~/.claude/agents/` and `~/.config/opencode/agents/`
-on every `abc sync` invocation and removes symlinks pointing into the
-connected warehouse's `agents/` directory. Idempotent — subsequent runs find
-nothing and return 0. A run-once marker (so the cleanup only fires the first
-time after upgrade) is tracked separately in PER-133.
+on the first `abc sync` invocation after upgrade and removes symlinks pointing
+into the connected warehouse's `agents/` directory. A run-once marker at
+`<project_root>/.agentic-beacon/.legacy-migrated` is written after the first
+successful scan so that subsequent syncs skip the home-dir I/O entirely.
+Delete that marker file to re-run the cleanup.
 """
 
+from datetime import UTC, datetime
 from pathlib import Path
 
 from loguru import logger
 
 
-def cleanup_legacy_global_agent_symlinks(warehouse_path: Path) -> int:
+def cleanup_legacy_global_agent_symlinks(
+    warehouse_path: Path, project_root: Path
+) -> int:
     """Remove legacy global agent symlinks that point into the connected warehouse.
 
-    Scans ~/.claude/agents/ and ~/.config/opencode/agents/ non-recursively.
-    For each entry that is a symlink whose resolved target is under
-    ``warehouse_path / "agents"``, unlinks it.
+    On the first call (no marker present), scans ~/.claude/agents/ and
+    ~/.config/opencode/agents/ non-recursively. For each entry that is a
+    symlink whose resolved target is under ``warehouse_path / "agents"``,
+    unlinks it. After the scan completes (whether or not anything was removed),
+    writes a marker at ``project_root / ".agentic-beacon" / ".legacy-migrated"``
+    so that all future calls short-circuit with 0 home-dir I/O.
 
-    Idempotent: subsequent calls find no matching symlinks and return 0.
-    Missing tool directories are silently skipped.
+    If the marker already exists, the function returns 0 immediately without
+    touching the filesystem.
+
+    Escape hatch: delete ``.agentic-beacon/.legacy-migrated`` to re-run the
+    cleanup. The marker lives under ``.agentic-beacon/``, which is
+    project-internal and gitignored via the project ``.gitignore``.
 
     Args:
         warehouse_path: Absolute path to the connected warehouse root.
+        project_root: Absolute path to the project root (where
+            ``.agentic-beacon/`` lives).
 
     Returns:
-        The total number of symlinks removed across both directories.
+        The total number of symlinks removed across both directories, or 0
+        when the marker is present and the scan is skipped.
     """
+    marker = project_root / ".agentic-beacon" / ".legacy-migrated"
+    if marker.exists():
+        return 0
+
     home = Path.home()
     global_agent_dirs = [
         home / ".claude" / "agents",
@@ -83,4 +101,11 @@ def cleanup_legacy_global_agent_symlinks(warehouse_path: Path) -> int:
                     "Could not remove legacy agent symlink {}: {}", entry, exc
                 )
 
+    # Write marker regardless of how many were removed; the marker means
+    # "scan ran", not "scan removed something".
+    marker.parent.mkdir(parents=True, exist_ok=True)
+    marker.write_text(
+        f"PER-113 legacy global-agent cleanup ran: {datetime.now(UTC).isoformat()}\n",
+        encoding="utf-8",
+    )
     return removed

--- a/libs/beacon/src/beacon/domains/distribution/orchestrator.py
+++ b/libs/beacon/src/beacon/domains/distribution/orchestrator.py
@@ -534,7 +534,9 @@ def run_sync(
     # Legacy global agent symlink cleanup (PER-113 migration)
     legacy_agents_cleaned = 0
     if not dry_run:
-        legacy_agents_cleaned = cleanup_legacy_global_agent_symlinks(warehouse_path)
+        legacy_agents_cleaned = cleanup_legacy_global_agent_symlinks(
+            warehouse_path, project_root
+        )
 
     adoption_notification = None
     if not dry_run:

--- a/libs/beacon/tests/unit/test_legacy_agent_cleanup.py
+++ b/libs/beacon/tests/unit/test_legacy_agent_cleanup.py
@@ -1,6 +1,6 @@
 """Unit tests for cleanup_legacy_global_agent_symlinks.
 
-Covers TC1-TC10 from task 4.1.
+Covers TC1-TC10 from task 4.1, plus marker-skip behavior (PER-133).
 All tests use tmp_path fixtures to simulate home dirs without touching real ~/.claude.
 """
 
@@ -26,6 +26,13 @@ def _make_home(tmp_path: Path) -> Path:
     return home
 
 
+def _make_project_root(tmp_path: Path) -> Path:
+    """Create a fake project root."""
+    project = tmp_path / "project"
+    project.mkdir()
+    return project
+
+
 def _patch_home(home: Path):
     """Context manager to patch Path.home() to return a fake home."""
     return patch.object(Path, "home", return_value=home)
@@ -36,6 +43,7 @@ class TestCleanupLegacyGlobalAgentSymlinks:
         """TC1: legacy symlink in ~/.claude/agents/ targeting warehouse/agents/foo.md → removed."""
         warehouse = _make_warehouse(tmp_path)
         home = _make_home(tmp_path)
+        project_root = _make_project_root(tmp_path)
 
         agent_file = warehouse / "agents" / "foo.md"
         agent_file.write_text("agent")
@@ -46,7 +54,7 @@ class TestCleanupLegacyGlobalAgentSymlinks:
         legacy.symlink_to(agent_file)
 
         with _patch_home(home):
-            count = cleanup_legacy_global_agent_symlinks(warehouse)
+            count = cleanup_legacy_global_agent_symlinks(warehouse, project_root)
 
         assert count == 1
         assert not legacy.exists() and not legacy.is_symlink()
@@ -55,6 +63,7 @@ class TestCleanupLegacyGlobalAgentSymlinks:
         """TC2: legacy symlink in ~/.config/opencode/agents/ targeting warehouse/agents/foo.md → removed."""
         warehouse = _make_warehouse(tmp_path)
         home = _make_home(tmp_path)
+        project_root = _make_project_root(tmp_path)
 
         agent_file = warehouse / "agents" / "foo.md"
         agent_file.write_text("agent")
@@ -65,7 +74,7 @@ class TestCleanupLegacyGlobalAgentSymlinks:
         legacy.symlink_to(agent_file)
 
         with _patch_home(home):
-            count = cleanup_legacy_global_agent_symlinks(warehouse)
+            count = cleanup_legacy_global_agent_symlinks(warehouse, project_root)
 
         assert count == 1
         assert not legacy.exists() and not legacy.is_symlink()
@@ -74,6 +83,7 @@ class TestCleanupLegacyGlobalAgentSymlinks:
         """TC3: symlink in ~/.claude/agents/ pointing elsewhere → preserved."""
         warehouse = _make_warehouse(tmp_path)
         home = _make_home(tmp_path)
+        project_root = _make_project_root(tmp_path)
 
         elsewhere = tmp_path / "elsewhere.md"
         elsewhere.write_text("not warehouse")
@@ -84,7 +94,7 @@ class TestCleanupLegacyGlobalAgentSymlinks:
         safe.symlink_to(elsewhere)
 
         with _patch_home(home):
-            count = cleanup_legacy_global_agent_symlinks(warehouse)
+            count = cleanup_legacy_global_agent_symlinks(warehouse, project_root)
 
         assert count == 0
         assert safe.is_symlink()
@@ -93,6 +103,7 @@ class TestCleanupLegacyGlobalAgentSymlinks:
         """TC4: regular file in ~/.claude/agents/handcrafted.md → preserved."""
         warehouse = _make_warehouse(tmp_path)
         home = _make_home(tmp_path)
+        project_root = _make_project_root(tmp_path)
 
         claude_agents = home / ".claude" / "agents"
         claude_agents.mkdir(parents=True)
@@ -100,7 +111,7 @@ class TestCleanupLegacyGlobalAgentSymlinks:
         regular.write_text("handcrafted")
 
         with _patch_home(home):
-            count = cleanup_legacy_global_agent_symlinks(warehouse)
+            count = cleanup_legacy_global_agent_symlinks(warehouse, project_root)
 
         assert count == 0
         assert regular.read_text() == "handcrafted"
@@ -109,11 +120,12 @@ class TestCleanupLegacyGlobalAgentSymlinks:
         """TC5: ~/.config/opencode/agents/ does not exist → function skips without error."""
         warehouse = _make_warehouse(tmp_path)
         home = _make_home(tmp_path)
+        project_root = _make_project_root(tmp_path)
         # Only create .claude/agents/, not .config/opencode/agents/
         (home / ".claude" / "agents").mkdir(parents=True)
 
         with _patch_home(home):
-            count = cleanup_legacy_global_agent_symlinks(warehouse)
+            count = cleanup_legacy_global_agent_symlinks(warehouse, project_root)
 
         assert count == 0
 
@@ -121,6 +133,7 @@ class TestCleanupLegacyGlobalAgentSymlinks:
         """TC6: dangling symlink (target does not exist) → preserved."""
         warehouse = _make_warehouse(tmp_path)
         home = _make_home(tmp_path)
+        project_root = _make_project_root(tmp_path)
 
         claude_agents = home / ".claude" / "agents"
         claude_agents.mkdir(parents=True)
@@ -129,7 +142,7 @@ class TestCleanupLegacyGlobalAgentSymlinks:
         dangling.symlink_to(warehouse / "agents" / "nonexistent.md")
 
         with _patch_home(home):
-            count = cleanup_legacy_global_agent_symlinks(warehouse)
+            count = cleanup_legacy_global_agent_symlinks(warehouse, project_root)
 
         # A dangling symlink whose target path resolves under warehouse/agents/
         # IS removed: resolve(strict=False) returns the canonical target path
@@ -142,6 +155,7 @@ class TestCleanupLegacyGlobalAgentSymlinks:
         """TC7: subdirectory containing symlinks → not recursed into; nested entries preserved."""
         warehouse = _make_warehouse(tmp_path)
         home = _make_home(tmp_path)
+        project_root = _make_project_root(tmp_path)
 
         claude_agents = home / ".claude" / "agents"
         (claude_agents / "subdir").mkdir(parents=True)
@@ -152,7 +166,7 @@ class TestCleanupLegacyGlobalAgentSymlinks:
         nested_symlink.symlink_to(agent_file)
 
         with _patch_home(home):
-            count = cleanup_legacy_global_agent_symlinks(warehouse)
+            count = cleanup_legacy_global_agent_symlinks(warehouse, project_root)
 
         assert count == 0
         assert nested_symlink.is_symlink()
@@ -161,6 +175,7 @@ class TestCleanupLegacyGlobalAgentSymlinks:
         """TC8: warehouse_path itself is a symlink → resolution still matches."""
         actual_warehouse = _make_warehouse(tmp_path)
         home = _make_home(tmp_path)
+        project_root = _make_project_root(tmp_path)
 
         # Create a symlink to the warehouse
         warehouse_link = tmp_path / "warehouse-link"
@@ -176,7 +191,7 @@ class TestCleanupLegacyGlobalAgentSymlinks:
 
         # Pass the symlinked path; function should still detect the match
         with _patch_home(home):
-            count = cleanup_legacy_global_agent_symlinks(warehouse_link)
+            count = cleanup_legacy_global_agent_symlinks(warehouse_link, project_root)
 
         assert count == 1
         assert not legacy.exists() and not legacy.is_symlink()
@@ -185,11 +200,12 @@ class TestCleanupLegacyGlobalAgentSymlinks:
         """TC9: empty home agent dirs → returns 0; no exception."""
         warehouse = _make_warehouse(tmp_path)
         home = _make_home(tmp_path)
+        project_root = _make_project_root(tmp_path)
         (home / ".claude" / "agents").mkdir(parents=True)
         (home / ".config" / "opencode" / "agents").mkdir(parents=True)
 
         with _patch_home(home):
-            count = cleanup_legacy_global_agent_symlinks(warehouse)
+            count = cleanup_legacy_global_agent_symlinks(warehouse, project_root)
 
         assert count == 0
 
@@ -197,6 +213,7 @@ class TestCleanupLegacyGlobalAgentSymlinks:
         """TC10: 50 matching symlinks → all 50 removed; returned count is 50."""
         warehouse = _make_warehouse(tmp_path)
         home = _make_home(tmp_path)
+        project_root = _make_project_root(tmp_path)
 
         claude_agents = home / ".claude" / "agents"
         claude_agents.mkdir(parents=True)
@@ -207,7 +224,7 @@ class TestCleanupLegacyGlobalAgentSymlinks:
             (claude_agents / f"agent-{i:02d}.md").symlink_to(agent_file)
 
         with _patch_home(home):
-            count = cleanup_legacy_global_agent_symlinks(warehouse)
+            count = cleanup_legacy_global_agent_symlinks(warehouse, project_root)
 
         assert count == 50
         for i in range(50):
@@ -217,6 +234,7 @@ class TestCleanupLegacyGlobalAgentSymlinks:
         """Symlinks removed from both dirs contribute to the total count."""
         warehouse = _make_warehouse(tmp_path)
         home = _make_home(tmp_path)
+        project_root = _make_project_root(tmp_path)
 
         agent_file = warehouse / "agents" / "shared.md"
         agent_file.write_text("shared agent")
@@ -230,7 +248,7 @@ class TestCleanupLegacyGlobalAgentSymlinks:
         (opencode_agents / "shared.md").symlink_to(agent_file)
 
         with _patch_home(home):
-            count = cleanup_legacy_global_agent_symlinks(warehouse)
+            count = cleanup_legacy_global_agent_symlinks(warehouse, project_root)
 
         assert count == 2
         assert not (claude_agents / "shared.md").is_symlink()
@@ -240,6 +258,7 @@ class TestCleanupLegacyGlobalAgentSymlinks:
         """Second run after cleanup returns 0 and raises no error."""
         warehouse = _make_warehouse(tmp_path)
         home = _make_home(tmp_path)
+        project_root = _make_project_root(tmp_path)
 
         agent_file = warehouse / "agents" / "foo.md"
         agent_file.write_text("agent")
@@ -249,8 +268,81 @@ class TestCleanupLegacyGlobalAgentSymlinks:
         (claude_agents / "foo.md").symlink_to(agent_file)
 
         with _patch_home(home):
-            count1 = cleanup_legacy_global_agent_symlinks(warehouse)
-            count2 = cleanup_legacy_global_agent_symlinks(warehouse)
+            count1 = cleanup_legacy_global_agent_symlinks(warehouse, project_root)
+            count2 = cleanup_legacy_global_agent_symlinks(warehouse, project_root)
 
         assert count1 == 1
+        # Second call short-circuits via marker
         assert count2 == 0
+
+    def test_cleanup_writes_marker_after_first_run(self, tmp_path):
+        """Marker file is written after the first scan, even when nothing was removed."""
+        warehouse = _make_warehouse(tmp_path)
+        home = _make_home(tmp_path)
+        project_root = _make_project_root(tmp_path)
+
+        marker = project_root / ".agentic-beacon" / ".legacy-migrated"
+        assert not marker.exists()
+
+        with _patch_home(home):
+            cleanup_legacy_global_agent_symlinks(warehouse, project_root)
+
+        assert marker.exists()
+        assert "PER-113" in marker.read_text()
+
+    def test_cleanup_skipped_when_marker_present(self, tmp_path):
+        """When the marker exists, the home-dir scan is skipped entirely."""
+        warehouse = _make_warehouse(tmp_path)
+        home = _make_home(tmp_path)
+        project_root = _make_project_root(tmp_path)
+
+        # Pre-create a symlink that would be removed if the scan ran
+        agent_file = warehouse / "agents" / "foo.md"
+        agent_file.write_text("agent")
+        claude_agents = home / ".claude" / "agents"
+        claude_agents.mkdir(parents=True)
+        legacy = claude_agents / "foo.md"
+        legacy.symlink_to(agent_file)
+
+        # Write marker to simulate "already ran"
+        marker = project_root / ".agentic-beacon" / ".legacy-migrated"
+        marker.parent.mkdir(parents=True, exist_ok=True)
+        marker.write_text("already ran\n")
+
+        with _patch_home(home):
+            count = cleanup_legacy_global_agent_symlinks(warehouse, project_root)
+
+        assert count == 0
+        # Symlink untouched because scan was skipped
+        assert legacy.is_symlink()
+
+    def test_marker_deletion_re_enables_cleanup(self, tmp_path):
+        """Deleting the marker allows the scan to run again on the next call."""
+        warehouse = _make_warehouse(tmp_path)
+        home = _make_home(tmp_path)
+        project_root = _make_project_root(tmp_path)
+
+        agent_file = warehouse / "agents" / "foo.md"
+        agent_file.write_text("agent")
+        claude_agents = home / ".claude" / "agents"
+        claude_agents.mkdir(parents=True)
+
+        marker = project_root / ".agentic-beacon" / ".legacy-migrated"
+
+        with _patch_home(home):
+            # First call: marker absent, scan runs but finds nothing (no symlinks yet)
+            count1 = cleanup_legacy_global_agent_symlinks(warehouse, project_root)
+            assert count1 == 0
+            assert marker.exists()
+
+            # Delete marker and add a symlink for the second call to find
+            marker.unlink()
+            legacy = claude_agents / "foo.md"
+            legacy.symlink_to(agent_file)
+
+            # Second call: marker absent again, scan runs and removes symlink
+            count2 = cleanup_legacy_global_agent_symlinks(warehouse, project_root)
+
+        assert count2 == 1
+        assert not legacy.is_symlink()
+        assert marker.exists()


### PR DESCRIPTION
## Summary

- `cleanup_legacy_global_agent_symlinks` now takes `project_root` and writes `.agentic-beacon/.legacy-migrated` after the first run
- Subsequent `abc sync` invocations short-circuit immediately — no home-dir I/O
- Marker is gitignored; deleting it re-enables the cleanup (escape hatch)
- Tests: +3 cases (writes marker, skipped when present, deletion re-enables)

Closes PER-133.

## Why

Bot Medium finding on PR #109 round 7: the legacy cleanup was idempotent but ran on every sync, scanning two home dirs and stat-ing every entry. Cheap but unnecessary after the first run. A one-shot marker eliminates the I/O entirely.

## Test plan

- [x] `pytest test_legacy_agent_cleanup.py` → 15/15 passing (12 existing + 3 new)
- [x] Out-of-scope guardrails clean (no changes to wiring.py or spec)
- [x] ruff clean
- [x] `datetime.UTC` import consistent with 3 other modules in the repo
- [ ] CI green
- [ ] opencode-review bot clean

## Out of scope

- Marker location (must stay under `.agentic-beacon/`)
- Tracking what was cleaned (just whether cleanup has run)