### PR TITLE
fix(skills): self-contained append_pending.py for record-* skills (PER-150)

### DIFF
--- a/libs/beacon/src/beacon/data/skills/record-knowledge/scripts/append_pending.py
+++ b/libs/beacon/src/beacon/data/skills/record-knowledge/scripts/append_pending.py
@@ -10,7 +10,6 @@ Usage:
 """
 
 import argparse
-import re
 import sys
 from datetime import UTC, datetime
 from pathlib import Path
@@ -22,8 +21,6 @@ VALID_ACTIONS = ("created", "modified")
 ERROR_NO_WAREHOUSE = (
     "Error: no warehouse connected. Run 'abc warehouse connect <path>' first."
 )
-
-_CANONICAL_DATETIME_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$")
 
 
 def find_project_root(start: Path) -> Path | None:
@@ -100,9 +97,19 @@ def _validate_entry(entry: dict, index: int) -> dict:
         sys.exit(1)
 
     created_at = entry["created_at"]
-    if not isinstance(created_at, datetime) and not (
-        isinstance(created_at, str) and _CANONICAL_DATETIME_RE.match(created_at)
-    ):
+    if isinstance(created_at, datetime):
+        pass
+    elif isinstance(created_at, str):
+        try:
+            datetime.strptime(created_at, "%Y-%m-%dT%H:%M:%SZ")
+        except ValueError as exc:
+            print(
+                f"Error: pending.yaml entry #{index}: 'created_at' is not a valid"
+                f" UTC timestamp in '%Y-%m-%dT%H:%M:%SZ' format ({exc})",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+    else:
         print(
             f"Error: pending.yaml entry #{index}: 'created_at' must be a datetime"
             f" or a string in '%Y-%m-%dT%H:%M:%SZ' format",

--- a/libs/beacon/src/beacon/data/skills/record-knowledge/scripts/append_pending.py
+++ b/libs/beacon/src/beacon/data/skills/record-knowledge/scripts/append_pending.py
@@ -2,7 +2,7 @@
 # requires-python = ">=3.11"
 # dependencies = ["pyyaml>=6.0"]
 # ///
-# Self-contained script — no beacon package required at runtime.
+# Self-contained script -- no beacon package required at runtime.
 """Append an entry to .agentic-beacon/pending.yaml.
 
 Usage:
@@ -10,6 +10,7 @@ Usage:
 """
 
 import argparse
+import re
 import sys
 from datetime import UTC, datetime
 from pathlib import Path
@@ -22,6 +23,8 @@ ERROR_NO_WAREHOUSE = (
     "Error: no warehouse connected. Run 'abc warehouse connect <path>' first."
 )
 
+_CANONICAL_DATETIME_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$")
+
 
 def find_project_root(start: Path) -> Path | None:
     """Walk up from start to find a directory containing .agentic-beacon/config.toml."""
@@ -33,6 +36,81 @@ def find_project_root(start: Path) -> Path | None:
         if parent == current:
             return None
         current = parent
+
+
+def _canonicalize_entry(entry: dict) -> dict:
+    """Return a new dict with created_at normalized to canonical Z string form."""
+    created_at = entry.get("created_at")
+    if isinstance(created_at, datetime):
+        if created_at.tzinfo is None:
+            ts = created_at.replace(tzinfo=UTC)
+        else:
+            ts = created_at.astimezone(UTC)
+        return {**entry, "created_at": ts.strftime("%Y-%m-%dT%H:%M:%SZ")}
+    return entry
+
+
+def _validate_entry(entry: dict, index: int) -> dict:
+    """Validate a pending.yaml entry; exit 1 with a clear message on failure."""
+    if not isinstance(entry, dict):
+        print(
+            f"Error: pending.yaml entry #{index}: must be a mapping,"
+            f" got {type(entry).__name__}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    required_fields = ("path", "type", "action", "source", "created_at")
+    for field in required_fields:
+        if field not in entry:
+            print(
+                f"Error: pending.yaml entry #{index}: missing required field '{field}'",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+
+    if entry["type"] not in VALID_TYPES:
+        print(
+            f"Error: pending.yaml entry #{index}: invalid type {entry['type']!r},"
+            f" must be one of {VALID_TYPES}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    if entry["action"] not in VALID_ACTIONS:
+        print(
+            f"Error: pending.yaml entry #{index}: invalid action {entry['action']!r},"
+            f" must be one of {VALID_ACTIONS}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    if not isinstance(entry["path"], str):
+        print(
+            f"Error: pending.yaml entry #{index}: 'path' must be a string",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    if not isinstance(entry["source"], str):
+        print(
+            f"Error: pending.yaml entry #{index}: 'source' must be a string",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    created_at = entry["created_at"]
+    if not isinstance(created_at, datetime) and not (
+        isinstance(created_at, str) and _CANONICAL_DATETIME_RE.match(created_at)
+    ):
+        print(
+            f"Error: pending.yaml entry #{index}: 'created_at' must be a datetime"
+            f" or a string in '%Y-%m-%dT%H:%M:%SZ' format",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    return entry
 
 
 def append_pending_entry(
@@ -73,7 +151,8 @@ def append_pending_entry(
                 )
                 sys.exit(1)
             else:
-                entries = list(raw_entries)
+                validated = [_validate_entry(e, i) for i, e in enumerate(raw_entries)]
+                entries = [_canonicalize_entry(e) for e in validated]
 
     created_at_str = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
     new_entry = {

--- a/libs/beacon/src/beacon/data/skills/record-knowledge/scripts/append_pending.py
+++ b/libs/beacon/src/beacon/data/skills/record-knowledge/scripts/append_pending.py
@@ -1,9 +1,8 @@
 # /// script
 # requires-python = ">=3.11"
-# dependencies = []
+# dependencies = ["pyyaml>=6.0"]
 # ///
-# Requires the beacon package installed in the active environment.
-# Run `uv sync` from the agentic-beacon repo root before invoking this script.
+# Self-contained script — no beacon package required at runtime.
 """Append an entry to .agentic-beacon/pending.yaml.
 
 Usage:
@@ -15,7 +14,7 @@ import sys
 from datetime import UTC, datetime
 from pathlib import Path
 
-from beacon.core.manifest.pending import PendingEntry, PendingManifest
+import yaml
 
 VALID_TYPES = ("skill", "context", "agent")
 VALID_ACTIONS = ("created", "modified")
@@ -45,16 +44,56 @@ def append_pending_entry(
 ) -> None:
     """Append a pending entry to .agentic-beacon/pending.yaml."""
     pending_path = project_root / ".agentic-beacon" / "pending.yaml"
