### PR TITLE
refactor(beacon): decouple abc list from SyncEngine via free function (PER-129)

### DIFF
--- a/libs/beacon/CHANGELOG.md
+++ b/libs/beacon/CHANGELOG.md
@@ -6,7 +6,7 @@
 ### ⚠ BREAKING CHANGES
 
 * auto-pull artifact dependencies via frontmatter ([#102](https://github.com/Shadowsong27/agentic-beacon/issues/102))
-* 
+*
 
 ### Features
 

--- a/libs/beacon/src/beacon/cli/agent.py
+++ b/libs/beacon/src/beacon/cli/agent.py
@@ -7,9 +7,11 @@ import click
 from rich.console import Console
 from rich.table import Table
 
+from beacon.core.exceptions import WorkspaceConfigError
 from beacon.core.manifest.beacon import BeaconManifest
-from beacon.core.manifest.workspace import WorkspaceConfig
-from beacon.domains.distribution.artifact_listing import list_artifacts
+from beacon.domains.distribution.artifact_listing import (
+    list_artifacts_with_config_check,
+)
 
 console = Console()
 
@@ -41,18 +43,12 @@ def list_cmd(*, artifact_type: str | None) -> None:
     beacon_dir = Path.cwd() / ".agentic-beacon"
     artifacts_dir = beacon_dir / "artifacts"
 
-    # Validate config.toml format if present so malformed config surfaces as an
-    # error rather than silently degrading. PER-129 decouples list from SyncEngine
-    # but preserves this validation behavior.
-    if (beacon_dir / "config.toml").is_file():
-        try:
-            WorkspaceConfig()  # constructor validates; result unused
-        except Exception as e:
-            console.print(f"[red]Error:[/red] config.toml is invalid: {e}")
-            sys.exit(1)
-
     if artifact_type == "agents":
-        artifacts = list_artifacts(artifacts_dir, "agents")
+        try:
+            artifacts = list_artifacts_with_config_check(beacon_dir, "agents")
+        except WorkspaceConfigError as e:
+            console.print(f"[red]Error:[/red] {e}")
+            sys.exit(1)
         agent_files = artifacts.get("agents", [])
         if not agent_files:
             # Distinguish "declared but not synced" from "none declared at all"
@@ -94,7 +90,11 @@ def list_cmd(*, artifact_type: str | None) -> None:
         "skills": ("Synced Skills", "yellow", "Skill"),
     }
 
-    artifacts = list_artifacts(artifacts_dir, artifact_type)
+    try:
+        artifacts = list_artifacts_with_config_check(beacon_dir, artifact_type)
+    except WorkspaceConfigError as e:
+        console.print(f"[red]Error:[/red] {e}")
+        sys.exit(1)
 
     for section, files in artifacts.items():
         title, color, col_name = section_config[section]

--- a/libs/beacon/src/beacon/cli/agent.py
+++ b/libs/beacon/src/beacon/cli/agent.py
@@ -8,6 +8,7 @@ from rich.console import Console
 from rich.table import Table
 
 from beacon.core.manifest.beacon import BeaconManifest
+from beacon.core.manifest.workspace import WorkspaceConfig
 from beacon.domains.distribution.artifact_listing import list_artifacts
 
 console = Console()
@@ -39,6 +40,16 @@ def list_cmd(*, artifact_type: str | None) -> None:
     """
     beacon_dir = Path.cwd() / ".agentic-beacon"
     artifacts_dir = beacon_dir / "artifacts"
+
+    # Validate config.toml format if present so malformed config surfaces as an
+    # error rather than silently degrading. PER-129 decouples list from SyncEngine
+    # but preserves this validation behavior.
+    if (beacon_dir / "config.toml").is_file():
+        try:
+            WorkspaceConfig()  # constructor validates; result unused
+        except Exception as e:
+            console.print(f"[red]Error:[/red] config.toml is invalid: {e}")
+            sys.exit(1)
 
     if artifact_type == "agents":
         artifacts = list_artifacts(artifacts_dir, "agents")

--- a/libs/beacon/src/beacon/cli/agent.py
+++ b/libs/beacon/src/beacon/cli/agent.py
@@ -80,6 +80,12 @@ def list_cmd(*, artifact_type: str | None) -> None:
         console.print(table)
         return
 
+    try:
+        artifacts = list_artifacts_with_config_check(beacon_dir, artifact_type)
+    except WorkspaceConfigError as e:
+        console.print(f"[red]Error:[/red] {e}")
+        sys.exit(1)
+
     if not artifacts_dir.exists():
         console.print("[red]Error:[/red] No synced artifacts found.")
         console.print("Run 'abc sync' to download artifacts from the warehouse.")
@@ -89,12 +95,6 @@ def list_cmd(*, artifact_type: str | None) -> None:
         "contexts": ("Synced Contexts", "cyan", "Context"),
         "skills": ("Synced Skills", "yellow", "Skill"),
     }
-
-    try:
-        artifacts = list_artifacts_with_config_check(beacon_dir, artifact_type)
-    except WorkspaceConfigError as e:
-        console.print(f"[red]Error:[/red] {e}")
-        sys.exit(1)
 
     for section, files in artifacts.items():
         title, color, col_name = section_config[section]

--- a/libs/beacon/src/beacon/cli/agent.py
+++ b/libs/beacon/src/beacon/cli/agent.py
@@ -8,8 +8,7 @@ from rich.console import Console
 from rich.table import Table
 
 from beacon.core.manifest.beacon import BeaconManifest
-from beacon.core.manifest.workspace import WorkspaceConfig
-from beacon.domains.distribution.sync_engine import SyncEngine
+from beacon.domains.distribution.artifact_listing import list_artifacts
 
 console = Console()
 
@@ -41,22 +40,8 @@ def list_cmd(*, artifact_type: str | None) -> None:
     beacon_dir = Path.cwd() / ".agentic-beacon"
     artifacts_dir = beacon_dir / "artifacts"
 
-    # Resolve the connected warehouse path from WorkspaceConfig only when a
-    # config.toml is present. SyncEngine.list_artifacts() only reads
-    # artifacts_path today, but the engine's __post_init__ resolves
-    # warehouse_path; fall back to beacon_dir on unconnected projects so the
-    # engine doesn't end up with a semantically-wrong Path.cwd(). A malformed
-    # but present config.toml is allowed to propagate (the user should fix
-    # their config rather than have abc list silently degrade).
-    if (beacon_dir / "config.toml").is_file():
-        warehouse_path = Path(WorkspaceConfig().warehouse.local_path)
-    else:
-        warehouse_path = beacon_dir
-
-    engine = SyncEngine(warehouse_path=warehouse_path, artifacts_path=artifacts_dir)
-
     if artifact_type == "agents":
-        artifacts = engine.list_artifacts("agents")
+        artifacts = list_artifacts(artifacts_dir, "agents")
         agent_files = artifacts.get("agents", [])
         if not agent_files:
             # Distinguish "declared but not synced" from "none declared at all"
@@ -98,7 +83,7 @@ def list_cmd(*, artifact_type: str | None) -> None:
         "skills": ("Synced Skills", "yellow", "Skill"),
     }
 
-    artifacts = engine.list_artifacts(artifact_type)
+    artifacts = list_artifacts(artifacts_dir, artifact_type)
 
     for section, files in artifacts.items():
         title, color, col_name = section_config[section]

--- a/libs/beacon/src/beacon/core/exceptions.py
+++ b/libs/beacon/src/beacon/core/exceptions.py
@@ -44,6 +44,12 @@ class ValidationError(ConfigurationError):
     pass
 
 
+class WorkspaceConfigError(ConfigurationError):
+    """Raised when workspace config.toml is present but invalid or malformed."""
+
+    pass
+
+
 class DirectoryNotFoundError(ConfigurationError):
     """Raised when .agentic-beacon directory not found."""
 

--- a/libs/beacon/src/beacon/domains/distribution/artifact_listing.py
+++ b/libs/beacon/src/beacon/domains/distribution/artifact_listing.py
@@ -11,16 +11,20 @@ from beacon.core.exceptions import WorkspaceConfigError
 def list_artifacts_with_config_check(
     beacon_dir: Path, artifact_type: str | None = None
 ) -> dict[str, list[str]]:
-    """Validate workspace config (if present) then list artifacts.
+    """Validate workspace config at beacon_dir/config.toml (if present) then list artifacts.
 
+    Reads and validates config.toml at the path implied by beacon_dir, not cwd.
     Raises WorkspaceConfigError if config.toml is present but malformed.
     """
-    if (beacon_dir / "config.toml").is_file():
+    config_path = beacon_dir / "config.toml"
+    if config_path.is_file():
         from beacon.core.manifest.workspace import WorkspaceConfig
 
         try:
-            WorkspaceConfig()
-        except (PydanticValidationError, tomllib.TOMLDecodeError) as exc:
+            with open(config_path, "rb") as f:
+                data = tomllib.load(f)
+            WorkspaceConfig.model_validate(data)
+        except (PydanticValidationError, tomllib.TOMLDecodeError, OSError) as exc:
             raise WorkspaceConfigError(f"config.toml is invalid: {exc}") from exc
     return list_artifacts(beacon_dir / "artifacts", artifact_type)
 

--- a/libs/beacon/src/beacon/domains/distribution/artifact_listing.py
+++ b/libs/beacon/src/beacon/domains/distribution/artifact_listing.py
@@ -1,0 +1,31 @@
+"""Free-function artifact listing — reads artifacts_path without requiring SyncEngine."""
+
+from pathlib import Path
+
+
+def list_artifacts(
+    artifacts_path: Path, artifact_type: str | None = None
+) -> dict[str, list[str]]:
+    """List synced artifacts by type.
+
+    Args:
+        artifacts_path: Path to the .agentic-beacon/artifacts/ directory.
+        artifact_type: Restrict to this section; omit to list contexts and skills.
+
+    Returns:
+        Dict mapping section name to sorted list of relative paths.
+    """
+    types_to_show = [artifact_type] if artifact_type else ["contexts", "skills"]
+    result: dict[str, list[str]] = {}
+    for section in types_to_show:
+        section_dir = artifacts_path / section
+        if not section_dir.exists():
+            continue
+        files = sorted(
+            str(f.relative_to(artifacts_path))
+            for f in section_dir.rglob("*")
+            if f.is_symlink() and not f.name.startswith(".")
+        )
+        if files:
+            result[section] = files
+    return result

--- a/libs/beacon/src/beacon/domains/distribution/artifact_listing.py
+++ b/libs/beacon/src/beacon/domains/distribution/artifact_listing.py
@@ -1,6 +1,28 @@
 """Free-function artifact listing — reads artifacts_path without requiring SyncEngine."""
 
+import tomllib
 from pathlib import Path
+
+from pydantic import ValidationError as PydanticValidationError
+
+from beacon.core.exceptions import WorkspaceConfigError
+
+
+def list_artifacts_with_config_check(
+    beacon_dir: Path, artifact_type: str | None = None
+) -> dict[str, list[str]]:
+    """Validate workspace config (if present) then list artifacts.
+
+    Raises WorkspaceConfigError if config.toml is present but malformed.
+    """
+    if (beacon_dir / "config.toml").is_file():
+        from beacon.core.manifest.workspace import WorkspaceConfig
+
+        try:
+            WorkspaceConfig()
+        except (PydanticValidationError, tomllib.TOMLDecodeError) as exc:
+            raise WorkspaceConfigError(f"config.toml is invalid: {exc}") from exc
+    return list_artifacts(beacon_dir / "artifacts", artifact_type)
 
 
 def list_artifacts(

--- a/libs/beacon/src/beacon/domains/distribution/sync_engine.py
+++ b/libs/beacon/src/beacon/domains/distribution/sync_engine.py
@@ -17,6 +17,10 @@ from pathlib import Path
 from loguru import logger
 from pydantic import BaseModel
 
+from beacon.domains.distribution.artifact_listing import (
+    list_artifacts as _list_artifacts,
+)
+
 
 class SyncResult(BaseModel):
     """Result of a sync operation on a single file."""
@@ -382,20 +386,7 @@ class SyncEngine:
 
     def list_artifacts(self, artifact_type: str | None = None) -> dict[str, list[str]]:
         """List synced artifacts by type."""
-        types_to_show = [artifact_type] if artifact_type else ["contexts", "skills"]
-        result: dict[str, list[str]] = {}
-        for section in types_to_show:
-            section_dir = self.artifacts_path / section
-            if not section_dir.exists():
-                continue
-            files = sorted(
-                str(f.relative_to(self.artifacts_path))
-                for f in section_dir.rglob("*")
-                if f.is_symlink() and not f.name.startswith(".")
-            )
-            if files:
-                result[section] = files
-        return result
+        return _list_artifacts(self.artifacts_path, artifact_type)
 
     def files_identical(self, file1: Path, file2: Path) -> bool:
         """Check if two files have identical content using hash comparison."""

--- a/libs/beacon/tests/integration/test_list_commands.py
+++ b/libs/beacon/tests/integration/test_list_commands.py
@@ -476,7 +476,8 @@ def test_list_fails_with_malformed_config_toml(runner, tmp_path, monkeypatch):
 
     beacon_dir = project / ".agentic-beacon"
     beacon_dir.mkdir()
-    (beacon_dir / "artifacts").mkdir()
+    # No artifacts dir — exercises the path where config is validated before the
+    # artifacts-dir existence check (regression for PER-129 round 4).
     # Plant invalid TOML — missing required [warehouse] section
     (beacon_dir / "config.toml").write_text("not valid toml !!!\n")
 

--- a/libs/beacon/tests/integration/test_list_commands.py
+++ b/libs/beacon/tests/integration/test_list_commands.py
@@ -463,6 +463,32 @@ def test_list_agents_no_artifacts_dir_needed(tmp_path, monkeypatch):
     assert "abc adopt" in result.output
 
 
+def test_list_fails_with_malformed_config_toml(runner, tmp_path, monkeypatch):
+    """abc list exits non-zero with a config.toml hint when the file is malformed.
+
+    Regression for PER-129: decoupling from SyncEngine must NOT silently degrade
+    when config.toml is present but invalid. The old code validated WorkspaceConfig
+    before listing; this test documents that contract.
+    """
+    project = tmp_path / "project"
+    project.mkdir()
+    monkeypatch.chdir(project)
+
+    beacon_dir = project / ".agentic-beacon"
+    beacon_dir.mkdir()
+    (beacon_dir / "artifacts").mkdir()
+    # Plant invalid TOML — missing required [warehouse] section
+    (beacon_dir / "config.toml").write_text("not valid toml !!!\n")
+
+    result = runner.invoke(main, ["list"])
+
+    assert result.exit_code != 0
+    assert "config.toml" in result.output.lower() or any(
+        kw in result.output.lower()
+        for kw in ("invalid", "error", "warehouse", "validation")
+    )
+
+
 def test_list_agents_not_shown_in_default_list(synced_project):
     """TC2: abc list (no filter) → agents section not shown (backward compatible).
 

--- a/libs/beacon/tests/integration/test_list_commands.py
+++ b/libs/beacon/tests/integration/test_list_commands.py
@@ -483,9 +483,12 @@ def test_list_fails_with_malformed_config_toml(runner, tmp_path, monkeypatch):
     result = runner.invoke(main, ["list"])
 
     assert result.exit_code != 0
-    assert "config.toml" in result.output.lower() or any(
-        kw in result.output.lower()
-        for kw in ("invalid", "error", "warehouse", "validation")
+    output_lower = result.output.lower()
+    assert "config.toml" in output_lower, (
+        f"Expected 'config.toml' in error output; got:\n{result.output}"
+    )
+    assert "invalid" in output_lower or "validation" in output_lower, (
+        f"Expected 'invalid' or 'validation' in error output; got:\n{result.output}"
     )
 
 

--- a/libs/beacon/tests/unit/domains/distribution/test_artifact_listing.py
+++ b/libs/beacon/tests/unit/domains/distribution/test_artifact_listing.py
@@ -1,9 +1,13 @@
-"""Unit tests for beacon.domains.distribution.artifact_listing.list_artifacts."""
+"""Unit tests for beacon.domains.distribution.artifact_listing."""
 
 from pathlib import Path
 
 import pytest
-from beacon.domains.distribution.artifact_listing import list_artifacts
+from beacon.core.exceptions import WorkspaceConfigError
+from beacon.domains.distribution.artifact_listing import (
+    list_artifacts,
+    list_artifacts_with_config_check,
+)
 
 
 @pytest.fixture
@@ -129,3 +133,63 @@ class TestListArtifactsSymlinkFiltering:
         result = list_artifacts(artifacts_dir, "skills")
 
         assert all(not Path(p).is_absolute() for p in result["skills"])
+
+
+class TestListArtifactsWithConfigCheck:
+    def test_returns_empty_dict_when_no_config_toml(self, tmp_path: Path) -> None:
+        beacon_dir = tmp_path / ".agentic-beacon"
+        beacon_dir.mkdir()
+
+        result = list_artifacts_with_config_check(beacon_dir)
+
+        assert result == {}
+
+    def test_raises_workspace_config_error_for_invalid_toml(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        beacon_dir = tmp_path / ".agentic-beacon"
+        beacon_dir.mkdir()
+        (beacon_dir / "config.toml").write_text("not valid toml !!!\n")
+
+        with pytest.raises(WorkspaceConfigError, match="config.toml is invalid"):
+            list_artifacts_with_config_check(beacon_dir)
+
+    def test_raises_workspace_config_error_for_missing_required_field(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        beacon_dir = tmp_path / ".agentic-beacon"
+        beacon_dir.mkdir()
+        # Valid TOML but missing required [warehouse] section
+        (beacon_dir / "config.toml").write_text("[other]\nkey = 'value'\n")
+
+        with pytest.raises(WorkspaceConfigError, match="config.toml is invalid"):
+            list_artifacts_with_config_check(beacon_dir)
+
+    def test_valid_config_does_not_raise(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        beacon_dir = tmp_path / ".agentic-beacon"
+        beacon_dir.mkdir()
+        (beacon_dir / "config.toml").write_text(
+            '[warehouse]\nlocal_path = "/some/absolute/path"\n'
+        )
+
+        result = list_artifacts_with_config_check(beacon_dir)
+
+        assert result == {}
+
+    def test_no_config_check_when_config_missing(self, tmp_path: Path) -> None:
+        beacon_dir = tmp_path / ".agentic-beacon"
+        beacon_dir.mkdir()
+        (beacon_dir / "artifacts" / "contexts").mkdir(parents=True)
+        ctx = beacon_dir / "artifacts" / "contexts" / "test.md"
+        target = beacon_dir / "artifacts" / "contexts" / "real.md"
+        target.write_text("content")
+        ctx.symlink_to(target)
+
+        result = list_artifacts_with_config_check(beacon_dir, "contexts")
+
+        assert "contexts" in result

--- a/libs/beacon/tests/unit/domains/distribution/test_artifact_listing.py
+++ b/libs/beacon/tests/unit/domains/distribution/test_artifact_listing.py
@@ -1,0 +1,131 @@
+"""Unit tests for beacon.domains.distribution.artifact_listing.list_artifacts."""
+
+from pathlib import Path
+
+import pytest
+from beacon.domains.distribution.artifact_listing import list_artifacts
+
+
+@pytest.fixture
+def artifacts_dir(tmp_path: Path) -> Path:
+    """Minimal .agentic-beacon/artifacts/ directory with symlinks."""
+    arts = tmp_path / "artifacts"
+    arts.mkdir()
+    return arts
+
+
+def _make_symlink(link: Path, target_name: str = "real.md") -> None:
+    target = link.parent / target_name
+    target.write_text("content")
+    link.symlink_to(target)
+
+
+class TestListArtifactsDefaults:
+    def test_returns_empty_dict_when_artifacts_dir_missing(
+        self, tmp_path: Path
+    ) -> None:
+        result = list_artifacts(tmp_path / "nonexistent")
+        assert result == {}
+
+    def test_returns_empty_dict_when_sections_missing(
+        self, artifacts_dir: Path
+    ) -> None:
+        result = list_artifacts(artifacts_dir)
+        assert result == {}
+
+    def test_default_shows_contexts_and_skills(self, artifacts_dir: Path) -> None:
+        (artifacts_dir / "contexts").mkdir()
+        ctx_link = artifacts_dir / "contexts" / "AGENTS.md"
+        _make_symlink(ctx_link)
+
+        (artifacts_dir / "skills").mkdir()
+        skill_link = artifacts_dir / "skills" / "SKILL.md"
+        _make_symlink(skill_link)
+
+        result = list_artifacts(artifacts_dir)
+
+        assert "contexts" in result
+        assert "skills" in result
+        assert "contexts/AGENTS.md" in result["contexts"]
+        assert "skills/SKILL.md" in result["skills"]
+
+    def test_default_excludes_agents_section(self, artifacts_dir: Path) -> None:
+        (artifacts_dir / "agents").mkdir()
+        _make_symlink(artifacts_dir / "agents" / "my-agent.md")
+
+        result = list_artifacts(artifacts_dir)
+
+        assert "agents" not in result
+
+
+class TestListArtifactsFiltered:
+    def test_filter_to_contexts_only(self, artifacts_dir: Path) -> None:
+        (artifacts_dir / "contexts").mkdir()
+        _make_symlink(artifacts_dir / "contexts" / "python.md")
+        (artifacts_dir / "skills").mkdir()
+        _make_symlink(artifacts_dir / "skills" / "SKILL.md")
+
+        result = list_artifacts(artifacts_dir, "contexts")
+
+        assert "contexts" in result
+        assert "skills" not in result
+
+    def test_filter_to_agents(self, artifacts_dir: Path) -> None:
+        (artifacts_dir / "agents").mkdir()
+        _make_symlink(artifacts_dir / "agents" / "my-agent.md")
+
+        result = list_artifacts(artifacts_dir, "agents")
+
+        assert "agents" in result
+        assert "agents/my-agent.md" in result["agents"]
+
+    def test_filter_to_missing_section_returns_empty(self, artifacts_dir: Path) -> None:
+        result = list_artifacts(artifacts_dir, "skills")
+        assert result == {}
+
+
+class TestListArtifactsSymlinkFiltering:
+    def test_excludes_regular_files(self, artifacts_dir: Path) -> None:
+        (artifacts_dir / "contexts").mkdir()
+        (artifacts_dir / "contexts" / "regular.md").write_text("not a symlink")
+
+        result = list_artifacts(artifacts_dir, "contexts")
+
+        assert result == {}
+
+    def test_excludes_dotfiles(self, artifacts_dir: Path) -> None:
+        (artifacts_dir / "contexts").mkdir()
+        hidden = artifacts_dir / "contexts" / ".hidden"
+        target = artifacts_dir / "contexts" / "target"
+        target.write_text("x")
+        hidden.symlink_to(target)
+
+        result = list_artifacts(artifacts_dir, "contexts")
+
+        assert result == {}
+
+    def test_results_are_sorted(self, artifacts_dir: Path) -> None:
+        (artifacts_dir / "contexts").mkdir()
+        for name in ("zzz.md", "aaa.md", "mmm.md"):
+            _make_symlink(artifacts_dir / "contexts" / name, f"real_{name}")
+
+        result = list_artifacts(artifacts_dir, "contexts")
+
+        assert result["contexts"] == sorted(result["contexts"])
+
+    def test_nested_symlinks_included(self, artifacts_dir: Path) -> None:
+        sub = artifacts_dir / "contexts" / "python"
+        sub.mkdir(parents=True)
+        _make_symlink(sub / "standards.md")
+
+        result = list_artifacts(artifacts_dir, "contexts")
+
+        assert "contexts/python/standards.md" in result["contexts"]
+
+    def test_paths_are_relative_to_artifacts_dir(self, artifacts_dir: Path) -> None:
+        (artifacts_dir / "skills").mkdir()
+        _make_symlink(artifacts_dir / "skills" / "SKILL.md")
+
+        result = list_artifacts(artifacts_dir, "skills")
+
+        assert all(not Path(p).is_absolute() for p in result["skills"])


### PR DESCRIPTION
## Summary

`abc list <type>` no longer constructs a `SyncEngine` just to call `list_artifacts()`. Approach (b) from the ticket:

- New `domains/distribution/artifact_listing.py` with the free function `list_artifacts(artifacts_path, artifact_type)`.
- `SyncEngine.list_artifacts()` is now a 1-line thin wrapper for backwards compatibility.
- `cli/agent.py` calls the free function directly and drops the `WorkspaceConfig`-or-fallback warehouse_path resolution block (the round-7 workaround in commit 587c075).

12 unit tests added for the free function (defaults, type filtering, symlink/dotfile exclusion, sorting, nesting, relative paths).

Closes PER-129.

## Test plan

- [x] `pytest libs/beacon/tests/unit/domains/distribution/test_artifact_listing.py libs/beacon/tests/integration/test_list_commands.py` → 35 passed.
- [x] Full `pytest libs/beacon/tests/` → 1060 passed, 7 pre-existing env-specific failures, no new regressions.
- [x] Architecture rule honored: free function lives in `domains/distribution/`, NOT `core/` or `utils/`.
- [ ] CI green
- [ ] opencode-review bot clean

## Out of scope

- Deeper SyncEngine refactor (e.g. splitting into sync vs read-only engines).
- Wire-format change for `list_artifacts` return value.