### PR TITLE
feat(beacon): wiring note when agents declared but no tool dirs (PER-121)

### DIFF
--- a/libs/beacon/CHANGELOG.md
+++ b/libs/beacon/CHANGELOG.md
@@ -6,7 +6,7 @@
 ### ⚠ BREAKING CHANGES
 
 * auto-pull artifact dependencies via frontmatter ([#102](https://github.com/Shadowsong27/agentic-beacon/issues/102))
-* 
+*
 
 ### Features
 

--- a/libs/beacon/src/beacon/cli/adoption.py
+++ b/libs/beacon/src/beacon/cli/adoption.py
@@ -149,7 +149,7 @@ def adopt(*, dry_run: bool) -> None:
         return
 
     try:
-        commit_session(
+        wiring_notes = commit_session(
             to_adopt=result.to_adopt,
             to_unadopt=result.to_unadopt,
             pending_accept=result.pending_accept,
@@ -199,6 +199,9 @@ def adopt(*, dry_run: bool) -> None:
             f"[green]✓[/green] Adopted {len(accepted_agents)} agent(s) "
             "(wired via abc sync or adopt)"
         )
+
+    for note in wiring_notes:
+        console.print(f"[yellow]ℹ[/yellow]\n{note}")
 
     if result.to_unadopt:
         cleanup_unadopted_artifacts(

--- a/libs/beacon/src/beacon/cli/adoption.py
+++ b/libs/beacon/src/beacon/cli/adoption.py
@@ -195,10 +195,16 @@ def adopt(*, dry_run: bool) -> None:
             )
 
     if accepted_agents:
-        console.print(
-            f"[green]✓[/green] Adopted {len(accepted_agents)} agent(s) "
-            "(wired via abc sync or adopt)"
-        )
+        if wiring_notes:
+            console.print(
+                f"[green]✓[/green] Adopted {len(accepted_agents)} agent(s) "
+                "(see wiring note below)"
+            )
+        else:
+            console.print(
+                f"[green]✓[/green] Adopted {len(accepted_agents)} agent(s) "
+                "(wired via abc sync or adopt)"
+            )
 
     for note in wiring_notes:
         console.print(f"[yellow]ℹ[/yellow]\n{note}")

--- a/libs/beacon/src/beacon/domains/adoption/apply.py
+++ b/libs/beacon/src/beacon/domains/adoption/apply.py
@@ -151,7 +151,7 @@ def commit_session(
     beacon_yaml_path: Path,
     _symlink_sync_fn: Callable[..., None] | None = None,
     _post_sync_wiring_fn: Callable[..., None] | None = None,
-) -> None:
+) -> list[str]:
     """Atomically commit a unified adopt session (warehouse browser + pending TODO).
 
     Two flows are merged into a single transaction:
@@ -211,6 +211,8 @@ def commit_session(
     new_pending_entries = [e for e in pending_entries if e.path not in pending_resolved]
 
     sync_fn = _symlink_sync_fn or _default_symlink_sync
+
+    wiring_notes: list[str] = []
 
     # Accumulators for filesystem rollback (Bug 2 fix)
     created_paths: list[Path] = []
@@ -273,6 +275,17 @@ def commit_session(
                     kind, prior = _snapshot_path(oc_dest)
                     tool_snapshots.append((oc_dest, kind, prior))
                     wire_agent_opencode(project_root, artifact_file)
+
+            if not detected_tools:
+                wiring_notes.append(
+                    "  Agents accepted but not wired — no tool directories found at"
+                    " project root.\n"
+                    "  Agent wiring into [bold].claude/agents/[/bold] and"
+                    " [bold].opencode/agents/[/bold] was skipped.\n"
+                    "  Create a tool directory then re-run [bold]abc sync[/bold]:\n"
+                    "    mkdir .claude    [dim]# for Claude Code[/dim]\n"
+                    "    mkdir .opencode  [dim]# for OpenCode[/dim]"
+                )
 
             # PER-113 (Finding 2): ensure root .gitignore has agent dir entries
             ensure_agent_dirs_gitignored(project_root)
@@ -370,6 +383,8 @@ def commit_session(
     except Exception as exc:
         _rollback()
         raise CommitError(f"Commit failed: {exc}") from exc
+
+    return wiring_notes
 
 
 def warehouse_uncommitted_paths(warehouse_path: Path) -> set[str]:

--- a/libs/beacon/src/beacon/domains/distribution/orchestrator.py
+++ b/libs/beacon/src/beacon/domains/distribution/orchestrator.py
@@ -453,6 +453,15 @@ def run_sync(
             for agent_entry in beacon_settings.artifacts.agents
         ]
         wire_agents_atomically(project_root, agent_artifact_files, detected_tools)
+        if beacon_settings.artifacts.agents and not detected_tools:
+            wiring_notes.append(
+                "  Agents declared but not wired — no tool directories found at project root.\n"
+                "  Agent wiring into [bold].claude/agents/[/bold] and"
+                " [bold].opencode/agents/[/bold] was skipped.\n"
+                "  Create a tool directory then re-run [bold]abc sync[/bold]:\n"
+                "    mkdir .claude    [dim]# for Claude Code[/dim]\n"
+                "    mkdir .opencode  [dim]# for OpenCode[/dim]"
+            )
 
     # Use effective set for wiring decisions
     has_contexts = bool(effective_set.contexts) and not dry_run

--- a/libs/beacon/tests/integration/test_adopt_command_agents.py
+++ b/libs/beacon/tests/integration/test_adopt_command_agents.py
@@ -343,3 +343,11 @@ def test_adopt_agent_with_no_tool_dirs_prints_wiring_note(
     assert "mkdir .claude" in r.output, (
         f"Expected remediation hint in adopt output; got:\n{r.output}"
     )
+
+    # The adopt summary must use the wiring-note variant, not the "wired" variant
+    assert "(see wiring note below)" in r.output, (
+        f"Expected '(see wiring note below)' in adopt output; got:\n{r.output}"
+    )
+    assert "(wired via abc sync or adopt)" not in r.output, (
+        f"Contradictory 'wired via abc sync or adopt' must not appear when wiring note fires; got:\n{r.output}"
+    )

--- a/libs/beacon/tests/integration/test_adopt_command_agents.py
+++ b/libs/beacon/tests/integration/test_adopt_command_agents.py
@@ -303,3 +303,43 @@ def test_adopt_mixed_agent_and_skill_records_both_in_beacon_yaml(
     )
     assert beacon["artifacts"]["agents"] == ["agents/code-reviewer.md"]
     assert beacon["artifacts"]["skills"] == ["skills/code-review/"]
+
+
+def test_adopt_agent_with_no_tool_dirs_prints_wiring_note(
+    valid_warehouse, temp_dir, monkeypatch, isolated_home
+):
+    """PER-121: when an agent is accepted but no .claude/ or .opencode/ dirs exist,
+    the adopt output must include a wiring note explaining the skip and remediation."""
+    import shutil
+
+    wh = _agent_warehouse(valid_warehouse)
+    project_dir, runner = _connected_project(wh, temp_dir, monkeypatch)
+
+    # Ensure no tool directories exist
+    for tool_dir in [project_dir / ".claude", project_dir / ".opencode"]:
+        if tool_dir.exists():
+            shutil.rmtree(tool_dir)
+
+    _force_interactive(monkeypatch)
+    _stub_adopt_app(monkeypatch, to_adopt=["agents/code-reviewer.md"])
+
+    r = runner.invoke(main, ["adopt"])
+    assert r.exit_code == 0, r.output
+
+    # beacon.yaml updated with agent
+    beacon = yaml.safe_load(
+        (project_dir / ".agentic-beacon" / "beacon.yaml").read_text()
+    )
+    assert beacon["artifacts"]["agents"] == ["agents/code-reviewer.md"]
+
+    # No tool symlinks created
+    assert not (project_dir / ".claude" / "agents" / "code-reviewer.md").exists()
+    assert not (project_dir / ".opencode" / "agents" / "code-reviewer.md").exists()
+
+    # Wiring note must explain the skip and the remediation
+    assert "no tool directories found" in r.output, (
+        f"Expected wiring note in adopt output; got:\n{r.output}"
+    )
+    assert "mkdir .claude" in r.output, (
+        f"Expected remediation hint in adopt output; got:\n{r.output}"
+    )

--- a/libs/beacon/tests/integration/test_agent_sync_lifecycle.py
+++ b/libs/beacon/tests/integration/test_agent_sync_lifecycle.py
@@ -229,6 +229,14 @@ def test_sync_creates_only_artifact_symlink_when_no_tool_dirs(
     assert not (project_dir / ".claude" / "agents" / "spec-planner.md").exists()
     assert not (project_dir / ".opencode" / "agents" / "spec-planner.md").exists()
 
+    # Wiring note must explain the skip and the remediation
+    assert "no tool directories found" in r.output, (
+        f"Expected wiring note in sync output; got:\n{r.output}"
+    )
+    assert "mkdir .claude" in r.output, (
+        f"Expected remediation hint in sync output; got:\n{r.output}"
+    )
+
 
 # ---------------------------------------------------------------------------
 # TC4: empty agents list → sync still succeeds


### PR DESCRIPTION
## Summary

When `beacon.yaml.artifacts.agents` is non-empty but neither `.claude/` nor `.opencode/` exists at the project root, `abc sync` and `abc adopt accept` now print a clear wiring note explaining:
1. Agent wiring was skipped.
2. No tool directories were detected.
3. Remediation: `mkdir .claude` (Claude Code) or `mkdir .opencode` (OpenCode), then re-run `abc sync`.

This is a UX fix only — no behavior change. The spec scenario "Neither tool configured → no error is raised" remains green.

## Implementation

- `domains/distribution/orchestrator.py`: appends note to existing `wiring_notes` accumulator after `wire_agents_atomically` when `agents` declared and `detected_tools=[]`.
- `domains/adoption/apply.py`: `commit_session` now returns `list[str]` of wiring notes; the agent-accept branch appends the same note when `not detected_tools`.
- `cli/adoption.py`: captures the return value and prints each note after the commit summary.

`commit_session` return-type change from `None` to `list[str]` is backwards-compatible — existing callsites (19 across unit/integration tests) discard the return value.

Closes PER-121.

## Test plan

- [x] `pytest libs/beacon/tests/integration/test_agent_sync_lifecycle.py libs/beacon/tests/integration/test_adopt_command_agents.py` → 19 passed (added 1 new + extended 1 existing).
- [x] Full `pytest libs/beacon/tests/` → no new failures vs origin/main.
- [x] `pre-commit run --all-files` → clean.
- [ ] CI green
- [ ] opencode-review bot clean

## Out of scope (per spec)

- Auto-creating `.claude/` or `.opencode/` (would violate Decision 1 of the project-agent-wiring spec).
- Erroring out instead of warning.