### PR TITLE
chore: wire pending agent + skills, gitignore claude settings

### DIFF
--- a/.agentic-beacon/beacon.yaml
+++ b/.agentic-beacon/beacon.yaml
@@ -8,7 +8,10 @@ artifacts:
   - skills/release-py-lib/
   - skills/linear-connect/
   - skills/delegate-to-oc/
+  - skills/delegate-to-cc/
+  - skills/file-linear-followup/
   agents:
   - agents/personal-blog-writer.md
   - agents/spec-planner.md
   - agents/implementation-supervisor.md
+  - agents/diligent-supervisor.md

--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ logs/
 .claude/worktrees/
 .claude/commands/opsx/
 .claude/skills/
+.claude/settings.json
 
 # Distributed warehouse content (project-specific)
 .opencode/


### PR DESCRIPTION
## Summary
- Wire three pending warehouse artifacts into project `beacon.yaml`: `delegate-to-cc`, `file-linear-followup` skills and `diligent-supervisor` agent
- Gitignore `.claude/settings.json` so machine-local Bash permission allowlists don't leak into the repo

## Test plan
- [ ] `abc warehouse status` shows no unwired pending artifacts
- [ ] `.claude/settings.json` no longer appears in `git status`