-    manifest = PendingManifest.from_yaml(pending_path)
-    entry = PendingEntry(
-        path=path,
-        type=type_,
-        action=action,
-        source=source,
-        created_at=datetime.now(UTC),
-    )
-    manifest.append(entry)
-    manifest.to_yaml(pending_path)
+
+    entries: list[dict] = []
+    if pending_path.exists():
+        try:
+            with open(pending_path, encoding="utf-8") as f:
+                data = yaml.safe_load(f)
+        except yaml.YAMLError as e:
+            print(f"Error: invalid YAML in {pending_path}: {e}", file=sys.stderr)
+            sys.exit(1)
+
+        if data is None:
+            entries = []
+        elif not isinstance(data, dict):
+            print(
+                f"Error: pending.yaml must be a YAML mapping, got {type(data).__name__}",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        else:
+            raw_entries = data.get("pending", [])
+            if raw_entries is None:
+                entries = []
+            elif not isinstance(raw_entries, list):
+                print(
+                    "Error: 'pending' field must be a list",
+                    file=sys.stderr,
+                )
+                sys.exit(1)
+            else:
+                entries = list(raw_entries)
+
+    created_at_str = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+    new_entry = {
+        "path": path,
+        "type": type_,
+        "action": action,
+        "source": source,
+        "created_at": created_at_str,
+    }
+    entries.append(new_entry)
+
+    pending_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(pending_path, "w", encoding="utf-8") as f:
+        yaml.dump(
+            {"pending": entries},
+            f,
+            default_flow_style=False,
+            sort_keys=False,
+            allow_unicode=True,
+        )
 
 
 def main() -> None:

--- a/libs/beacon/src/beacon/data/skills/record-knowledge/scripts/append_pending.py
+++ b/libs/beacon/src/beacon/data/skills/record-knowledge/scripts/append_pending.py
@@ -101,11 +101,20 @@ def _validate_entry(entry: dict, index: int) -> dict:
         pass
     elif isinstance(created_at, str):
         try:
-            datetime.strptime(created_at, "%Y-%m-%dT%H:%M:%SZ")
+            parsed = datetime.strptime(created_at, "%Y-%m-%dT%H:%M:%SZ")
         except ValueError as exc:
             print(
                 f"Error: pending.yaml entry #{index}: 'created_at' is not a valid"
                 f" UTC timestamp in '%Y-%m-%dT%H:%M:%SZ' format ({exc})",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        canonical = parsed.strftime("%Y-%m-%dT%H:%M:%SZ")
+        if canonical != created_at:
+            print(
+                f"Error: pending.yaml entry #{index}: 'created_at' {created_at!r}"
+                f" is not in canonical '%Y-%m-%dT%H:%M:%SZ' form"
+                f" (expected {canonical!r}; check zero-padding)",
                 file=sys.stderr,
             )
             sys.exit(1)

--- a/libs/beacon/src/beacon/data/skills/record-skill/scripts/append_pending.py
+++ b/libs/beacon/src/beacon/data/skills/record-skill/scripts/append_pending.py
@@ -10,7 +10,6 @@ Usage:
 """
 
 import argparse
-import re
 import sys
 from datetime import UTC, datetime
 from pathlib import Path
@@ -22,8 +21,6 @@ VALID_ACTIONS = ("created", "modified")
 ERROR_NO_WAREHOUSE = (
     "Error: no warehouse connected. Run 'abc warehouse connect <path>' first."
 )
-
-_CANONICAL_DATETIME_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$")
 
 
 def find_project_root(start: Path) -> Path | None:
@@ -100,9 +97,19 @@ def _validate_entry(entry: dict, index: int) -> dict:
         sys.exit(1)
 
     created_at = entry["created_at"]
-    if not isinstance(created_at, datetime) and not (
-        isinstance(created_at, str) and _CANONICAL_DATETIME_RE.match(created_at)
-    ):
+    if isinstance(created_at, datetime):
+        pass
+    elif isinstance(created_at, str):
+        try:
+            datetime.strptime(created_at, "%Y-%m-%dT%H:%M:%SZ")
+        except ValueError as exc:
+            print(
+                f"Error: pending.yaml entry #{index}: 'created_at' is not a valid"
+                f" UTC timestamp in '%Y-%m-%dT%H:%M:%SZ' format ({exc})",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+    else:
         print(
             f"Error: pending.yaml entry #{index}: 'created_at' must be a datetime"
             f" or a string in '%Y-%m-%dT%H:%M:%SZ' format",

--- a/libs/beacon/src/beacon/data/skills/record-skill/scripts/append_pending.py
+++ b/libs/beacon/src/beacon/data/skills/record-skill/scripts/append_pending.py
@@ -2,7 +2,7 @@
 # requires-python = ">=3.11"
 # dependencies = ["pyyaml>=6.0"]
 # ///
-# Self-contained script — no beacon package required at runtime.
+# Self-contained script -- no beacon package required at runtime.
 """Append an entry to .agentic-beacon/pending.yaml.
 
 Usage:
@@ -10,6 +10,7 @@ Usage:
 """
 
 import argparse
+import re
 import sys
 from datetime import UTC, datetime
 from pathlib import Path
@@ -22,6 +23,8 @@ ERROR_NO_WAREHOUSE = (
     "Error: no warehouse connected. Run 'abc warehouse connect <path>' first."
 )
 
+_CANONICAL_DATETIME_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$")
+
 
 def find_project_root(start: Path) -> Path | None:
     """Walk up from start to find a directory containing .agentic-beacon/config.toml."""
@@ -33,6 +36,81 @@ def find_project_root(start: Path) -> Path | None:
         if parent == current:
             return None
         current = parent
+
+
+def _canonicalize_entry(entry: dict) -> dict:
+    """Return a new dict with created_at normalized to canonical Z string form."""
+    created_at = entry.get("created_at")
+    if isinstance(created_at, datetime):
+        if created_at.tzinfo is None:
+            ts = created_at.replace(tzinfo=UTC)
+        else:
+            ts = created_at.astimezone(UTC)
+        return {**entry, "created_at": ts.strftime("%Y-%m-%dT%H:%M:%SZ")}
+    return entry
+
+
+def _validate_entry(entry: dict, index: int) -> dict:
+    """Validate a pending.yaml entry; exit 1 with a clear message on failure."""
+    if not isinstance(entry, dict):
+        print(
+            f"Error: pending.yaml entry #{index}: must be a mapping,"
+            f" got {type(entry).__name__}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    required_fields = ("path", "type", "action", "source", "created_at")
+    for field in required_fields:
+        if field not in entry:
+            print(
+                f"Error: pending.yaml entry #{index}: missing required field '{field}'",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+
+    if entry["type"] not in VALID_TYPES:
+        print(
+            f"Error: pending.yaml entry #{index}: invalid type {entry['type']!r},"
+            f" must be one of {VALID_TYPES}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    if entry["action"] not in VALID_ACTIONS:
+        print(
+            f"Error: pending.yaml entry #{index}: invalid action {entry['action']!r},"
+            f" must be one of {VALID_ACTIONS}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    if not isinstance(entry["path"], str):
+        print(
+            f"Error: pending.yaml entry #{index}: 'path' must be a string",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    if not isinstance(entry["source"], str):
+        print(
+            f"Error: pending.yaml entry #{index}: 'source' must be a string",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    created_at = entry["created_at"]
+    if not isinstance(created_at, datetime) and not (
+        isinstance(created_at, str) and _CANONICAL_DATETIME_RE.match(created_at)
+    ):
+        print(
+            f"Error: pending.yaml entry #{index}: 'created_at' must be a datetime"
+            f" or a string in '%Y-%m-%dT%H:%M:%SZ' format",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    return entry
 
 
 def append_pending_entry(
@@ -73,7 +151,8 @@ def append_pending_entry(
                 )
                 sys.exit(1)
             else:
-                entries = list(raw_entries)
+                validated = [_validate_entry(e, i) for i, e in enumerate(raw_entries)]
+                entries = [_canonicalize_entry(e) for e in validated]
 
     created_at_str = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
     new_entry = {

--- a/libs/beacon/src/beacon/data/skills/record-skill/scripts/append_pending.py
+++ b/libs/beacon/src/beacon/data/skills/record-skill/scripts/append_pending.py
@@ -1,9 +1,8 @@
 # /// script
 # requires-python = ">=3.11"
-# dependencies = []
+# dependencies = ["pyyaml>=6.0"]
 # ///
-# Requires the beacon package installed in the active environment.
-# Run `uv sync` from the agentic-beacon repo root before invoking this script.
+# Self-contained script — no beacon package required at runtime.
 """Append an entry to .agentic-beacon/pending.yaml.
 
 Usage:
@@ -15,7 +14,7 @@ import sys
 from datetime import UTC, datetime
 from pathlib import Path
 
-from beacon.core.manifest.pending import PendingEntry, PendingManifest
+import yaml
 
 VALID_TYPES = ("skill", "context", "agent")
 VALID_ACTIONS = ("created", "modified")
@@ -45,16 +44,56 @@ def append_pending_entry(
 ) -> None:
     """Append a pending entry to .agentic-beacon/pending.yaml."""
     pending_path = project_root / ".agentic-beacon" / "pending.yaml"
-    manifest = PendingManifest.from_yaml(pending_path)
-    entry = PendingEntry(
-        path=path,
-        type=type_,
-        action=action,
-        source=source,
-        created_at=datetime.now(UTC),
-    )
-    manifest.append(entry)
-    manifest.to_yaml(pending_path)
+
+    entries: list[dict] = []
+    if pending_path.exists():
+        try:
+            with open(pending_path, encoding="utf-8") as f:
+                data = yaml.safe_load(f)
+        except yaml.YAMLError as e:
+            print(f"Error: invalid YAML in {pending_path}: {e}", file=sys.stderr)
+            sys.exit(1)
+
+        if data is None:
+            entries = []
+        elif not isinstance(data, dict):
+            print(
+                f"Error: pending.yaml must be a YAML mapping, got {type(data).__name__}",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        else:
+            raw_entries = data.get("pending", [])
+            if raw_entries is None:
+                entries = []
+            elif not isinstance(raw_entries, list):
+                print(
+                    "Error: 'pending' field must be a list",
+                    file=sys.stderr,
+                )
+                sys.exit(1)
+            else:
+                entries = list(raw_entries)
+
+    created_at_str = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+    new_entry = {
+        "path": path,
+        "type": type_,
+        "action": action,
+        "source": source,
+        "created_at": created_at_str,
+    }
+    entries.append(new_entry)
+
+    pending_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(pending_path, "w", encoding="utf-8") as f:
+        yaml.dump(
+            {"pending": entries},
+            f,
+            default_flow_style=False,
+            sort_keys=False,
+            allow_unicode=True,
+        )
 
 
 def main() -> None:

--- a/libs/beacon/src/beacon/data/skills/record-skill/scripts/append_pending.py
+++ b/libs/beacon/src/beacon/data/skills/record-skill/scripts/append_pending.py
@@ -101,11 +101,20 @@ def _validate_entry(entry: dict, index: int) -> dict:
         pass
     elif isinstance(created_at, str):
         try:
-            datetime.strptime(created_at, "%Y-%m-%dT%H:%M:%SZ")
+            parsed = datetime.strptime(created_at, "%Y-%m-%dT%H:%M:%SZ")
         except ValueError as exc:
             print(
                 f"Error: pending.yaml entry #{index}: 'created_at' is not a valid"
                 f" UTC timestamp in '%Y-%m-%dT%H:%M:%SZ' format ({exc})",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        canonical = parsed.strftime("%Y-%m-%dT%H:%M:%SZ")
+        if canonical != created_at:
+            print(
+                f"Error: pending.yaml entry #{index}: 'created_at' {created_at!r}"
+                f" is not in canonical '%Y-%m-%dT%H:%M:%SZ' form"
+                f" (expected {canonical!r}; check zero-padding)",
                 file=sys.stderr,
             )
             sys.exit(1)

--- a/libs/beacon/tests/integration/test_append_pending_standalone.py
+++ b/libs/beacon/tests/integration/test_append_pending_standalone.py
@@ -46,9 +46,9 @@ def _make_project(root: Path) -> None:
     )
 
 
-# ─────────────────────────────────────────────────────────────
+# ----
 # Core: script resolves pyyaml from PEP 723 header, not workspace venv
-# ─────────────────────────────────────────────────────────────
+# ----
 
 
 @pytest.mark.integration
@@ -98,9 +98,9 @@ def test_script_works_without_beacon_package(skill_name: str, tmp_path: Path) ->
     assert entry.source == skill_name
 
 
-# ─────────────────────────────────────────────────────────────
+# ----
 # find_project_root walks up from nested subdirectory
-# ─────────────────────────────────────────────────────────────
+# ----
 
 
 @pytest.mark.integration

--- a/libs/beacon/tests/integration/test_append_pending_standalone.py
+++ b/libs/beacon/tests/integration/test_append_pending_standalone.py
@@ -1,0 +1,147 @@
+"""Integration tests: append_pending.py works without beacon installed.
+
+Invokes scripts via `uv run --no-project --isolated` with a clean environment
+that strips PYTHONPATH, VIRTUAL_ENV, and BEACON_* variables. This proves the
+PEP 723 pyyaml dependency is resolved in a fresh ephemeral venv, independent
+of the workspace venv that has beacon installed.
+
+This is the direct regression test for PER-150.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+from beacon.core.manifest.pending import PendingManifest
+
+_SKILLS_DIR = (
+    Path(__file__).resolve().parent.parent.parent / "src" / "beacon" / "data" / "skills"
+)
+
+_SCRIPT_PATHS = {
+    "record-skill": _SKILLS_DIR / "record-skill" / "scripts" / "append_pending.py",
+    "record-knowledge": _SKILLS_DIR
+    / "record-knowledge"
+    / "scripts"
+    / "append_pending.py",
+}
+
+
+def _clean_env() -> dict[str, str]:
+    """Return os.environ with beacon-exposing vars stripped."""
+    env = dict(os.environ)
+    for key in list(env.keys()):
+        if key in ("PYTHONPATH", "VIRTUAL_ENV") or key.startswith("BEACON_"):
+            del env[key]
+    return env
+
+
+def _make_project(root: Path) -> None:
+    (root / ".agentic-beacon").mkdir(parents=True)
+    (root / ".agentic-beacon" / "config.toml").write_text(
+        '[warehouse]\nlocal_path = "/tmp/dummy-warehouse"\n'
+    )
+
+
+# ─────────────────────────────────────────────────────────────
+# Core: script resolves pyyaml from PEP 723 header, not workspace venv
+# ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("skill_name", ["record-skill", "record-knowledge"])
+def test_script_works_without_beacon_package(skill_name: str, tmp_path: Path) -> None:
+    """Script runs in an isolated env where beacon is NOT on sys.path."""
+    _make_project(tmp_path)
+    script_path = _SCRIPT_PATHS[skill_name]
+
+    result = subprocess.run(
+        [
+            "uv",
+            "run",
+            "--no-project",
+            "--isolated",
+            str(script_path),
+            "--path",
+            "skills/test-skill/",
+            "--type",
+            "skill",
+            "--action",
+            "created",
+            "--source",
+            skill_name,
+        ],
+        cwd=str(tmp_path),
+        env=_clean_env(),
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, (
+        f"Script failed (returncode={result.returncode}):\n"
+        f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+
+    pending_path = tmp_path / ".agentic-beacon" / "pending.yaml"
+    assert pending_path.exists(), "pending.yaml was not created"
+
+    # Round-trip through canonical PendingManifest to verify format compatibility
+    manifest = PendingManifest.from_yaml(pending_path)
+    assert len(manifest.pending) == 1
+    entry = manifest.pending[0]
+    assert entry.path == "skills/test-skill/"
+    assert entry.type == "skill"
+    assert entry.action == "created"
+    assert entry.source == skill_name
+
+
+# ─────────────────────────────────────────────────────────────
+# find_project_root walks up from nested subdirectory
+# ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("skill_name", ["record-skill", "record-knowledge"])
+def test_script_finds_project_root_from_nested_subdir(
+    skill_name: str, tmp_path: Path
+) -> None:
+    """find_project_root walks up correctly when invoked from a nested subdirectory."""
+    _make_project(tmp_path)
+    nested = tmp_path / "a" / "b" / "c"
+    nested.mkdir(parents=True)
+    script_path = _SCRIPT_PATHS[skill_name]
+
+    result = subprocess.run(
+        [
+            "uv",
+            "run",
+            "--no-project",
+            "--isolated",
+            str(script_path),
+            "--path",
+            "contexts/test.md",
+            "--type",
+            "context",
+            "--action",
+            "created",
+            "--source",
+            skill_name,
+        ],
+        cwd=str(nested),
+        env=_clean_env(),
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, (
+        f"Script failed from nested subdir:\nstderr: {result.stderr}"
+    )
+
+    pending_path = tmp_path / ".agentic-beacon" / "pending.yaml"
+    assert pending_path.exists()
+    manifest = PendingManifest.from_yaml(pending_path)
+    assert len(manifest.pending) == 1
+    assert manifest.pending[0].path == "contexts/test.md"

--- a/libs/beacon/tests/integration/test_append_pending_standalone.py
+++ b/libs/beacon/tests/integration/test_append_pending_standalone.py
@@ -1,9 +1,10 @@
 """Integration tests: append_pending.py works without beacon installed.
 
-Invokes scripts via `uv run --no-project --isolated` with a clean environment
-that strips PYTHONPATH, VIRTUAL_ENV, and BEACON_* variables. This proves the
-PEP 723 pyyaml dependency is resolved in a fresh ephemeral venv, independent
-of the workspace venv that has beacon installed.
+These tests run `uv run --no-project --isolated`, which resolves PEP 723
+dependencies (`pyyaml`) from the active package index. On a cache-cold CI
+environment the first invocation will hit the network; subsequent calls reuse
+uv's local cache. Tests are marked `@pytest.mark.integration` and are expected
+to be skipped in offline or pre-commit fast-path runs.
 
 This is the direct regression test for PER-150.
 """
@@ -47,14 +48,17 @@ def _make_project(root: Path) -> None:
 
 
 # ----
-# Core: script resolves pyyaml from PEP 723 header, not workspace venv
+# Smoke test: PEP 723 + ephemeral venv path works end-to-end
 # ----
 
 
 @pytest.mark.integration
 @pytest.mark.parametrize("skill_name", ["record-skill", "record-knowledge"])
-def test_script_works_without_beacon_package(skill_name: str, tmp_path: Path) -> None:
-    """Script runs in an isolated env where beacon is NOT on sys.path."""
+def test_uv_run_pep723_executes_script_without_beacon(
+    skill_name: str, tmp_path: Path
+) -> None:
+    """Script runs in an isolated env where beacon is NOT on sys.path and
+    pyyaml is resolved from the PEP 723 header — not the workspace venv."""
     _make_project(tmp_path)
     script_path = _SCRIPT_PATHS[skill_name]
 
@@ -96,52 +100,3 @@ def test_script_works_without_beacon_package(skill_name: str, tmp_path: Path) ->
     assert entry.type == "skill"
     assert entry.action == "created"
     assert entry.source == skill_name
-
-
-# ----
-# find_project_root walks up from nested subdirectory
-# ----
-
-
-@pytest.mark.integration
-@pytest.mark.parametrize("skill_name", ["record-skill", "record-knowledge"])
-def test_script_finds_project_root_from_nested_subdir(
-    skill_name: str, tmp_path: Path
-) -> None:
-    """find_project_root walks up correctly when invoked from a nested subdirectory."""
-    _make_project(tmp_path)
-    nested = tmp_path / "a" / "b" / "c"
-    nested.mkdir(parents=True)
-    script_path = _SCRIPT_PATHS[skill_name]
-
-    result = subprocess.run(
-        [
-            "uv",
-            "run",
-            "--no-project",
-            "--isolated",
-            str(script_path),
-            "--path",
-            "contexts/test.md",
-            "--type",
-            "context",
-            "--action",
-            "created",
-            "--source",
-            skill_name,
-        ],
-        cwd=str(nested),
-        env=_clean_env(),
-        capture_output=True,
-        text=True,
-    )
-
-    assert result.returncode == 0, (
-        f"Script failed from nested subdir:\nstderr: {result.stderr}"
-    )
-
-    pending_path = tmp_path / ".agentic-beacon" / "pending.yaml"
-    assert pending_path.exists()
-    manifest = PendingManifest.from_yaml(pending_path)
-    assert len(manifest.pending) == 1
-    assert manifest.pending[0].path == "contexts/test.md"

--- a/libs/beacon/tests/integration/test_record_write_subprocess.py
+++ b/libs/beacon/tests/integration/test_record_write_subprocess.py
@@ -3,7 +3,7 @@
 The original bug was: record-knowledge wrote a real file into the project's
 symlink-mirror at .agentic-beacon/artifacts/knowledge/ instead of the warehouse.
 These tests pin that the new write_*.py scripts, when launched as a fresh
-process from inside a project's CWD, only write under the resolved warehouse —
+process from inside a project's CWD, only write under the resolved warehouse --
 never under the project's .agentic-beacon/artifacts/.
 """
 
@@ -118,7 +118,7 @@ def test_write_skill_subprocess_lands_in_warehouse(tmp_path: Path) -> None:
 
 
 def test_write_knowledge_no_warehouse_exits_nonzero(tmp_path: Path) -> None:
-    """Run from a directory with no .agentic-beacon/config.toml → hard error."""
+    """Run from a directory with no .agentic-beacon/config.toml -- hard error."""
     result = subprocess.run(
         [
             sys.executable,
@@ -157,9 +157,9 @@ def test_write_skill_no_warehouse_exits_nonzero(tmp_path: Path) -> None:
     assert list(tmp_path.iterdir()) == []
 
 
-# ─────────────────────────────────────────────────────────────
+# ----
 # E2E smoke: full record-skill flow (PER-150 regression guard)
-# ─────────────────────────────────────────────────────────────
+# ----
 
 _APPEND_PENDING_SKILL = _SKILLS_DIR / "record-skill" / "scripts" / "append_pending.py"
 
@@ -172,7 +172,7 @@ def test_record_skill_e2e_write_then_append_pending(tmp_path: Path) -> None:
     """
     project, warehouse = _setup(tmp_path)
 
-    # Step 1: write_skill.py — stdlib-only, no uv run needed
+    # Step 1: write_skill.py -- stdlib-only, no uv run needed
     write_result = subprocess.run(
         [
             sys.executable,
@@ -190,7 +190,7 @@ def test_record_skill_e2e_write_then_append_pending(tmp_path: Path) -> None:
     skill_path_out = write_result.stdout.strip()  # e.g. "skills/e2e-skill/"
     assert skill_path_out == "skills/e2e-skill/"
 
-    # Step 2: append_pending.py — requires pyyaml; use uv run --isolated to
+    # Step 2: append_pending.py -- requires pyyaml; use uv run --isolated to
     # prove it works in a fresh environment where beacon is NOT importable.
     clean_env = {
         k: v

--- a/libs/beacon/tests/integration/test_record_write_subprocess.py
+++ b/libs/beacon/tests/integration/test_record_write_subprocess.py
@@ -14,6 +14,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 _SKILLS_DIR = (
     Path(__file__).resolve().parent.parent.parent / "src" / "beacon" / "data" / "skills"
 )
@@ -164,6 +166,7 @@ def test_write_skill_no_warehouse_exits_nonzero(tmp_path: Path) -> None:
 _APPEND_PENDING_SKILL = _SKILLS_DIR / "record-skill" / "scripts" / "append_pending.py"
 
 
+@pytest.mark.integration
 def test_record_skill_e2e_write_then_append_pending(tmp_path: Path) -> None:
     """Full record-skill flow: write_skill.py then append_pending.py via uv run.
 

--- a/libs/beacon/tests/integration/test_record_write_subprocess.py
+++ b/libs/beacon/tests/integration/test_record_write_subprocess.py
@@ -9,6 +9,7 @@ never under the project's .agentic-beacon/artifacts/.
 
 from __future__ import annotations
 
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -154,3 +155,81 @@ def test_write_skill_no_warehouse_exits_nonzero(tmp_path: Path) -> None:
     assert result.returncode != 0
     assert "no warehouse connected" in result.stderr
     assert list(tmp_path.iterdir()) == []
+
+
+# ─────────────────────────────────────────────────────────────
+# E2E smoke: full record-skill flow (PER-150 regression guard)
+# ─────────────────────────────────────────────────────────────
+
+_APPEND_PENDING_SKILL = _SKILLS_DIR / "record-skill" / "scripts" / "append_pending.py"
+
+
+def test_record_skill_e2e_write_then_append_pending(tmp_path: Path) -> None:
+    """Full record-skill flow: write_skill.py then append_pending.py via uv run.
+
+    Without the PER-150 fix, append_pending.py fails with:
+        ModuleNotFoundError: No module named 'beacon'
+    """
+    project, warehouse = _setup(tmp_path)
+
+    # Step 1: write_skill.py — stdlib-only, no uv run needed
+    write_result = subprocess.run(
+        [
+            sys.executable,
+            str(WRITE_SKILL),
+            "--name",
+            "e2e-skill",
+            "--description",
+            "End-to-end test skill",
+        ],
+        cwd=project,
+        capture_output=True,
+        text=True,
+    )
+    assert write_result.returncode == 0, write_result.stderr
+    skill_path_out = write_result.stdout.strip()  # e.g. "skills/e2e-skill/"
+    assert skill_path_out == "skills/e2e-skill/"
+
+    # Step 2: append_pending.py — requires pyyaml; use uv run --isolated to
+    # prove it works in a fresh environment where beacon is NOT importable.
+    clean_env = {
+        k: v
+        for k, v in os.environ.items()
+        if k not in ("PYTHONPATH", "VIRTUAL_ENV") and not k.startswith("BEACON_")
+    }
+    append_result = subprocess.run(
+        [
+            "uv",
+            "run",
+            "--no-project",
+            "--isolated",
+            str(_APPEND_PENDING_SKILL),
+            "--path",
+            skill_path_out,
+            "--type",
+            "skill",
+            "--action",
+            "created",
+            "--source",
+            "record-skill",
+        ],
+        cwd=project,
+        env=clean_env,
+        capture_output=True,
+        text=True,
+    )
+    assert append_result.returncode == 0, (
+        f"append_pending.py failed: {append_result.stderr}"
+    )
+
+    # Verify pending.yaml exists and round-trips through PendingManifest
+    from beacon.core.manifest.pending import PendingManifest
+
+    pending_path = project / ".agentic-beacon" / "pending.yaml"
+    assert pending_path.exists()
+    manifest = PendingManifest.from_yaml(pending_path)
+    assert len(manifest.pending) == 1
+    entry = manifest.pending[0]
+    assert entry.path == skill_path_out
+    assert entry.type == "skill"
+    assert entry.source == "record-skill"

--- a/libs/beacon/tests/unit/test_append_pending_inline.py
+++ b/libs/beacon/tests/unit/test_append_pending_inline.py
@@ -936,3 +936,36 @@ def test_existing_entry_valid_canonical_string_accepted(mod, tmp_path):
         created_at = created_at.strftime("%Y-%m-%dT%H:%M:%SZ")
     assert created_at == "2026-05-13T07:00:00Z"
     assert data["pending"][1]["path"] == "skills/new/"
+
+
+# ----
+# 16. find_project_root walks up from nested subdirectory
+# ----
+
+
+def test_find_project_root_walks_up_from_nested_subdir(mod, tmp_path):
+    # Arrange
+    _make_project(tmp_path)
+    nested = tmp_path / "a" / "b" / "c"
+    nested.mkdir(parents=True)
+
+    # Act
+    result = mod.find_project_root(nested)
+
+    # Assert
+    assert result == tmp_path
+
+
+# ----
+# 17. find_project_root returns None when no config above
+# ----
+
+
+def test_find_project_root_returns_none_when_no_config(mod, tmp_path):
+    # Arrange -- tmp_path has no .agentic-beacon/config.toml
+
+    # Act
+    result = mod.find_project_root(tmp_path)
+
+    # Assert
+    assert result is None

--- a/libs/beacon/tests/unit/test_append_pending_inline.py
+++ b/libs/beacon/tests/unit/test_append_pending_inline.py
@@ -723,3 +723,136 @@ def test_existing_entry_malformed_created_at_rejected(mod, tmp_path, capsys):
     assert exc.value.code != 0
     assert "created_at" in capsys.readouterr().err
     assert pending_path.read_bytes() == original_content
+
+
+# ----
+# New tests: impossible date/time values rejected (PER-150 review round 2)
+# ----
+
+
+def test_existing_entry_impossible_month_rejected(mod, tmp_path, capsys):
+    # Arrange: month=99 passes shape regex but strptime raises ValueError
+    root = _make_project(tmp_path)
+    pending_path = root / ".agentic-beacon" / "pending.yaml"
+    pending_path.write_text(
+        yaml.dump(
+            {
+                "pending": [
+                    {
+                        "path": "skills/bad/",
+                        "type": "skill",
+                        "action": "created",
+                        "source": "s",
+                        "created_at": "2026-99-01T00:00:00Z",
+                    }
+                ]
+            },
+            default_flow_style=False,
+        )
+    )
+    original_content = pending_path.read_bytes()
+
+    # Act
+    with pytest.raises(SystemExit) as exc:
+        mod.append_pending_entry(root, "skills/new/", "skill", "created", "s")
+
+    # Assert
+    assert exc.value.code != 0
+    assert "created_at" in capsys.readouterr().err
+    assert pending_path.read_bytes() == original_content
+
+
+def test_existing_entry_impossible_day_rejected(mod, tmp_path, capsys):
+    # Arrange: Feb 30 doesn't exist
+    root = _make_project(tmp_path)
+    pending_path = root / ".agentic-beacon" / "pending.yaml"
+    pending_path.write_text(
+        yaml.dump(
+            {
+                "pending": [
+                    {
+                        "path": "skills/bad/",
+                        "type": "skill",
+                        "action": "created",
+                        "source": "s",
+                        "created_at": "2026-02-30T00:00:00Z",
+                    }
+                ]
+            },
+            default_flow_style=False,
+        )
+    )
+    original_content = pending_path.read_bytes()
+
+    # Act
+    with pytest.raises(SystemExit) as exc:
+        mod.append_pending_entry(root, "skills/new/", "skill", "created", "s")
+
+    # Assert
+    assert exc.value.code != 0
+    assert "created_at" in capsys.readouterr().err
+    assert pending_path.read_bytes() == original_content
+
+
+def test_existing_entry_impossible_hour_rejected(mod, tmp_path, capsys):
+    # Arrange: hour=25 is out of range
+    root = _make_project(tmp_path)
+    pending_path = root / ".agentic-beacon" / "pending.yaml"
+    pending_path.write_text(
+        yaml.dump(
+            {
+                "pending": [
+                    {
+                        "path": "skills/bad/",
+                        "type": "skill",
+                        "action": "created",
+                        "source": "s",
+                        "created_at": "2026-01-01T25:00:00Z",
+                    }
+                ]
+            },
+            default_flow_style=False,
+        )
+    )
+    original_content = pending_path.read_bytes()
+
+    # Act
+    with pytest.raises(SystemExit) as exc:
+        mod.append_pending_entry(root, "skills/new/", "skill", "created", "s")
+
+    # Assert
+    assert exc.value.code != 0
+    assert "created_at" in capsys.readouterr().err
+    assert pending_path.read_bytes() == original_content
+
+
+def test_existing_entry_valid_canonical_string_accepted(mod, tmp_path):
+    # Arrange: well-formed, in-range timestamp as quoted string
+    root = _make_project(tmp_path)
+    pending_path = root / ".agentic-beacon" / "pending.yaml"
+    original_entry = {
+        "path": "skills/preexisting/",
+        "type": "skill",
+        "action": "created",
+        "source": "s",
+        "created_at": "2026-05-13T07:00:00Z",
+    }
+    pending_path.write_text(
+        yaml.dump(
+            {"pending": [original_entry]}, default_flow_style=False, sort_keys=False
+        )
+    )
+
+    # Act
+    mod.append_pending_entry(root, "skills/new/", "skill", "created", "record-skill")
+
+    # Assert: script succeeded, original entry preserved verbatim, new entry appended
+    data = yaml.safe_load(pending_path.read_text())
+    assert len(data["pending"]) == 2
+    first = data["pending"][0]
+    assert first["path"] == "skills/preexisting/"
+    created_at = first["created_at"]
+    if not isinstance(created_at, str):
+        created_at = created_at.strftime("%Y-%m-%dT%H:%M:%SZ")
+    assert created_at == "2026-05-13T07:00:00Z"
+    assert data["pending"][1]["path"] == "skills/new/"

--- a/libs/beacon/tests/unit/test_append_pending_inline.py
+++ b/libs/beacon/tests/unit/test_append_pending_inline.py
@@ -45,9 +45,9 @@ def mod(request):
     return _load_module(request.param)
 
 
-# ─────────────────────────────────────────────────────────────
+# ----
 # 1. Creates file when pending.yaml doesn't exist
-# ─────────────────────────────────────────────────────────────
+# ----
 
 
 def test_appends_to_empty_dir_creates_file(mod, tmp_path):
@@ -67,9 +67,9 @@ def test_appends_to_empty_dir_creates_file(mod, tmp_path):
     assert len(data["pending"]) == 1
 
 
-# ─────────────────────────────────────────────────────────────
+# ----
 # 2. Appends to existing entries preserving insertion order
-# ─────────────────────────────────────────────────────────────
+# ----
 
 
 def test_appends_to_existing_entries_preserves_order(mod, tmp_path):
@@ -107,9 +107,9 @@ def test_appends_to_existing_entries_preserves_order(mod, tmp_path):
     assert paths == ["skills/first/", "contexts/second.md", "agents/third/"]
 
 
-# ─────────────────────────────────────────────────────────────
+# ----
 # 3. pending: null treated as empty list
-# ─────────────────────────────────────────────────────────────
+# ----
 
 
 def test_appends_when_pending_is_null(mod, tmp_path):
@@ -127,9 +127,9 @@ def test_appends_when_pending_is_null(mod, tmp_path):
     assert data["pending"][0]["path"] == "skills/x/"
 
 
-# ─────────────────────────────────────────────────────────────
+# ----
 # 4. pending key missing from dict treated as empty list
-# ─────────────────────────────────────────────────────────────
+# ----
 
 
 def test_appends_when_pending_is_missing_key(mod, tmp_path):
@@ -147,9 +147,9 @@ def test_appends_when_pending_is_missing_key(mod, tmp_path):
     assert data["pending"][0]["path"] == "contexts/x.md"
 
 
-# ─────────────────────────────────────────────────────────────
+# ----
 # 5. Rejects YAML that is a list at root (not a dict)
-# ─────────────────────────────────────────────────────────────
+# ----
 
 
 def test_rejects_malformed_yaml_not_a_dict(mod, tmp_path, capsys):
@@ -169,9 +169,9 @@ def test_rejects_malformed_yaml_not_a_dict(mod, tmp_path, capsys):
     assert pending_path.read_text() == original_content
 
 
-# ─────────────────────────────────────────────────────────────
+# ----
 # 6. Rejects pending field that is a string (not a list)
-# ─────────────────────────────────────────────────────────────
+# ----
 
 
 def test_rejects_pending_not_a_list(mod, tmp_path, capsys):
@@ -191,9 +191,9 @@ def test_rejects_pending_not_a_list(mod, tmp_path, capsys):
     assert pending_path.read_text() == original_content
 
 
-# ─────────────────────────────────────────────────────────────
+# ----
 # 7. created_at format is UTC ISO 8601 with Z suffix
-# ─────────────────────────────────────────────────────────────
+# ----
 
 
 def test_datetime_format_is_utc_iso_z(mod, tmp_path):
@@ -213,9 +213,9 @@ def test_datetime_format_is_utc_iso_z(mod, tmp_path):
     assert re.match(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$", created_at)
 
 
-# ─────────────────────────────────────────────────────────────
+# ----
 # 8. Field order is canonical: path / type / action / source / created_at
-# ─────────────────────────────────────────────────────────────
+# ----
 
 
 def test_field_order_is_canonical(mod, tmp_path):
@@ -225,7 +225,7 @@ def test_field_order_is_canonical(mod, tmp_path):
     # Act
     mod.append_pending_entry(root, "skills/test/", "skill", "created", "test-source")
 
-    # Assert — check key appearance order in raw YAML text
+    # Assert -- check key appearance order in raw YAML text
     lines = (root / ".agentic-beacon" / "pending.yaml").read_text().splitlines()
     key_order = ["path:", "type:", "action:", "source:", "created_at:"]
 
@@ -245,9 +245,9 @@ def test_field_order_is_canonical(mod, tmp_path):
     )
 
 
-# ─────────────────────────────────────────────────────────────
+# ----
 # 9. Written file ends with a trailing newline
-# ─────────────────────────────────────────────────────────────
+# ----
 
 
 def test_trailing_newline_present(mod, tmp_path):
@@ -262,9 +262,9 @@ def test_trailing_newline_present(mod, tmp_path):
     assert raw.endswith(b"\n")
 
 
-# ─────────────────────────────────────────────────────────────
+# ----
 # 10. Multibyte (Unicode) path roundtrips correctly
-# ─────────────────────────────────────────────────────────────
+# ----
 
 
 def test_unicode_path_roundtrip(mod, tmp_path):
@@ -282,9 +282,9 @@ def test_unicode_path_roundtrip(mod, tmp_path):
     assert data["pending"][0]["path"] == unicode_path
 
 
-# ─────────────────────────────────────────────────────────────
+# ----
 # 11. Output round-trips through canonical PendingManifest
-# ─────────────────────────────────────────────────────────────
+# ----
 
 
 def test_round_trips_through_canonical_pending_manifest(mod, tmp_path):
@@ -296,7 +296,7 @@ def test_round_trips_through_canonical_pending_manifest(mod, tmp_path):
         root, "skills/myskill/", "skill", "created", "record-skill"
     )
 
-    # Assert — import the canonical Pydantic model and verify it parses the output
+    # Assert -- import the canonical Pydantic model and verify it parses the output
     from beacon.core.manifest.pending import PendingManifest
 
     manifest = PendingManifest.from_yaml(root / ".agentic-beacon" / "pending.yaml")
@@ -308,9 +308,9 @@ def test_round_trips_through_canonical_pending_manifest(mod, tmp_path):
     assert entry.source == "record-skill"
 
 
-# ─────────────────────────────────────────────────────────────
+# ----
 # 12. Invalid --type rejected by argparse (exits 2)
-# ─────────────────────────────────────────────────────────────
+# ----
 
 
 def test_invalid_type_rejected_by_argparse(mod, monkeypatch, tmp_path):
@@ -343,9 +343,9 @@ def test_invalid_type_rejected_by_argparse(mod, monkeypatch, tmp_path):
     assert not pending_path.exists()
 
 
-# ─────────────────────────────────────────────────────────────
+# ----
 # 13. Invalid --action rejected by argparse (exits 2)
-# ─────────────────────────────────────────────────────────────
+# ----
 
 
 def test_invalid_action_rejected_by_argparse(mod, monkeypatch, tmp_path):
@@ -378,13 +378,13 @@ def test_invalid_action_rejected_by_argparse(mod, monkeypatch, tmp_path):
     assert not pending_path.exists()
 
 
-# ─────────────────────────────────────────────────────────────
-# 14. No project root → exits 1 with ERROR_NO_WAREHOUSE on stderr
-# ─────────────────────────────────────────────────────────────
+# ----
+# 14. No project root -> exits 1 with ERROR_NO_WAREHOUSE on stderr
+# ----
 
 
 def test_no_project_root_exits_with_error(mod, monkeypatch, tmp_path, capsys):
-    # Arrange — tmp_path has no .agentic-beacon/config.toml
+    # Arrange -- tmp_path has no .agentic-beacon/config.toml
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(
         sys,
@@ -411,13 +411,13 @@ def test_no_project_root_exits_with_error(mod, monkeypatch, tmp_path, capsys):
     assert "Error: no warehouse connected" in capsys.readouterr().err
 
 
-# ─────────────────────────────────────────────────────────────
+# ----
 # Extra coverage: yaml.YAMLError branch (line 53-55)
-# ─────────────────────────────────────────────────────────────
+# ----
 
 
 def test_yaml_syntax_error_exits_with_message(mod, tmp_path, capsys):
-    # Arrange — write a file with invalid YAML syntax (unclosed brace)
+    # Arrange -- write a file with invalid YAML syntax (unclosed brace)
     root = _make_project(tmp_path)
     pending_path = root / ".agentic-beacon" / "pending.yaml"
     pending_path.write_bytes(b"pending: {unclosed\n")
@@ -433,13 +433,13 @@ def test_yaml_syntax_error_exits_with_message(mod, tmp_path, capsys):
     assert pending_path.read_bytes() == original_content
 
 
-# ─────────────────────────────────────────────────────────────
-# Extra coverage: data is None (empty / null YAML file) → line 58
-# ─────────────────────────────────────────────────────────────
+# ----
+# Extra coverage: data is None (empty / null YAML file) -> line 58
+# ----
 
 
 def test_null_yaml_file_treated_as_empty(mod, tmp_path):
-    # Arrange — file contains only "null" (yaml.safe_load returns None)
+    # Arrange -- file contains only "null" (yaml.safe_load returns None)
     root = _make_project(tmp_path)
     pending_path = root / ".agentic-beacon" / "pending.yaml"
     pending_path.write_text("null\n")
@@ -447,14 +447,14 @@ def test_null_yaml_file_treated_as_empty(mod, tmp_path):
     # Act
     mod.append_pending_entry(root, "skills/x/", "skill", "created", "s")
 
-    # Assert — treated as empty list, one entry written
+    # Assert -- treated as empty list, one entry written
     data = yaml.safe_load(pending_path.read_text())
     assert len(data["pending"]) == 1
 
 
-# ─────────────────────────────────────────────────────────────
+# ----
 # Extra coverage: main() success path (lines 31 and 132)
-# ─────────────────────────────────────────────────────────────
+# ----
 
 
 def test_main_success_path_writes_pending(mod, monkeypatch, tmp_path):
@@ -487,9 +487,9 @@ def test_main_success_path_writes_pending(mod, monkeypatch, tmp_path):
     assert data["pending"][0]["path"] == "skills/my-skill/"
 
 
-# ─────────────────────────────────────────────────────────────
+# ----
 # 15. Both script copies are byte-identical
-# ─────────────────────────────────────────────────────────────
+# ----
 
 
 def test_both_script_copies_byte_identical():
@@ -505,3 +505,221 @@ def test_both_script_copies_byte_identical():
     assert _sha256(skill_path) == _sha256(knowledge_path), (
         "record-skill and record-knowledge append_pending.py copies have diverged"
     )
+
+
+# ----
+# New tests: timestamp canonicalization and entry validation (PER-150 review)
+# ----
+
+
+def test_existing_unquoted_timestamp_canonicalized(mod, tmp_path):
+    # Arrange: seed with unquoted timestamp -- yaml.safe_load parses it as datetime
+    root = _make_project(tmp_path)
+    pending_path = root / ".agentic-beacon" / "pending.yaml"
+    pending_path.write_text(
+        "pending:\n"
+        "- path: skills/preexisting/\n"
+        "  type: skill\n"
+        "  action: created\n"
+        "  source: x\n"
+        "  created_at: 2026-01-01T00:00:00Z\n"
+    )
+
+    # Act
+    mod.append_pending_entry(root, "skills/new/", "skill", "created", "record-skill")
+
+    # Assert: no entry may use the Python-repr drift format (space + +00:00)
+    content = pending_path.read_text()
+    assert "00:00:00+00:00" not in content, (
+        f"Timestamp was rewritten to Python repr style:\n{content}"
+    )
+    for line in content.splitlines():
+        if "created_at:" in line:
+            assert re.search(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z", line), (
+                f"created_at not in canonical Z form: {line!r}"
+            )
+
+
+def test_existing_entry_datetime_created_at_accepted_and_canonicalized(mod, tmp_path):
+    # Arrange: seed with unquoted timestamp so yaml.safe_load returns datetime
+    root = _make_project(tmp_path)
+    pending_path = root / ".agentic-beacon" / "pending.yaml"
+    pending_path.write_text(
+        "pending:\n"
+        "- path: skills/old/\n"
+        "  type: skill\n"
+        "  action: created\n"
+        "  source: s\n"
+        "  created_at: 2025-06-15T10:30:00Z\n"
+    )
+
+    # Act: should NOT raise SystemExit -- datetime value is valid, just canonicalized
+    mod.append_pending_entry(root, "skills/new/", "skill", "created", "s")
+
+    # Assert: both entries present; first entry's created_at is in canonical form
+    data = yaml.safe_load(pending_path.read_text())
+    assert len(data["pending"]) == 2
+    first_created_at = data["pending"][0]["created_at"]
+    if not isinstance(first_created_at, str):
+        first_created_at = first_created_at.strftime("%Y-%m-%dT%H:%M:%SZ")
+    assert re.match(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$", first_created_at)
+
+
+def test_existing_entry_missing_required_field_rejected(mod, tmp_path, capsys):
+    # Arrange: entry missing 'source'
+    root = _make_project(tmp_path)
+    pending_path = root / ".agentic-beacon" / "pending.yaml"
+    pending_path.write_text(
+        yaml.dump(
+            {
+                "pending": [
+                    {
+                        "path": "skills/x/",
+                        "type": "skill",
+                        "action": "created",
+                        # source intentionally omitted
+                        "created_at": "2026-01-01T00:00:00Z",
+                    }
+                ]
+            },
+            default_flow_style=False,
+        )
+    )
+    original_content = pending_path.read_bytes()
+
+    # Act
+    with pytest.raises(SystemExit) as exc:
+        mod.append_pending_entry(root, "skills/new/", "skill", "created", "s")
+
+    # Assert
+    assert exc.value.code != 0
+    assert "source" in capsys.readouterr().err
+    assert pending_path.read_bytes() == original_content
+
+
+def test_existing_entry_invalid_type_rejected(mod, tmp_path, capsys):
+    # Arrange: entry with type='bogus'
+    root = _make_project(tmp_path)
+    pending_path = root / ".agentic-beacon" / "pending.yaml"
+    pending_path.write_text(
+        yaml.dump(
+            {
+                "pending": [
+                    {
+                        "path": "skills/x/",
+                        "type": "bogus",
+                        "action": "created",
+                        "source": "s",
+                        "created_at": "2026-01-01T00:00:00Z",
+                    }
+                ]
+            },
+            default_flow_style=False,
+        )
+    )
+    original_content = pending_path.read_bytes()
+
+    # Act
+    with pytest.raises(SystemExit) as exc:
+        mod.append_pending_entry(root, "skills/new/", "skill", "created", "s")
+
+    # Assert
+    assert exc.value.code != 0
+    assert "type" in capsys.readouterr().err
+    assert pending_path.read_bytes() == original_content
+
+
+def test_existing_entry_invalid_action_rejected(mod, tmp_path, capsys):
+    # Arrange: entry with action='deleted' (not in VALID_ACTIONS)
+    root = _make_project(tmp_path)
+    pending_path = root / ".agentic-beacon" / "pending.yaml"
+    pending_path.write_text(
+        yaml.dump(
+            {
+                "pending": [
+                    {
+                        "path": "skills/x/",
+                        "type": "skill",
+                        "action": "deleted",
+                        "source": "s",
+                        "created_at": "2026-01-01T00:00:00Z",
+                    }
+                ]
+            },
+            default_flow_style=False,
+        )
+    )
+    original_content = pending_path.read_bytes()
+
+    # Act
+    with pytest.raises(SystemExit) as exc:
+        mod.append_pending_entry(root, "skills/new/", "skill", "created", "s")
+
+    # Assert
+    assert exc.value.code != 0
+    assert "action" in capsys.readouterr().err
+    assert pending_path.read_bytes() == original_content
+
+
+def test_existing_entry_non_string_path_rejected(mod, tmp_path, capsys):
+    # Arrange: entry with path=42 (integer, not string)
+    root = _make_project(tmp_path)
+    pending_path = root / ".agentic-beacon" / "pending.yaml"
+    pending_path.write_text(
+        yaml.dump(
+            {
+                "pending": [
+                    {
+                        "path": 42,
+                        "type": "skill",
+                        "action": "created",
+                        "source": "s",
+                        "created_at": "2026-01-01T00:00:00Z",
+                    }
+                ]
+            },
+            default_flow_style=False,
+        )
+    )
+    original_content = pending_path.read_bytes()
+
+    # Act
+    with pytest.raises(SystemExit) as exc:
+        mod.append_pending_entry(root, "skills/new/", "skill", "created", "s")
+
+    # Assert
+    assert exc.value.code != 0
+    assert "path" in capsys.readouterr().err
+    assert pending_path.read_bytes() == original_content
+
+
+def test_existing_entry_malformed_created_at_rejected(mod, tmp_path, capsys):
+    # Arrange: entry with created_at='not-a-date'
+    root = _make_project(tmp_path)
+    pending_path = root / ".agentic-beacon" / "pending.yaml"
+    pending_path.write_text(
+        yaml.dump(
+            {
+                "pending": [
+                    {
+                        "path": "skills/x/",
+                        "type": "skill",
+                        "action": "created",
+                        "source": "s",
+                        "created_at": "not-a-date",
+                    }
+                ]
+            },
+            default_flow_style=False,
+        )
+    )
+    original_content = pending_path.read_bytes()
+
+    # Act
+    with pytest.raises(SystemExit) as exc:
+        mod.append_pending_entry(root, "skills/new/", "skill", "created", "s")
+
+    # Assert
+    assert exc.value.code != 0
+    assert "created_at" in capsys.readouterr().err
+    assert pending_path.read_bytes() == original_content

--- a/libs/beacon/tests/unit/test_append_pending_inline.py
+++ b/libs/beacon/tests/unit/test_append_pending_inline.py
@@ -1,0 +1,507 @@
+"""Unit tests for the inlined YAML logic in both append_pending.py copies.
+
+Validates the self-contained read-merge-write behaviour introduced in PER-150.
+Parametrised over both copies to enforce the byte-identity invariant.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import re
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+_SKILLS_DIR = (
+    Path(__file__).resolve().parent.parent.parent / "src" / "beacon" / "data" / "skills"
+)
+
+_SKILL_NAMES = ["record-skill", "record-knowledge"]
+
+
+def _load_module(skill_name: str):
+    script_path = _SKILLS_DIR / skill_name / "scripts" / "append_pending.py"
+    spec = importlib.util.spec_from_file_location(
+        f"{skill_name.replace('-', '_')}_append_pending_inline",
+        script_path,
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _make_project(tmp_path: Path) -> Path:
+    beacon_dir = tmp_path / ".agentic-beacon"
+    beacon_dir.mkdir(parents=True)
+    (beacon_dir / "config.toml").write_text(f'[warehouse]\nlocal_path = "{tmp_path}"\n')
+    return tmp_path
+
+
+@pytest.fixture(params=_SKILL_NAMES)
+def mod(request):
+    return _load_module(request.param)
+
+
+# ─────────────────────────────────────────────────────────────
+# 1. Creates file when pending.yaml doesn't exist
+# ─────────────────────────────────────────────────────────────
+
+
+def test_appends_to_empty_dir_creates_file(mod, tmp_path):
+    # Arrange
+    root = _make_project(tmp_path)
+    pending_path = root / ".agentic-beacon" / "pending.yaml"
+    assert not pending_path.exists()
+
+    # Act
+    mod.append_pending_entry(root, "skills/test/", "skill", "created", "record-skill")
+
+    # Assert
+    assert pending_path.exists()
+    data = yaml.safe_load(pending_path.read_text())
+    assert isinstance(data, dict)
+    assert isinstance(data["pending"], list)
+    assert len(data["pending"]) == 1
+
+
+# ─────────────────────────────────────────────────────────────
+# 2. Appends to existing entries preserving insertion order
+# ─────────────────────────────────────────────────────────────
+
+
+def test_appends_to_existing_entries_preserves_order(mod, tmp_path):
+    # Arrange
+    root = _make_project(tmp_path)
+    pending_path = root / ".agentic-beacon" / "pending.yaml"
+    existing = {
+        "pending": [
+            {
+                "path": "skills/first/",
+                "type": "skill",
+                "action": "created",
+                "source": "s",
+                "created_at": "2026-01-01T00:00:00Z",
+            },
+            {
+                "path": "contexts/second.md",
+                "type": "context",
+                "action": "modified",
+                "source": "s",
+                "created_at": "2026-01-02T00:00:00Z",
+            },
+        ]
+    }
+    pending_path.write_text(
+        yaml.dump(existing, default_flow_style=False, sort_keys=False)
+    )
+
+    # Act
+    mod.append_pending_entry(root, "agents/third/", "agent", "created", "record-skill")
+
+    # Assert
+    data = yaml.safe_load(pending_path.read_text())
+    paths = [e["path"] for e in data["pending"]]
+    assert paths == ["skills/first/", "contexts/second.md", "agents/third/"]
+
+
+# ─────────────────────────────────────────────────────────────
+# 3. pending: null treated as empty list
+# ─────────────────────────────────────────────────────────────
+
+
+def test_appends_when_pending_is_null(mod, tmp_path):
+    # Arrange
+    root = _make_project(tmp_path)
+    pending_path = root / ".agentic-beacon" / "pending.yaml"
+    pending_path.write_text("pending: null\n")
+
+    # Act
+    mod.append_pending_entry(root, "skills/x/", "skill", "created", "s")
+
+    # Assert
+    data = yaml.safe_load(pending_path.read_text())
+    assert len(data["pending"]) == 1
+    assert data["pending"][0]["path"] == "skills/x/"
+
+
+# ─────────────────────────────────────────────────────────────
+# 4. pending key missing from dict treated as empty list
+# ─────────────────────────────────────────────────────────────
+
+
+def test_appends_when_pending_is_missing_key(mod, tmp_path):
+    # Arrange
+    root = _make_project(tmp_path)
+    pending_path = root / ".agentic-beacon" / "pending.yaml"
+    pending_path.write_text("{}\n")
+
+    # Act
+    mod.append_pending_entry(root, "contexts/x.md", "context", "created", "s")
+
+    # Assert
+    data = yaml.safe_load(pending_path.read_text())
+    assert len(data["pending"]) == 1
+    assert data["pending"][0]["path"] == "contexts/x.md"
+
+
+# ─────────────────────────────────────────────────────────────
+# 5. Rejects YAML that is a list at root (not a dict)
+# ─────────────────────────────────────────────────────────────
+
+
+def test_rejects_malformed_yaml_not_a_dict(mod, tmp_path, capsys):
+    # Arrange
+    root = _make_project(tmp_path)
+    pending_path = root / ".agentic-beacon" / "pending.yaml"
+    pending_path.write_text("- foo\n- bar\n")
+    original_content = pending_path.read_text()
+
+    # Act
+    with pytest.raises(SystemExit) as exc:
+        mod.append_pending_entry(root, "x", "skill", "created", "s")
+
+    # Assert
+    assert exc.value.code != 0
+    assert "Error" in capsys.readouterr().err
+    assert pending_path.read_text() == original_content
+
+
+# ─────────────────────────────────────────────────────────────
+# 6. Rejects pending field that is a string (not a list)
+# ─────────────────────────────────────────────────────────────
+
+
+def test_rejects_pending_not_a_list(mod, tmp_path, capsys):
+    # Arrange
+    root = _make_project(tmp_path)
+    pending_path = root / ".agentic-beacon" / "pending.yaml"
+    pending_path.write_text("pending: 'not-a-list'\n")
+    original_content = pending_path.read_text()
+
+    # Act
+    with pytest.raises(SystemExit) as exc:
+        mod.append_pending_entry(root, "x", "skill", "created", "s")
+
+    # Assert
+    assert exc.value.code != 0
+    assert "Error" in capsys.readouterr().err
+    assert pending_path.read_text() == original_content
+
+
+# ─────────────────────────────────────────────────────────────
+# 7. created_at format is UTC ISO 8601 with Z suffix
+# ─────────────────────────────────────────────────────────────
+
+
+def test_datetime_format_is_utc_iso_z(mod, tmp_path):
+    # Arrange
+    root = _make_project(tmp_path)
+
+    # Act
+    mod.append_pending_entry(root, "skills/x/", "skill", "created", "s")
+
+    # Assert
+    content = (root / ".agentic-beacon" / "pending.yaml").read_text()
+    data = yaml.safe_load(content)
+    created_at = data["pending"][0]["created_at"]
+    # Pydantic/yaml may return datetime or string; normalise to string
+    if not isinstance(created_at, str):
+        created_at = created_at.strftime("%Y-%m-%dT%H:%M:%SZ")
+    assert re.match(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$", created_at)
+
+
+# ─────────────────────────────────────────────────────────────
+# 8. Field order is canonical: path / type / action / source / created_at
+# ─────────────────────────────────────────────────────────────
+
+
+def test_field_order_is_canonical(mod, tmp_path):
+    # Arrange
+    root = _make_project(tmp_path)
+
+    # Act
+    mod.append_pending_entry(root, "skills/test/", "skill", "created", "test-source")
+
+    # Assert — check key appearance order in raw YAML text
+    lines = (root / ".agentic-beacon" / "pending.yaml").read_text().splitlines()
+    key_order = ["path:", "type:", "action:", "source:", "created_at:"]
+
+    def _find_line(key: str) -> int:
+        for i, line in enumerate(lines):
+            s = line.strip()
+            if s.startswith(key) or s.startswith(f"- {key}"):
+                return i
+        return -1
+
+    positions = [_find_line(k) for k in key_order]
+    assert all(p >= 0 for p in positions), (
+        f"Some keys not found in YAML output: {list(zip(key_order, positions, strict=False))}"
+    )
+    assert positions == sorted(positions), (
+        f"Keys are out of canonical order: {list(zip(key_order, positions, strict=False))}"
+    )
+
+
+# ─────────────────────────────────────────────────────────────
+# 9. Written file ends with a trailing newline
+# ─────────────────────────────────────────────────────────────
+
+
+def test_trailing_newline_present(mod, tmp_path):
+    # Arrange
+    root = _make_project(tmp_path)
+
+    # Act
+    mod.append_pending_entry(root, "skills/x/", "skill", "created", "s")
+
+    # Assert
+    raw = (root / ".agentic-beacon" / "pending.yaml").read_bytes()
+    assert raw.endswith(b"\n")
+
+
+# ─────────────────────────────────────────────────────────────
+# 10. Multibyte (Unicode) path roundtrips correctly
+# ─────────────────────────────────────────────────────────────
+
+
+def test_unicode_path_roundtrip(mod, tmp_path):
+    # Arrange
+    root = _make_project(tmp_path)
+    unicode_path = "skills/测试/"
+
+    # Act
+    mod.append_pending_entry(root, unicode_path, "skill", "created", "s")
+
+    # Assert
+    data = yaml.safe_load(
+        (root / ".agentic-beacon" / "pending.yaml").read_text(encoding="utf-8")
+    )
+    assert data["pending"][0]["path"] == unicode_path
+
+
+# ─────────────────────────────────────────────────────────────
+# 11. Output round-trips through canonical PendingManifest
+# ─────────────────────────────────────────────────────────────
+
+
+def test_round_trips_through_canonical_pending_manifest(mod, tmp_path):
+    # Arrange
+    root = _make_project(tmp_path)
+
+    # Act
+    mod.append_pending_entry(
+        root, "skills/myskill/", "skill", "created", "record-skill"
+    )
+
+    # Assert — import the canonical Pydantic model and verify it parses the output
+    from beacon.core.manifest.pending import PendingManifest
+
+    manifest = PendingManifest.from_yaml(root / ".agentic-beacon" / "pending.yaml")
+    assert len(manifest.pending) == 1
+    entry = manifest.pending[0]
+    assert entry.path == "skills/myskill/"
+    assert entry.type == "skill"
+    assert entry.action == "created"
+    assert entry.source == "record-skill"
+
+
+# ─────────────────────────────────────────────────────────────
+# 12. Invalid --type rejected by argparse (exits 2)
+# ─────────────────────────────────────────────────────────────
+
+
+def test_invalid_type_rejected_by_argparse(mod, monkeypatch, tmp_path):
+    # Arrange
+    root = _make_project(tmp_path)
+    pending_path = root / ".agentic-beacon" / "pending.yaml"
+    monkeypatch.chdir(root)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "append_pending.py",
+            "--path",
+            "x",
+            "--type",
+            "bogus",
+            "--action",
+            "created",
+            "--source",
+            "s",
+        ],
+    )
+
+    # Act
+    with pytest.raises(SystemExit) as exc:
+        mod.main()
+
+    # Assert
+    assert exc.value.code == 2
+    assert not pending_path.exists()
+
+
+# ─────────────────────────────────────────────────────────────
+# 13. Invalid --action rejected by argparse (exits 2)
+# ─────────────────────────────────────────────────────────────
+
+
+def test_invalid_action_rejected_by_argparse(mod, monkeypatch, tmp_path):
+    # Arrange
+    root = _make_project(tmp_path)
+    pending_path = root / ".agentic-beacon" / "pending.yaml"
+    monkeypatch.chdir(root)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "append_pending.py",
+            "--path",
+            "x",
+            "--type",
+            "skill",
+            "--action",
+            "bogus",
+            "--source",
+            "s",
+        ],
+    )
+
+    # Act
+    with pytest.raises(SystemExit) as exc:
+        mod.main()
+
+    # Assert
+    assert exc.value.code == 2
+    assert not pending_path.exists()
+
+
+# ─────────────────────────────────────────────────────────────
+# 14. No project root → exits 1 with ERROR_NO_WAREHOUSE on stderr
+# ─────────────────────────────────────────────────────────────
+
+
+def test_no_project_root_exits_with_error(mod, monkeypatch, tmp_path, capsys):
+    # Arrange — tmp_path has no .agentic-beacon/config.toml
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "append_pending.py",
+            "--path",
+            "x",
+            "--type",
+            "skill",
+            "--action",
+            "created",
+            "--source",
+            "s",
+        ],
+    )
+
+    # Act
+    with pytest.raises(SystemExit) as exc:
+        mod.main()
+
+    # Assert
+    assert exc.value.code == 1
+    assert "Error: no warehouse connected" in capsys.readouterr().err
+
+
+# ─────────────────────────────────────────────────────────────
+# Extra coverage: yaml.YAMLError branch (line 53-55)
+# ─────────────────────────────────────────────────────────────
+
+
+def test_yaml_syntax_error_exits_with_message(mod, tmp_path, capsys):
+    # Arrange — write a file with invalid YAML syntax (unclosed brace)
+    root = _make_project(tmp_path)
+    pending_path = root / ".agentic-beacon" / "pending.yaml"
+    pending_path.write_bytes(b"pending: {unclosed\n")
+    original_content = pending_path.read_bytes()
+
+    # Act
+    with pytest.raises(SystemExit) as exc:
+        mod.append_pending_entry(root, "x", "skill", "created", "s")
+
+    # Assert
+    assert exc.value.code != 0
+    assert "Error" in capsys.readouterr().err
+    assert pending_path.read_bytes() == original_content
+
+
+# ─────────────────────────────────────────────────────────────
+# Extra coverage: data is None (empty / null YAML file) → line 58
+# ─────────────────────────────────────────────────────────────
+
+
+def test_null_yaml_file_treated_as_empty(mod, tmp_path):
+    # Arrange — file contains only "null" (yaml.safe_load returns None)
+    root = _make_project(tmp_path)
+    pending_path = root / ".agentic-beacon" / "pending.yaml"
+    pending_path.write_text("null\n")
+
+    # Act
+    mod.append_pending_entry(root, "skills/x/", "skill", "created", "s")
+
+    # Assert — treated as empty list, one entry written
+    data = yaml.safe_load(pending_path.read_text())
+    assert len(data["pending"]) == 1
+
+
+# ─────────────────────────────────────────────────────────────
+# Extra coverage: main() success path (lines 31 and 132)
+# ─────────────────────────────────────────────────────────────
+
+
+def test_main_success_path_writes_pending(mod, monkeypatch, tmp_path):
+    # Arrange
+    root = _make_project(tmp_path)
+    pending_path = root / ".agentic-beacon" / "pending.yaml"
+    monkeypatch.chdir(root)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "append_pending.py",
+            "--path",
+            "skills/my-skill/",
+            "--type",
+            "skill",
+            "--action",
+            "created",
+            "--source",
+            "record-skill",
+        ],
+    )
+
+    # Act
+    mod.main()
+
+    # Assert
+    assert pending_path.exists()
+    data = yaml.safe_load(pending_path.read_text())
+    assert data["pending"][0]["path"] == "skills/my-skill/"
+
+
+# ─────────────────────────────────────────────────────────────
+# 15. Both script copies are byte-identical
+# ─────────────────────────────────────────────────────────────
+
+
+def test_both_script_copies_byte_identical():
+    # Arrange
+    skill_path = _SKILLS_DIR / "record-skill" / "scripts" / "append_pending.py"
+    knowledge_path = _SKILLS_DIR / "record-knowledge" / "scripts" / "append_pending.py"
+
+    # Act
+    def _sha256(p: Path) -> str:
+        return hashlib.sha256(p.read_bytes()).hexdigest()
+
+    # Assert
+    assert _sha256(skill_path) == _sha256(knowledge_path), (
+        "record-skill and record-knowledge append_pending.py copies have diverged"
+    )

--- a/libs/beacon/tests/unit/test_append_pending_inline.py
+++ b/libs/beacon/tests/unit/test_append_pending_inline.py
@@ -826,6 +826,86 @@ def test_existing_entry_impossible_hour_rejected(mod, tmp_path, capsys):
     assert pending_path.read_bytes() == original_content
 
 
+# ----
+# New tests: non-canonical zero-padding rejected (PER-150 review round 3)
+# ----
+
+
+def test_existing_entry_non_canonical_zero_padding_rejected(mod, tmp_path, capsys):
+    # Arrange: all components unpadded — strptime accepts but round-trip differs
+    root = _make_project(tmp_path)
+    pending_path = root / ".agentic-beacon" / "pending.yaml"
+    pending_path.write_text(
+        "pending:\n"
+        "- path: skills/x/\n"
+        "  type: skill\n"
+        "  action: created\n"
+        "  source: x\n"
+        "  created_at: '2026-1-1T0:0:0Z'\n"
+    )
+    original_content = pending_path.read_bytes()
+
+    # Act
+    with pytest.raises(SystemExit) as exc:
+        mod.append_pending_entry(root, "skills/new/", "skill", "created", "s")
+
+    # Assert
+    assert exc.value.code != 0
+    err = capsys.readouterr().err
+    assert "canonical" in err
+    assert pending_path.read_bytes() == original_content
+
+
+def test_existing_entry_unpadded_day_rejected(mod, tmp_path, capsys):
+    # Arrange: day component unpadded ('1' instead of '01')
+    root = _make_project(tmp_path)
+    pending_path = root / ".agentic-beacon" / "pending.yaml"
+    pending_path.write_text(
+        "pending:\n"
+        "- path: skills/x/\n"
+        "  type: skill\n"
+        "  action: created\n"
+        "  source: x\n"
+        "  created_at: '2026-01-1T07:00:00Z'\n"
+    )
+    original_content = pending_path.read_bytes()
+
+    # Act
+    with pytest.raises(SystemExit) as exc:
+        mod.append_pending_entry(root, "skills/new/", "skill", "created", "s")
+
+    # Assert
+    assert exc.value.code != 0
+    err = capsys.readouterr().err
+    assert "canonical" in err
+    assert pending_path.read_bytes() == original_content
+
+
+def test_existing_entry_unpadded_hour_rejected(mod, tmp_path, capsys):
+    # Arrange: hour component unpadded ('7' instead of '07')
+    root = _make_project(tmp_path)
+    pending_path = root / ".agentic-beacon" / "pending.yaml"
+    pending_path.write_text(
+        "pending:\n"
+        "- path: skills/x/\n"
+        "  type: skill\n"
+        "  action: created\n"
+        "  source: x\n"
+        "  created_at: '2026-01-01T7:00:00Z'\n"
+    )
+    original_content = pending_path.read_bytes()
+
+    # Act
+    with pytest.raises(SystemExit) as exc:
+        mod.append_pending_entry(root, "skills/new/", "skill", "created", "s")
+
+    # Assert
+    assert exc.value.code != 0
+    err = capsys.readouterr().err
+    assert "canonical" in err
+    assert pending_path.read_bytes() == original_content
+
+
 def test_existing_entry_valid_canonical_string_accepted(mod, tmp_path):
     # Arrange: well-formed, in-range timestamp as quoted string
     root = _make_project(tmp_path)


### PR DESCRIPTION
## Summary

`record-skill` and `record-knowledge` SKILL.md instruct the LLM agent to run `uv run append_pending.py` to append an entry to `.agentic-beacon/pending.yaml`. The script's PEP 723 header declared `dependencies = []` but the body imported `from beacon.core.manifest.pending import ...`. Since PEP 723 inline-metadata scripts **always** run in an isolated ephemeral venv (verified via `uv` warning), the import fails with `ModuleNotFoundError: No module named 'beacon'` for any user who installed `abc` outside the agentic-beacon source tree. Result: warehouse files get written, but `pending.yaml` is never created — breaking the documented `record-* → pending → adopt` loop for all end users.

Fix: inline the YAML read-merge-write logic with `pyyaml>=6.0` declared in the PEP 723 header. Output remains byte-compatible with the canonical `PendingManifest.from_yaml` (round-trip test covers this). Both `append_pending.py` copies stay byte-identical (SHA256 check in CI).

Closes [PER-150](https://linear.app/shadowsong-personal/issue/PER-150).

## What changed

- `libs/beacon/src/beacon/data/skills/record-skill/scripts/append_pending.py` — inline YAML logic, `pyyaml` in PEP 723 deps, no more `beacon` import.
- `libs/beacon/src/beacon/data/skills/record-knowledge/scripts/append_pending.py` — byte-identical to the record-skill copy.
- `libs/beacon/tests/unit/test_append_pending_inline.py` (new, 35 tests) — covers empty file, existing entries, null `pending`, malformed YAML, datetime format, field order, trailing newline, unicode, round-trip with canonical `PendingManifest`, argparse rejection, no-project-root error, byte-identical script copies.
- `libs/beacon/tests/integration/test_append_pending_standalone.py` (new, 4 tests) — runs the script via `uv run` in a clean env (stripped `PYTHONPATH`/`VIRTUAL_ENV`/`BEACON_*`), parametrized over both skill copies, plus a nested-cwd variant.
- `libs/beacon/tests/integration/test_record_write_subprocess.py` (+1 E2E test) — full `record-skill` flow: `write_skill.py` then `append_pending.py` via `uv run`. Without this fix the test fails with `ModuleNotFoundError`.

Coverage: 98% on both scripts (only the `if __name__ == "__main__"` line missed, unreachable via importlib).

## Test plan

- [x] Unit tests (35 cases): `pytest libs/beacon/tests/unit/test_append_pending_inline.py -v`
- [x] Integration tests (4 cases, real `uv run` in clean env): `pytest libs/beacon/tests/integration/test_append_pending_standalone.py -v`
- [x] E2E regression (record-skill write_skill + append_pending): `pytest libs/beacon/tests/integration/test_record_write_subprocess.py::test_record_skill_e2e_write_then_append_pending -v`
- [x] Manual e2e: `uv run append_pending.py` from `env -i` in a tmp project → exit 0, valid `pending.yaml`, two sequential invocations correctly appended.
- [x] Coverage ≥ 90% target: actual 98% on both scripts.
- [ ] CI green
- [ ] opencode-review bot clean

## Out of scope

- `abc adopt` not auto-wiring bundled skills / not initializing `opencode.json` / `CLAUDE.md` — tracked in [PER-151](https://linear.app/shadowsong-personal/issue/PER-151).
- New docs pages for bundled skills + `pending.yaml` — tracked in [PER-152](https://linear.app/shadowsong-personal/issue/PER-152).