### PR TITLE
fix(beacon): wire_agent_* compares resolved canonical paths (PER-134)

### DIFF
--- a/libs/beacon/src/beacon/domains/setup/wiring.py
+++ b/libs/beacon/src/beacon/domains/setup/wiring.py
@@ -360,7 +360,7 @@ def wire_agent_claudecode(project_root: Path, artifact_file: Path) -> Path:
 
     if dest.is_symlink():
         try:
-            if dest.readlink() == artifact_file:
+            if dest.resolve(strict=False) == artifact_file.resolve(strict=False):
                 return dest
         except OSError:
             pass
@@ -410,7 +410,7 @@ def wire_agent_opencode(project_root: Path, artifact_file: Path) -> Path:
 
     if dest.is_symlink():
         try:
-            if dest.readlink() == artifact_file:
+            if dest.resolve(strict=False) == artifact_file.resolve(strict=False):
                 return dest
         except OSError:
             pass

--- a/libs/beacon/tests/unit/test_wire_agents.py
+++ b/libs/beacon/tests/unit/test_wire_agents.py
@@ -623,3 +623,52 @@ def test_regular_file_conflict_error_empty_conflicts_raises_value_error():
 def test_regular_file_conflict_error_is_beacon_sync_error_subclass():
     """RegularFileConflictError must be a subclass of BeaconSyncError."""
     assert issubclass(RegularFileConflictError, BeaconSyncError)
+
+
+# ---------------------------------------------------------------------------
+# PER-134: resolve()-based path comparison handles relative symlinks
+# ---------------------------------------------------------------------------
+
+
+def test_wire_agent_claudecode_idempotent_with_relative_readlink(tmp_path):
+    """Symlink created with a relative path is treated as identical to the absolute artifact_file."""
+    project_root = tmp_path / "project"
+    artifact_file = project_root / ".agentic-beacon" / "artifacts" / "agents" / "foo.md"
+    artifact_file.parent.mkdir(parents=True, exist_ok=True)
+    artifact_file.write_text("# foo")
+
+    claude_dir = project_root / ".claude" / "agents"
+    claude_dir.mkdir(parents=True, exist_ok=True)
+    rel_target = (
+        Path("..") / ".." / ".agentic-beacon" / "artifacts" / "agents" / "foo.md"
+    )
+    (claude_dir / "foo.md").symlink_to(rel_target)
+
+    pre_inode = (claude_dir / "foo.md").lstat().st_ino
+    result = wire_agent_claudecode(project_root, artifact_file)
+    post_inode = (claude_dir / "foo.md").lstat().st_ino
+
+    assert pre_inode == post_inode  # idempotent — not replaced
+    assert result == claude_dir / "foo.md"
+
+
+def test_wire_agent_opencode_idempotent_with_relative_readlink(tmp_path):
+    """Symmetric test for wire_agent_opencode: relative symlink is kept, not replaced."""
+    project_root = tmp_path / "project"
+    artifact_file = project_root / ".agentic-beacon" / "artifacts" / "agents" / "bar.md"
+    artifact_file.parent.mkdir(parents=True, exist_ok=True)
+    artifact_file.write_text("# bar")
+
+    opencode_dir = project_root / ".opencode" / "agents"
+    opencode_dir.mkdir(parents=True, exist_ok=True)
+    rel_target = (
+        Path("..") / ".." / ".agentic-beacon" / "artifacts" / "agents" / "bar.md"
+    )
+    (opencode_dir / "bar.md").symlink_to(rel_target)
+
+    pre_inode = (opencode_dir / "bar.md").lstat().st_ino
+    result = wire_agent_opencode(project_root, artifact_file)
+    post_inode = (opencode_dir / "bar.md").lstat().st_ino
+
+    assert pre_inode == post_inode  # idempotent — not replaced
+    assert result == opencode_dir / "bar.md"


### PR DESCRIPTION
## Summary

- Replace `dest.readlink() == artifact_file` with `dest.resolve(strict=False) == artifact_file.resolve(strict=False)` in `wire_agent_claudecode` and `wire_agent_opencode`
- Tests: +2 idempotency cases pinning the relative-vs-absolute path equivalence

Closes PER-134.

## Why

Bot Low finding on PR #109 round 7. The previous comparison treated absolute and relative readlink targets as different even when they pointed at the same canonical file — leading to a needless symlink replace (and brief inode churn) on `abc sync` if the symlink had been created via a relative path.

The fix accepts a single extra `realpath` per wire call; trade-off explicitly accepted in the ticket.

## Test plan

- [x] `pytest -k wire_agent` → 37/37 passing (35 existing + 2 new idempotency cases)
- [x] Out-of-scope guardrails clean (no changes to unwire_agent / legacy_cleanup)
- [x] `rg "dest.readlink() == artifact_file"` → 0 matches (old pattern gone)
- [x] `rg "dest.resolve(strict=False) == artifact_file.resolve(strict=False)"` → 2 matches (both callsites)
- [x] ruff clean
- [ ] CI green
- [ ] opencode-review bot clean