### PR TITLE
test: unskip TC7 reject-rollback (PER-124) + fix latent rollback gap

### DIFF
--- a/libs/beacon/CHANGELOG.md
+++ b/libs/beacon/CHANGELOG.md
@@ -6,7 +6,7 @@
 ### ⚠ BREAKING CHANGES
 
 * auto-pull artifact dependencies via frontmatter ([#102](https://github.com/Shadowsong27/agentic-beacon/issues/102))
-* 
+*
 
 ### Features
 

--- a/libs/beacon/src/beacon/domains/adoption/apply.py
+++ b/libs/beacon/src/beacon/domains/adoption/apply.py
@@ -151,6 +151,7 @@ def commit_session(
     beacon_yaml_path: Path,
     _symlink_sync_fn: Callable[..., None] | None = None,
     _post_sync_wiring_fn: Callable[..., None] | None = None,
+    _unlink_fn: Callable[[Path], None] | None = None,
 ) -> None:
     """Atomically commit a unified adopt session (warehouse browser + pending TODO).
 
@@ -177,6 +178,8 @@ def commit_session(
         beacon_yaml_path: Path to beacon.yaml.
         _symlink_sync_fn: Injectable sync function for testing rollback scenarios.
         _post_sync_wiring_fn: Injectable post-sync wiring hook for testing.
+        _unlink_fn: Injectable unlink callable for testing reject rollback scenarios;
+            defaults to Path.unlink. Production code never passes this.
     """
     from beacon.core.manifest.pending import PendingManifest
 
@@ -345,19 +348,35 @@ def commit_session(
         if agent_unadoptions:
             from beacon.domains.setup.wiring import unwire_agent_with_undo
 
+            unlink_fn: Callable[[Path], None] = _unlink_fn or Path.unlink
+
             for agent_path in agent_unadoptions:
                 agent_name = Path(agent_path).stem
-                removed = unwire_agent_with_undo(project_root, agent_name)
+                leaf = Path(agent_path).name
+
+                # Pre-snapshot all 3 symlinks before any removal so _rollback()
+                # can restore them even if unwire_agent_with_undo fails mid-operation.
+                for p in (
+                    project_root / ".claude" / "agents" / leaf,
+                    project_root / ".opencode" / "agents" / leaf,
+                    artifacts_path / agent_path,
+                ):
+                    kind, prior = _snapshot_path(p)
+                    tool_snapshots.append((p, kind, prior))
+
+                removed = unwire_agent_with_undo(
+                    project_root, agent_name, _unlink_fn=_unlink_fn
+                )
                 removed_paths_with_target.extend(removed)
 
                 # Bug 1 fix: also remove the artifact symlink atomically
                 artifact_symlink = artifacts_path / agent_path
                 if artifact_symlink.is_symlink():
                     target = artifact_symlink.readlink()
-                    artifact_symlink.unlink()
+                    unlink_fn(artifact_symlink)
                     removed_paths_with_target.append((artifact_symlink, target))
                 elif artifact_symlink.exists():
-                    artifact_symlink.unlink()
+                    unlink_fn(artifact_symlink)
 
         # 3. Rewrite pending.yaml (drop accepted + rejected; keep deferred).
         if pending_resolved or pre_pending:

--- a/libs/beacon/src/beacon/domains/setup/wiring.py
+++ b/libs/beacon/src/beacon/domains/setup/wiring.py
@@ -2,7 +2,7 @@
 
 import json
 import shutil
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 from pathlib import Path
 
 import click
@@ -619,7 +619,9 @@ def unwire_agent(project_root: Path, agent_name: str) -> None:
 
 
 def unwire_agent_with_undo(
-    project_root: Path, agent_name: str
+    project_root: Path,
+    agent_name: str,
+    _unlink_fn: Callable[[Path], None] | None = None,
 ) -> list[tuple[Path, Path]]:
     """Remove project-local agent symlinks, returning (path, target) pairs for rollback.
 
@@ -634,11 +636,15 @@ def unwire_agent_with_undo(
     Args:
         project_root: Project root directory.
         agent_name: Stem name of the agent (without .md extension), or full filename.
+        _unlink_fn: Callable used to unlink each symlink; defaults to Path.unlink.
+            Provided for testing rollback scenarios; production code never passes this.
 
     Returns:
         List of (path, target) pairs for each symlink successfully removed.
         User-owned symlinks and regular files at the agent paths are not included.
     """
+    unlink_fn: Callable[[Path], None] = _unlink_fn or Path.unlink
+
     leaf = Path(agent_name).name
     if not leaf.endswith(".md"):
         leaf = leaf + ".md"
@@ -661,7 +667,7 @@ def unwire_agent_with_undo(
                 )
                 continue
             target = dest.readlink()
-            dest.unlink()
+            unlink_fn(dest)
             removed.append((dest, target))
             logger.debug("Unwired agent: {}", dest)
         elif dest.exists():

--- a/libs/beacon/tests/integration/test_adopt_agent.py
+++ b/libs/beacon/tests/integration/test_adopt_agent.py
@@ -445,13 +445,102 @@ def test_accept_agent_rollback_on_wire_failure(
 
 
 def test_reject_agent_artifact_symlink_restored_on_failure(
-    project: tuple, warehouse: Path, monkeypatch
+    project: tuple, warehouse: Path
 ):
-    """Reject with mid-commit failure restores artifact symlink and tool symlinks."""
-    pytest.skip(
-        "TODO: patching Path.unlink to force a failure mid-reject is too brittle "
-        "without a dedicated injectable hook in the reject path; skipping per spec allowance."
+    """Reject with mid-commit I/O failure rolls back all 3 symlinks.
+
+    Uses the _unlink_fn seam to succeed on the first call (.claude symlink removed)
+    and raise OSError on the second call (.opencode symlink would be removed).
+    Asserts _rollback() restores beacon.yaml and all 3 paths to pre-commit state.
+    """
+    project_root, artifacts_path, beacon_yaml = project
+
+    # Need .opencode/ so all 3 paths are wired
+    (project_root / ".opencode").mkdir()
+
+    beacon_yaml.write_text(
+        "artifacts:\n"
+        "  contexts: []\n"
+        "  skills: []\n"
+        "  agents:\n"
+        "    - agents/spec-planner.md\n"
     )
+    pre_beacon_bytes = beacon_yaml.read_bytes()
+
+    # Pre-create all 3 symlinks
+    artifact = artifacts_path / "agents" / "spec-planner.md"
+    artifact.parent.mkdir(parents=True, exist_ok=True)
+    artifact.symlink_to(warehouse / "agents" / "spec-planner.md")
+    pre_artifact_target = artifact.readlink()
+
+    claude_agents = project_root / ".claude" / "agents"
+    claude_agents.mkdir(parents=True, exist_ok=True)
+    claude_link = claude_agents / "spec-planner.md"
+    claude_link.symlink_to(artifact)
+    pre_claude_target = claude_link.readlink()
+
+    oc_agents = project_root / ".opencode" / "agents"
+    oc_agents.mkdir(parents=True, exist_ok=True)
+    oc_link = oc_agents / "spec-planner.md"
+    oc_link.symlink_to(artifact)
+    pre_oc_target = oc_link.readlink()
+
+    # _unlink_fn: succeed on first call (.claude removed), fail on second (.opencode)
+    call_count = {"n": 0}
+
+    def _failing_unlink(path: Path) -> None:
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            path.unlink()
+        else:
+            raise OSError("forced unlink failure")
+
+    agent_candidate = AdoptCandidate(
+        artifact_type="agents",
+        path="agents/spec-planner.md",
+        description="Plans specs",
+    )
+
+    from beacon.domains.adoption.apply import CommitError
+
+    with pytest.raises(CommitError):
+        commit_session(
+            to_adopt=[],
+            to_unadopt=["agents/spec-planner.md"],
+            pending_accept=[],
+            pending_reject=[],
+            candidates=[agent_candidate],
+            pending_entries=[],
+            project_root=project_root,
+            warehouse_path=warehouse,
+            artifacts_path=artifacts_path,
+            beacon_yaml_path=beacon_yaml,
+            _unlink_fn=_failing_unlink,
+        )
+
+    # Failing call was reached (first succeeded, second failed)
+    assert call_count["n"] >= 2
+
+    # beacon.yaml restored to pre-commit state
+    assert beacon_yaml.read_bytes() == pre_beacon_bytes, (
+        "beacon.yaml was not rolled back after reject failure"
+    )
+
+    # .claude symlink restored (was removed by the first successful unlink)
+    assert claude_link.is_symlink(), (
+        ".claude/agents/spec-planner.md should be restored after reject rollback"
+    )
+    assert claude_link.readlink() == pre_claude_target, (
+        ".claude/agents/spec-planner.md target changed after rollback"
+    )
+
+    # .opencode symlink untouched (unlink was never attempted due to failure)
+    assert oc_link.is_symlink(), ".opencode/agents/spec-planner.md should still exist"
+    assert oc_link.readlink() == pre_oc_target
+
+    # artifact symlink untouched (never reached)
+    assert artifact.is_symlink(), "artifact symlink should still exist after rollback"
+    assert artifact.readlink() == pre_artifact_target
 
 
 # ---------------------------------------------------------------------------

--- a/libs/beacon/tests/integration/test_adopt_agent.py
+++ b/libs/beacon/tests/integration/test_adopt_agent.py
@@ -447,11 +447,13 @@ def test_accept_agent_rollback_on_wire_failure(
 def test_reject_agent_artifact_symlink_restored_on_failure(
     project: tuple, warehouse: Path
 ):
-    """Reject with mid-commit I/O failure rolls back all 3 symlinks.
+    """Reject with post-artifact-unlink failure rolls back all 3 symlinks.
 
-    Uses the _unlink_fn seam to succeed on the first call (.claude symlink removed)
-    and raise OSError on the second call (.opencode symlink would be removed).
-    Asserts _rollback() restores beacon.yaml and all 3 paths to pre-commit state.
+    Uses the _unlink_fn seam to actually unlink on every call but raise OSError
+    after the third call (artifact symlink), which is the last unlink in the
+    reject sequence (.claude → .opencode → artifact).  Asserts _rollback()
+    restores beacon.yaml and all 3 paths — including the artifact symlink that
+    was successfully removed before the failure — to their pre-commit state.
     """
     project_root, artifacts_path, beacon_yaml = project
 
@@ -485,15 +487,16 @@ def test_reject_agent_artifact_symlink_restored_on_failure(
     oc_link.symlink_to(artifact)
     pre_oc_target = oc_link.readlink()
 
-    # _unlink_fn: succeed on first call (.claude removed), fail on second (.opencode)
+    # _unlink_fn: actually unlink on every call; raise AFTER call 3 (artifact).
+    # This simulates a post-unlink I/O failure that forces rollback after all 3
+    # symlinks have already been removed.
     call_count = {"n": 0}
 
     def _failing_unlink(path: Path) -> None:
         call_count["n"] += 1
-        if call_count["n"] == 1:
-            path.unlink()
-        else:
-            raise OSError("forced unlink failure")
+        path.unlink()
+        if call_count["n"] == 3:
+            raise OSError("forced post-unlink failure")
 
     agent_candidate = AdoptCandidate(
         artifact_type="agents",
@@ -518,15 +521,15 @@ def test_reject_agent_artifact_symlink_restored_on_failure(
             _unlink_fn=_failing_unlink,
         )
 
-    # Failing call was reached (first succeeded, second failed)
-    assert call_count["n"] >= 2
+    # All 3 unlinks were attempted; the 3rd raised after doing its work
+    assert call_count["n"] == 3
 
     # beacon.yaml restored to pre-commit state
     assert beacon_yaml.read_bytes() == pre_beacon_bytes, (
         "beacon.yaml was not rolled back after reject failure"
     )
 
-    # .claude symlink restored (was removed by the first successful unlink)
+    # .claude symlink restored (was removed by unlink call 1)
     assert claude_link.is_symlink(), (
         ".claude/agents/spec-planner.md should be restored after reject rollback"
     )
@@ -534,13 +537,21 @@ def test_reject_agent_artifact_symlink_restored_on_failure(
         ".claude/agents/spec-planner.md target changed after rollback"
     )
 
-    # .opencode symlink untouched (unlink was never attempted due to failure)
-    assert oc_link.is_symlink(), ".opencode/agents/spec-planner.md should still exist"
-    assert oc_link.readlink() == pre_oc_target
+    # .opencode symlink restored (was removed by unlink call 2)
+    assert oc_link.is_symlink(), (
+        ".opencode/agents/spec-planner.md should be restored after reject rollback"
+    )
+    assert oc_link.readlink() == pre_oc_target, (
+        ".opencode/agents/spec-planner.md target changed after rollback"
+    )
 
-    # artifact symlink untouched (never reached)
-    assert artifact.is_symlink(), "artifact symlink should still exist after rollback"
-    assert artifact.readlink() == pre_artifact_target
+    # artifact symlink restored (was removed by unlink call 3 before the raise)
+    assert artifact.is_symlink(), (
+        "artifact symlink should be restored after reject rollback"
+    )
+    assert artifact.readlink() == pre_artifact_target, (
+        "artifact symlink target changed after rollback"
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Unskips `test_reject_agent_artifact_symlink_restored_on_failure` (TC7) by adding a `_unlink_fn` test seam to `unwire_agent_with_undo` and `commit_session`. Production callers never pass it; default is `Path.unlink` so production behavior is unchanged.

While implementing the test, the delegate identified that the existing reject-rollback path was actually **broken**: `unwire_agent_with_undo` removes symlinks one-by-one and returns the list of (path, target) pairs. If it raises mid-removal, the partial list never reaches `commit_session`, so `_rollback()` has no record of the partial removals to restore. Without this fix, the test would fail to demonstrate rollback correctness because rollback was silently incomplete.

**Production fix:** `commit_session` now pre-snapshots all 3 agent paths (`.claude`, `.opencode`, artifact) into the existing `tool_snapshots` accumulator BEFORE calling `unwire_agent_with_undo`. The existing `_rollback()` already iterates `tool_snapshots` for accept-path rollback; the reject path now feeds the same accumulator. Idempotent rollback semantics preserved (rollback iterates current state and only fixes if needed).

Closes PER-124.

## Test plan

- [x] `pytest libs/beacon/tests/integration/test_adopt_agent.py -v` → 10 passed (was 9 passed + 1 skipped on main).
- [x] Full `pytest libs/beacon/tests/` → no new failures vs origin/main (7 env-specific pre-existing).
- [x] `_unlink_fn` defaults to `Path.unlink`; no production callsite passes it (verified by grep).
- [ ] CI green
- [ ] opencode-review bot clean

## Production behavior change

Reject of an agent now correctly restores all 3 symlinks if `unwire_agent_with_undo` raises mid-operation (e.g. unexpected I/O failure). Previously, partial removals were leaked. No effect on the happy path.