### PR TITLE
fix(record-knowledge): allow nested kebab-case topics like data-platform/clickhouse

### DIFF
--- a/libs/beacon/src/beacon/data/skills/record-knowledge/SKILL.md
+++ b/libs/beacon/src/beacon/data/skills/record-knowledge/SKILL.md
@@ -78,18 +78,36 @@ Examine the user's description and determine:
 **Filename** (`--name`): kebab-case, descriptive but concise.
 Example: `use-pydantic-for-data-carriers`.
 
-**Topic** (`--topic`, optional): kebab-case category. Inspect the existing
-warehouse layout to follow the established convention:
+**Topic** (`--topic`, optional): Inspect the existing warehouse layout to
+follow the established convention:
 
 ```bash
 WAREHOUSE_ROOT=$(uv run ${SKILL_DIR}/scripts/resolve_warehouse.py)
 ls "$WAREHOUSE_ROOT/knowledge/"
+# For nested-topic warehouses, also check one level deeper:
+find "$WAREHOUSE_ROOT/knowledge" -maxdepth 2 -type d
 ```
 
-If the warehouse already groups knowledge by topic (e.g.
-`knowledge/python-standards/`, `knowledge/infrastructure/`), pick the matching
-topic. Otherwise omit `--topic` for a flat layout
-(`knowledge/<type>s/<name>.md`).
+Rules for `--topic`:
+
+- Each path segment must be kebab-case (`^[a-z0-9]+(?:-[a-z0-9]+)*$`).
+- **Nested topics are allowed** using `/` as the separator — e.g.
+  `data-platform/clickhouse`, `cicd`, `infrastructure`.
+- Pick the deepest existing topic that matches the subject. If the warehouse
+  already has `knowledge/data-platform/clickhouse/lessons/`, pass
+  `--topic data-platform/clickhouse` — do **not** flatten it to
+  `data-platform-clickhouse`, and do **not** drop to `data-platform` only.
+- If no existing topic fits and the knowledge is broadly scoped, omit
+  `--topic` entirely for a flat layout (`knowledge/<type>s/<name>.md`).
+
+Examples of valid `--topic` values:
+
+| Topic | Resulting path (for a lesson) |
+|---|---|
+| `infrastructure` | `knowledge/infrastructure/lessons/<name>.md` |
+| `data-platform/clickhouse` | `knowledge/data-platform/clickhouse/lessons/<name>.md` |
+| `python-standards` | `knowledge/python-standards/lessons/<name>.md` |
+| *(omitted)* | `knowledge/lessons/<name>.md` |
 
 ### Step 3: Generate the Markdown Body
 

--- a/libs/beacon/src/beacon/data/skills/record-knowledge/scripts/write_knowledge.py
+++ b/libs/beacon/src/beacon/data/skills/record-knowledge/scripts/write_knowledge.py
@@ -35,7 +35,18 @@ from pathlib import Path
 VALID_TYPES = ("decision", "lesson", "fact")
 TYPE_TO_DIR = {"decision": "decisions", "lesson": "lessons", "fact": "facts"}
 NAME_PATTERN = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
-TOPIC_PATTERN = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+# Each path segment must be kebab-case. Topics may be nested with '/',
+# e.g. 'data-platform/clickhouse' or 'python-standards'.
+TOPIC_SEGMENT_PATTERN = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+
+
+def is_valid_topic(topic: str) -> bool:
+    """Return True iff *topic* is one-or-more slash-separated kebab-case segments."""
+    if not topic:
+        return False
+    segments = topic.split("/")
+    return all(TOPIC_SEGMENT_PATTERN.match(seg) for seg in segments)
+
 
 ERROR_NO_WAREHOUSE = (
     "Error: no warehouse connected. Run 'abc warehouse connect <path>' first."
@@ -120,8 +131,10 @@ def main() -> None:
         "--topic",
         default=None,
         help=(
-            "Optional kebab-case topic subdirectory under knowledge/ "
-            "(e.g. 'infrastructure'). Default: flat layout."
+            "Optional topic subdirectory under knowledge/. Each segment must "
+            "be kebab-case; nested topics are allowed using '/' as separator "
+            "(e.g. 'infrastructure' or 'data-platform/clickhouse'). "
+            "Default: flat layout (knowledge/<type>s/<name>.md)."
         ),
     )
     parser.add_argument(
@@ -142,9 +155,10 @@ def main() -> None:
             file=sys.stderr,
         )
         sys.exit(2)
-    if args.topic is not None and not TOPIC_PATTERN.match(args.topic):
+    if args.topic is not None and not is_valid_topic(args.topic):
         print(
-            f"Error: --topic must be kebab-case (got {args.topic!r})",
+            f"Error: --topic must be one or more slash-separated kebab-case "
+            f"segments (got {args.topic!r})",
             file=sys.stderr,
         )
         sys.exit(2)


### PR DESCRIPTION
## Summary

- Accept slash-separated topics (e.g. \`data-platform/clickhouse\`) in \`write_knowledge.py --topic\` by validating each segment as kebab-case instead of the whole string.
- Update SKILL.md so agents know nested topics are allowed and what convention to follow.

## Why

Sample warehouse and real warehouses (e.g. \`hl-knowledge-market\`) already organise knowledge under nested topic dirs like \`knowledge/data-platform/clickhouse/lessons/\`. The pre-fix \`TOPIC_PATTERN\` rejected any \`/\` in the topic argument with \"must be kebab-case\", forcing agents to either:
- Flatten the topic (\`data-platform-clickhouse\`) — inconsistent with existing layout, or
- Bypass the helper and use their editor's write tool — contradicts the skill's own instruction (\"always go through \`write_knowledge.py\`\") and loses the warehouse-boundary safety check.

Hit in practice on 2026-05-10 while recording three homelab lessons under \`knowledge/data-platform/clickhouse/\`.

## Behaviour

| Input | Before | After |
|---|---|---|
| \`--topic infrastructure\` | ✅ accepted | ✅ accepted |
| \`--topic data-platform/clickhouse\` | ❌ rejected | ✅ accepted |
| \`--topic Data-Platform\` | ❌ rejected | ❌ rejected |
| \`--topic data-platform/BadCase\` | ❌ rejected | ❌ rejected |
| \`--topic ../../../etc\` | ❌ rejected | ❌ rejected (segment validation catches \`..\`; \`assert_under_warehouse\` is secondary defence) |

## Tests

No test file existed for this script. Manually verified all five cases above pass or fail as expected. Pre-commit hooks (ruff, ruff-format, AST check) all pass.