### PR TITLE
feat(setup): auto-init agent config + wire bundled skills on adopt (PER-151)

### DIFF
--- a/libs/beacon/src/beacon/cli/setup.py
+++ b/libs/beacon/src/beacon/cli/setup.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import click
 from rich.console import Console
 
-from beacon.domains.setup.wiring import create_beacon_template
+from beacon.domains.setup.wiring import setup_project
 
 console = Console()
 
@@ -41,13 +41,17 @@ def setup() -> None:
             console.print("Setup cancelled.")
             sys.exit(0)
 
-    create_beacon_template(beacon_yaml)
     # Note: .gitignore entries for .claude/agents/ and .opencode/agents/ are
     # added later by `abc sync` or `abc adopt` accept when agents are first
     # declared. Doing it here unconditionally would dirty the .gitignore on
     # projects that never declare agents.
+    setup_project(beacon_yaml, beacon_dir.parent)
     console.print("\n[bold green]✓ Created beacon.yaml template[/bold green]")
     console.print(f"  [blue]Location:[/blue] {beacon_yaml}")
+    if (beacon_dir.parent / "opencode.json").exists():
+        console.print("[green]✓[/green] Initialized opencode.json")
+    if (beacon_dir.parent / "CLAUDE.md").exists():
+        console.print("[green]✓[/green] Initialized CLAUDE.md")
     console.print("\n[bold]Next Steps:[/bold]")
     console.print("  1. Run 'abc adopt' to select artifacts from the warehouse")
     console.print("  2. Or edit .agentic-beacon/beacon.yaml directly")

--- a/libs/beacon/src/beacon/cli/setup.py
+++ b/libs/beacon/src/beacon/cli/setup.py
@@ -45,12 +45,12 @@ def setup() -> None:
     # added later by `abc sync` or `abc adopt` accept when agents are first
     # declared. Doing it here unconditionally would dirty the .gitignore on
     # projects that never declare agents.
-    setup_project(beacon_yaml, beacon_dir.parent)
+    result = setup_project(beacon_yaml, beacon_dir.parent)
     console.print("\n[bold green]✓ Created beacon.yaml template[/bold green]")
     console.print(f"  [blue]Location:[/blue] {beacon_yaml}")
-    if (beacon_dir.parent / "opencode.json").exists():
+    if result.opencode_created:
         console.print("[green]✓[/green] Initialized opencode.json")
-    if (beacon_dir.parent / "CLAUDE.md").exists():
+    if result.claude_created:
         console.print("[green]✓[/green] Initialized CLAUDE.md")
     console.print("\n[bold]Next Steps:[/bold]")
     console.print("  1. Run 'abc adopt' to select artifacts from the warehouse")

--- a/libs/beacon/src/beacon/cli/sync.py
+++ b/libs/beacon/src/beacon/cli/sync.py
@@ -246,39 +246,19 @@ def sync(
             console.print(note)
 
     if result.agent_config_init_needed:
-        if is_interactive():
+        init_opencode_json(result.project_root)
+        oc_init = wire_contexts_opencode(result.project_root, result.artifacts_dir)
+        if oc_init:
             console.print(
-                "\n[yellow]No agent config detected.[/yellow] "
-                "Set one up to wire contexts automatically."
+                f"[green]✓[/green] Created opencode.json and "
+                f"wired {len(oc_init)} context(s)"
             )
-            if click.confirm("  Initialize opencode.json?", default=False):
-                init_opencode_json(result.project_root)
-                oc_init = wire_contexts_opencode(
-                    result.project_root, result.artifacts_dir
-                )
-                if oc_init:
-                    console.print(
-                        f"[green]✓[/green] Created opencode.json and "
-                        f"wired {len(oc_init)} context(s)"
-                    )
-            if click.confirm("  Initialize CLAUDE.md?", default=False):
-                init_claude_md(result.project_root)
-                cc_init = wire_contexts_claudecode(
-                    result.project_root, result.artifacts_dir
-                )
-                if cc_init:
-                    console.print(
-                        f"[green]✓[/green] Created CLAUDE.md and "
-                        f"wired {len(cc_init)} context(s)"
-                    )
-        else:
+        init_claude_md(result.project_root)
+        cc_init = wire_contexts_claudecode(result.project_root, result.artifacts_dir)
+        if cc_init:
             console.print(
-                "\n[bold]Manual wiring required:[/bold]\n"
-                "  Contexts synced — wire them into your agent config:\n"
-                '  [bold]opencode.json[/bold] → add to "instructions" array:\n'
-                '    ".agentic-beacon/artifacts/contexts/<name>.md"\n'
-                "  [bold]CLAUDE.md[/bold] → add a line per context:\n"
-                "    @.agentic-beacon/artifacts/contexts/<name>.md"
+                f"[green]✓[/green] Created CLAUDE.md and "
+                f"wired {len(cc_init)} context(s)"
             )
 
     print_bundled_install_result(result.bundled_installed, result.bundled_skipped)

--- a/libs/beacon/src/beacon/cli/sync.py
+++ b/libs/beacon/src/beacon/cli/sync.py
@@ -245,7 +245,7 @@ def sync(
         for note in result.wiring_notes:
             console.print(note)
 
-    if result.agent_config_init_needed:
+    if result.agent_config_init_needed and not result.dry_run:
         init_opencode_json(result.project_root)
         oc_init = wire_contexts_opencode(result.project_root, result.artifacts_dir)
         if oc_init:

--- a/libs/beacon/src/beacon/domains/adoption/apply.py
+++ b/libs/beacon/src/beacon/domains/adoption/apply.py
@@ -293,6 +293,23 @@ def commit_session(
             # PER-113 (Finding 2): ensure root .gitignore has agent dir entries
             ensure_agent_dirs_gitignored(project_root)
 
+        # Wire bundled skills into the project's agent directories
+        from beacon.domains.artifact.skill import wire_bundled_skills_per_project
+
+        bundled_wired, bundled_errors = wire_bundled_skills_per_project(project_root)
+        if bundled_wired:
+            skill_names = ", ".join(
+                dict.fromkeys(s.split(" (")[0] for s in bundled_wired)
+            )
+            wiring_notes.append(
+                f"  Wired bundled skills: {skill_names}"
+                " → .opencode/command/, .claude/skills/"
+            )
+        for err in bundled_errors:
+            wiring_notes.append(
+                f"  [yellow]warning[/yellow] Bundled skill wiring: {err}"
+            )
+
     post_sync_wiring_fn = _post_sync_wiring_fn or _default_post_sync_wiring
 
     def _rollback() -> None:

--- a/libs/beacon/src/beacon/domains/setup/wiring.py
+++ b/libs/beacon/src/beacon/domains/setup/wiring.py
@@ -146,6 +146,17 @@ def wire_contexts_claudecode(project_root: Path, artifacts_dir: Path) -> list[st
     return added
 
 
+def setup_project(beacon_yaml: Path, project_root: Path) -> None:
+    """Bootstrap all project-level scaffolding in one call.
+
+    Creates beacon.yaml from the template and unconditionally initializes
+    opencode.json and CLAUDE.md (both are no-ops if the files already exist).
+    """
+    create_beacon_template(beacon_yaml)
+    init_opencode_json(project_root)
+    init_claude_md(project_root)
+
+
 def init_opencode_json(project_root: Path) -> None:
     """Create a minimal opencode.json if one does not already exist."""
     opencode_json = project_root / "opencode.json"

--- a/libs/beacon/src/beacon/domains/setup/wiring.py
+++ b/libs/beacon/src/beacon/domains/setup/wiring.py
@@ -4,6 +4,7 @@ import json
 import shutil
 from collections.abc import Callable, Iterable
 from pathlib import Path
+from typing import NamedTuple
 
 import click
 from loguru import logger
@@ -146,30 +147,49 @@ def wire_contexts_claudecode(project_root: Path, artifacts_dir: Path) -> list[st
     return added
 
 
-def setup_project(beacon_yaml: Path, project_root: Path) -> None:
+class SetupResult(NamedTuple):
+    """Outcome of setup_project — which files were newly created."""
+
+    opencode_created: bool
+    claude_created: bool
+
+
+def setup_project(beacon_yaml: Path, project_root: Path) -> SetupResult:
     """Bootstrap all project-level scaffolding in one call.
 
-    Creates beacon.yaml from the template and unconditionally initializes
+    Creates beacon.yaml from the template and conditionally initializes
     opencode.json and CLAUDE.md (both are no-ops if the files already exist).
+    Returns a SetupResult indicating which files were newly created.
     """
     create_beacon_template(beacon_yaml)
-    init_opencode_json(project_root)
-    init_claude_md(project_root)
+    opencode_created = init_opencode_json(project_root)
+    claude_created = init_claude_md(project_root)
+    return SetupResult(opencode_created=opencode_created, claude_created=claude_created)
 
 
-def init_opencode_json(project_root: Path) -> None:
-    """Create a minimal opencode.json if one does not already exist."""
+def init_opencode_json(project_root: Path) -> bool:
+    """Create a minimal opencode.json if one does not already exist.
+
+    Returns True when the file was newly created, False when it already existed.
+    """
     opencode_json = project_root / "opencode.json"
     if not opencode_json.exists():
         data = {"$schema": "https://opencode.ai/config.json", "instructions": []}
         opencode_json.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+        return True
+    return False
 
 
-def init_claude_md(project_root: Path) -> None:
-    """Create an empty CLAUDE.md at the project root if none exists."""
+def init_claude_md(project_root: Path) -> bool:
+    """Create an empty CLAUDE.md at the project root if none exists.
+
+    Returns True when the file was newly created, False when it already existed.
+    """
     claude_md = project_root / "CLAUDE.md"
     if not claude_md.exists():
         claude_md.write_text("", encoding="utf-8")
+        return True
+    return False
 
 
 def confirm_prune(orphans: list, *, dry_run: bool = False) -> list[str]:

--- a/libs/beacon/tests/integration/test_e2e_happy_path.py
+++ b/libs/beacon/tests/integration/test_e2e_happy_path.py
@@ -17,10 +17,13 @@ unit tests:
 
 import os
 import subprocess
+from datetime import UTC, datetime
 
 import pytest
 import yaml
 from beacon.cli.main import main
+from beacon.core.manifest.pending import PendingEntry, PendingManifest
+from beacon.domains.adoption.apply import commit_session
 from click.testing import CliRunner
 
 
@@ -542,3 +545,58 @@ def test_e2e_contribute_skill_identical_live_is_noop(e2e_project):
 
     assert result.exit_code == 0
     assert "no uncommitted changes to contribute" in result.output.lower()
+
+
+# ---------------------------------------------------------------------------
+# Bug 2 (PER-151): connect → setup → adopt wires bundled skills
+# ---------------------------------------------------------------------------
+
+
+def test_e2e_adopt_wires_bundled_skills(e2e_project, isolated_home):
+    """After connect → setup → adopt, bundled skills exist as slash commands.
+
+    Regression test for PER-151: abc adopt did not wire bundled skills because
+    _default_post_sync_wiring omitted the wire_bundled_skills_per_project call.
+    """
+    project_dir, warehouse, runner = e2e_project
+
+    # Step 1: Connect (fixture's monkeypatch.chdir ensures CWD = project_dir)
+    result = runner.invoke(main, ["warehouse", "connect", "--path", str(warehouse)])
+    assert result.exit_code == 0, result.output
+
+    # Step 2: Setup — creates beacon.yaml, opencode.json, CLAUDE.md
+    result = runner.invoke(main, ["setup"])
+    assert result.exit_code == 0, result.output
+    assert (project_dir / "opencode.json").exists()
+
+    # Step 3: Simulate adopt commit via commit_session (non-interactive CLI exits early)
+    ab = project_dir / ".agentic-beacon"
+    artifacts = ab / "artifacts"
+    artifacts.mkdir(exist_ok=True)
+    beacon_yaml = ab / "beacon.yaml"
+
+    entry = PendingEntry(
+        path="contexts/team.md",
+        type="context",
+        action="created",
+        source="record-knowledge",
+        created_at=datetime(2026, 5, 6, 12, 0, tzinfo=UTC),
+    )
+    PendingManifest(pending=[entry]).to_yaml(ab / "pending.yaml")
+
+    commit_session(
+        to_adopt=[],
+        to_unadopt=[],
+        pending_accept=["contexts/team.md"],
+        pending_reject=[],
+        candidates=[],
+        pending_entries=[entry],
+        project_root=project_dir,
+        warehouse_path=warehouse,
+        artifacts_path=artifacts,
+        beacon_yaml_path=beacon_yaml,
+    )
+
+    # Bundled skills must be wired as OpenCode slash commands (Bug 2 regression)
+    assert (project_dir / ".opencode" / "command" / "record-knowledge.md").exists()
+    assert (project_dir / ".opencode" / "command" / "record-skill.md").exists()

--- a/libs/beacon/tests/integration/test_sync_wiring.py
+++ b/libs/beacon/tests/integration/test_sync_wiring.py
@@ -849,6 +849,30 @@ def test_sync_no_agent_config_dry_run_does_not_wire(skills_only_project, monkeyp
     assert not (project / ".claude" / "skills").exists()
 
 
+def test_sync_dry_run_does_not_create_agent_config_files(
+    full_sync_project, monkeypatch
+):
+    """abc sync --dry-run must NOT create opencode.json or CLAUDE.md.
+
+    Defends against the implicit-gate breakage described in PER-151: even if the
+    orchestrator's agent_config_init_needed flag is unexpectedly True during
+    dry-run, the CLI layer must guard explicitly and write nothing to disk.
+    """
+    project, runner = full_sync_project
+    monkeypatch.chdir(project)
+    # No opencode.json, no CLAUDE.md — dry-run must not create either
+    assert not (project / "opencode.json").exists()
+    assert not (project / "CLAUDE.md").exists()
+
+    result = runner.invoke(main, ["sync", "--dry-run"])
+
+    assert result.exit_code == 0
+    assert not (project / "opencode.json").exists(), (
+        "dry-run must not create opencode.json"
+    )
+    assert not (project / "CLAUDE.md").exists(), "dry-run must not create CLAUDE.md"
+
+
 def test_sync_full_project_skills_and_agent_configs_wired_unconditionally(
     full_sync_project, monkeypatch
 ):

--- a/libs/beacon/tests/integration/test_sync_wiring.py
+++ b/libs/beacon/tests/integration/test_sync_wiring.py
@@ -480,52 +480,38 @@ def test_sync_wiring_is_idempotent(full_sync_project, monkeypatch):
     assert instructions.count(".agentic-beacon/artifacts/contexts/global.md") == 1
 
 
-def test_sync_prints_manual_instructions_when_no_agent_config_non_interactive(
-    full_sync_project, monkeypatch
-):
+def test_sync_auto_inits_agent_configs_when_missing(full_sync_project, monkeypatch):
+    """abc sync unconditionally creates opencode.json + CLAUDE.md and wires contexts."""
     project, runner = full_sync_project
     monkeypatch.chdir(project)
-    # No opencode.json, no CLAUDE.md; simulate non-interactive (CI) environment
+    # No opencode.json, no CLAUDE.md — sync should auto-init both
 
-    with patch("beacon.cli.sync.is_interactive", return_value=False):
-        result = runner.invoke(main, ["sync"])
-
-    assert result.exit_code == 0
-    assert "manual" in result.output.lower() or "wire" in result.output.lower()
-
-
-def test_sync_interactive_init_opencode_json(full_sync_project, monkeypatch):
-    project, runner = full_sync_project
-    monkeypatch.chdir(project)
-    # No opencode.json, no CLAUDE.md; user answers yes/no to prompts
-
-    with patch("beacon.cli.sync.is_interactive", return_value=True):
-        # "y" for opencode.json prompt, "n" for CLAUDE.md prompt
-        result = runner.invoke(main, ["sync"], input="y\nn\n")
+    result = runner.invoke(main, ["sync"])
 
     assert result.exit_code == 0
     assert (project / "opencode.json").exists()
+    assert (project / "CLAUDE.md").exists()
     data = json.loads((project / "opencode.json").read_text())
     assert ".agentic-beacon/artifacts/contexts/global.md" in data["instructions"]
-    assert not (project / "CLAUDE.md").exists()
-
-
-def test_sync_interactive_init_claude_md(full_sync_project, monkeypatch):
-    project, runner = full_sync_project
-    monkeypatch.chdir(project)
-    # No opencode.json, no CLAUDE.md; user answers no/yes to prompts
-
-    with patch("beacon.cli.sync.is_interactive", return_value=True):
-        # "n" for opencode.json (contexts), "y" for CLAUDE.md (contexts),
-        # "n" for opencode.json (skills), "n" for CLAUDE.md (skills)
-        # (CLAUDE.md alone doesn't create .claude/ so skill prompt also fires)
-        result = runner.invoke(main, ["sync"], input="n\ny\nn\nn\n")
-
-    assert result.exit_code == 0
-    assert not (project / "opencode.json").exists()
-    assert (project / "CLAUDE.md").exists()
     content = (project / "CLAUDE.md").read_text()
     assert "@.agentic-beacon/artifacts/contexts/global.md" in content
+
+
+def test_sync_initializes_missing_agent_config_files(
+    full_sync_project, monkeypatch, isolated_home
+):
+    """Backward-compat: projects set up before Bug 1 fix still get opencode.json + CLAUDE.md on sync."""
+    project, runner = full_sync_project
+    monkeypatch.chdir(project)
+    # Simulate a project where abc setup was run BEFORE the fix (no opencode.json, no CLAUDE.md)
+    assert not (project / "opencode.json").exists()
+    assert not (project / "CLAUDE.md").exists()
+
+    result = runner.invoke(main, ["sync"])
+
+    assert result.exit_code == 0
+    assert (project / "opencode.json").exists()
+    assert (project / "CLAUDE.md").exists()
 
 
 def test_sync_does_not_report_installed_skills_on_second_run(
@@ -863,23 +849,26 @@ def test_sync_no_agent_config_dry_run_does_not_wire(skills_only_project, monkeyp
     assert not (project / ".claude" / "skills").exists()
 
 
-def test_sync_full_project_skills_wired_even_when_contexts_need_agent_config(
+def test_sync_full_project_skills_and_agent_configs_wired_unconditionally(
     full_sync_project, monkeypatch
 ):
-    """When no agent config exists, skills wire unconditionally while contexts still prompt."""
+    """abc sync wires skills AND auto-inits opencode.json + CLAUDE.md unconditionally."""
     project, runner = full_sync_project
     monkeypatch.chdir(project)
+    # No opencode.json, no CLAUDE.md — sync should auto-init both and wire skills
 
-    with patch("beacon.cli.sync.is_interactive", return_value=False):
-        result = runner.invoke(main, ["sync"])
+    result = runner.invoke(main, ["sync"])
 
     assert result.exit_code == 0
     # Skills wired to both agents
     assert (project / ".opencode" / "skills" / "my-skill" / "SKILL.md").exists()
     assert (project / ".claude" / "skills" / "my-skill" / "SKILL.md").exists()
     assert "installed" in result.output.lower()
-    # Contexts still need manual wiring (no opencode.json / CLAUDE.md)
-    assert "manual wiring required" in result.output.lower()
+    # Agent configs auto-initialized and contexts wired (Bug 1 fix)
+    assert (project / "opencode.json").exists()
+    assert (project / "CLAUDE.md").exists()
+    assert "created opencode.json" in result.output.lower()
+    assert "created claude.md" in result.output.lower()
 
 
 def test_sync_no_agent_config_second_run_idempotent(skills_only_project, monkeypatch):

--- a/libs/beacon/tests/unit/domains/adoption/test_apply_commit.py
+++ b/libs/beacon/tests/unit/domains/adoption/test_apply_commit.py
@@ -344,3 +344,115 @@ def test_sync_failure_triggers_rollback(tmp_path):
 
     assert beacon_yaml.read_bytes() == pre_beacon
     assert pending_yaml.read_bytes() == pre_pending
+
+
+# ─────────────────────────────────────────────────────────────
+# Bug 2 (PER-151): bundled skill wiring in _default_post_sync_wiring
+# ─────────────────────────────────────────────────────────────
+
+
+def test_adopt_commit_wires_bundled_skills(tmp_path, monkeypatch):
+    """commit_session calls wire_bundled_skills_per_project for the project root."""
+    wh = _make_warehouse(tmp_path)
+    (wh / "contexts" / "foo.md").write_text("# Foo\n")
+    _git_commit(wh, "add foo")
+
+    project, beacon_yaml, artifacts, ab = _make_project(tmp_path)
+    pending_entries = [_pending_entry("contexts/foo.md", "context")]
+    _write_pending(project, pending_entries)
+
+    called_with: list[Path] = []
+
+    def _fake_wire(project_root: Path, agents=None):
+        called_with.append(project_root)
+        return (["record-knowledge (opencode)", "record-skill (opencode)"], [])
+
+    monkeypatch.setattr(
+        "beacon.domains.artifact.skill.wire_bundled_skills_per_project",
+        _fake_wire,
+    )
+
+    commit_session(
+        to_adopt=[],
+        to_unadopt=[],
+        pending_accept=["contexts/foo.md"],
+        pending_reject=[],
+        candidates=[],
+        pending_entries=pending_entries,
+        project_root=project,
+        warehouse_path=wh,
+        artifacts_path=artifacts,
+        beacon_yaml_path=beacon_yaml,
+        _symlink_sync_fn=_noop_sync,
+    )
+
+    assert called_with == [project]
+
+
+def test_adopt_commit_emits_bundled_skill_summary(tmp_path, monkeypatch):
+    """wiring_notes contains the bundled-skill summary when skills were wired."""
+    wh = _make_warehouse(tmp_path)
+    (wh / "contexts" / "bar.md").write_text("# Bar\n")
+    _git_commit(wh, "add bar")
+
+    project, beacon_yaml, artifacts, ab = _make_project(tmp_path)
+    pending_entries = [_pending_entry("contexts/bar.md", "context")]
+    _write_pending(project, pending_entries)
+
+    monkeypatch.setattr(
+        "beacon.domains.artifact.skill.wire_bundled_skills_per_project",
+        lambda *a, **kw: (
+            ["record-knowledge (opencode)", "record-skill (opencode)"],
+            [],
+        ),
+    )
+
+    wiring_notes = commit_session(
+        to_adopt=[],
+        to_unadopt=[],
+        pending_accept=["contexts/bar.md"],
+        pending_reject=[],
+        candidates=[],
+        pending_entries=pending_entries,
+        project_root=project,
+        warehouse_path=wh,
+        artifacts_path=artifacts,
+        beacon_yaml_path=beacon_yaml,
+        _symlink_sync_fn=_noop_sync,
+    )
+
+    assert any("record-knowledge" in note for note in wiring_notes)
+    assert any("record-skill" in note for note in wiring_notes)
+
+
+def test_adopt_commit_no_bundled_skills_no_summary_noise(tmp_path, monkeypatch):
+    """No summary line emitted when bundled-wire returns empty wired + empty errors."""
+    wh = _make_warehouse(tmp_path)
+    (wh / "contexts" / "baz.md").write_text("# Baz\n")
+    _git_commit(wh, "add baz")
+
+    project, beacon_yaml, artifacts, ab = _make_project(tmp_path)
+    pending_entries = [_pending_entry("contexts/baz.md", "context")]
+    _write_pending(project, pending_entries)
+
+    monkeypatch.setattr(
+        "beacon.domains.artifact.skill.wire_bundled_skills_per_project",
+        lambda *a, **kw: ([], []),
+    )
+
+    wiring_notes = commit_session(
+        to_adopt=[],
+        to_unadopt=[],
+        pending_accept=["contexts/baz.md"],
+        pending_reject=[],
+        candidates=[],
+        pending_entries=pending_entries,
+        project_root=project,
+        warehouse_path=wh,
+        artifacts_path=artifacts,
+        beacon_yaml_path=beacon_yaml,
+        _symlink_sync_fn=_noop_sync,
+    )
+
+    bundled_notes = [n for n in wiring_notes if "bundled" in n.lower()]
+    assert bundled_notes == []

--- a/libs/beacon/tests/unit/domains/setup/test_setup_opencode_init.py
+++ b/libs/beacon/tests/unit/domains/setup/test_setup_opencode_init.py
@@ -63,3 +63,22 @@ def test_setup_idempotent_does_not_overwrite_existing_files(tmp_path, monkeypatc
     assert result.exit_code == 0, result.output
     assert (project / "opencode.json").read_text() == custom_opencode
     assert (project / "CLAUDE.md").read_text() == custom_claude
+
+
+def test_setup_does_not_claim_initialization_when_files_preexisted(
+    tmp_path, monkeypatch
+):
+    """abc setup must not print 'Initialized' for files that already existed."""
+    project, runner = _connected_project(tmp_path, monkeypatch)
+
+    (project / "opencode.json").write_text('{"custom": true}\n')
+    (project / "CLAUDE.md").write_text("# Mine\n")
+
+    result = runner.invoke(main, ["setup"], catch_exceptions=False)
+
+    assert result.exit_code == 0, result.output
+    assert "Initialized opencode.json" not in result.output
+    assert "Initialized CLAUDE.md" not in result.output
+    # Files must remain unchanged
+    assert (project / "opencode.json").read_text() == '{"custom": true}\n'
+    assert (project / "CLAUDE.md").read_text() == "# Mine\n"

--- a/libs/beacon/tests/unit/domains/setup/test_setup_opencode_init.py
+++ b/libs/beacon/tests/unit/domains/setup/test_setup_opencode_init.py
@@ -1,0 +1,65 @@
+"""Unit tests for auto-init of opencode.json + CLAUDE.md during abc setup (PER-151).
+
+Tests 1-2 cover the setup CLI handler invoking init_opencode_json + init_claude_md.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from beacon.cli.main import main
+from click.testing import CliRunner
+
+
+def _connected_project(tmp_path: Path, monkeypatch) -> tuple[Path, CliRunner]:
+    """Create a project connected to a minimal warehouse stub with CWD set."""
+    project = tmp_path / "project"
+    project.mkdir()
+    warehouse = tmp_path / "warehouse"
+    warehouse.mkdir()
+    (warehouse / "contexts").mkdir()
+    (warehouse / "skills").mkdir()
+    (warehouse / "README.md").write_text("# Warehouse\n")
+
+    ab = project / ".agentic-beacon"
+    ab.mkdir()
+    (ab / "config.toml").write_text(f'[warehouse]\nlocal_path = "{warehouse}"\n')
+
+    monkeypatch.chdir(project)
+    runner = CliRunner()
+    return project, runner
+
+
+def test_setup_creates_opencode_json_and_claude_md(tmp_path, monkeypatch):
+    """abc setup creates opencode.json and CLAUDE.md at project root."""
+    project, runner = _connected_project(tmp_path, monkeypatch)
+
+    result = runner.invoke(main, ["setup"], catch_exceptions=False)
+
+    assert result.exit_code == 0, result.output
+    assert (project / "opencode.json").exists()
+    assert (project / "CLAUDE.md").exists()
+
+    data = json.loads((project / "opencode.json").read_text())
+    assert "$schema" in data
+    assert "instructions" in data
+
+
+def test_setup_idempotent_does_not_overwrite_existing_files(tmp_path, monkeypatch):
+    """abc setup does not overwrite existing opencode.json or CLAUDE.md."""
+    project, runner = _connected_project(tmp_path, monkeypatch)
+
+    custom_opencode = (
+        '{"$schema": "https://opencode.ai/config.json", "instructions": ["custom"]}\n'
+    )
+    custom_claude = "# My Custom CLAUDE.md\nDo not overwrite me.\n"
+    (project / "opencode.json").write_text(custom_opencode)
+    (project / "CLAUDE.md").write_text(custom_claude)
+
+    # Run setup (beacon.yaml doesn't exist yet, so it will create it)
+    result = runner.invoke(main, ["setup"], catch_exceptions=False)
+
+    assert result.exit_code == 0, result.output
+    assert (project / "opencode.json").read_text() == custom_opencode
+    assert (project / "CLAUDE.md").read_text() == custom_claude


### PR DESCRIPTION
## Summary

Two demo bugs share a single root cause: `abc adopt`'s post-commit wiring (`_default_post_sync_wiring` in `domains/adoption/apply.py`) is a strict subset of `abc sync`'s wiring pipeline. Adopt wired contexts/declared-skills/agents but didn't (a) initialize `opencode.json` / `CLAUDE.md`, or (b) wire bundled skills as opencode slash commands. Users running `connect -> setup -> adopt` ended up with a half-wired project.

This PR closes the gap from both directions:

- **`abc setup` now auto-initializes** `opencode.json` (with minimal `$schema` + empty `instructions` array) and `CLAUDE.md` (empty file) at the project root. Both are idempotent — existing user-edited files are not overwritten.
- **`abc sync` init is now unconditional** (no more `click.confirm` prompts). Existing projects that ran `abc setup` before this PR will get the scaffolds on their next sync. The interactive prompt branch and the non-interactive "Manual wiring required" fallback are removed (dead code).
- **`abc adopt` now wires bundled skills** by calling `wire_bundled_skills_per_project` at the end of `_default_post_sync_wiring`. A summary line is appended to `wiring_notes` listing the wired skills (dedup'd across opencode/claudecode), surfacing through the existing CLI rendering.

Closes [PER-151](https://linear.app/shadowsong-personal/issue/PER-151).

## What changed

- `libs/beacon/src/beacon/cli/setup.py` — delegates to a single domain call `setup_project()`; emits status lines for created files.
- `libs/beacon/src/beacon/cli/sync.py` — removed interactive prompts + manual-wiring fallback; `init_opencode_json` and `init_claude_md` now called unconditionally when `agent_config_init_needed` is True.
- `libs/beacon/src/beacon/domains/adoption/apply.py` — `_default_post_sync_wiring` now calls `wire_bundled_skills_per_project` and appends a summary line to `wiring_notes`.
- `libs/beacon/src/beacon/domains/setup/wiring.py` — new `setup_project()` wrapper that bundles `create_beacon_template` + `init_opencode_json` + `init_claude_md` into one call (preserves CLI thin-handler rule).

## Tests

- `libs/beacon/tests/unit/domains/setup/test_setup_opencode_init.py` (new) — covers Bug 1 happy path and idempotency.
- `libs/beacon/tests/unit/domains/adoption/test_apply_commit.py` — adds 3 Bug 2 cases: bundled wiring is invoked, summary is emitted, silence when nothing to wire.
- `libs/beacon/tests/integration/test_e2e_happy_path.py` — adds `test_e2e_adopt_wires_bundled_skills` (full `connect -> setup -> adopt` flow — regression for the original demo symptom).
- `libs/beacon/tests/integration/test_sync_wiring.py` — 3 obsolete interactive-prompt tests removed; 2 new tests added covering the unconditional init paths.

## Test plan

- [x] Unit tests: `pytest libs/beacon/tests/unit/domains/setup/test_setup_opencode_init.py libs/beacon/tests/unit/domains/adoption/test_apply_commit.py` — passing.
- [x] Integration tests: `pytest libs/beacon/tests/integration/test_e2e_happy_path.py libs/beacon/tests/integration/test_sync_wiring.py` — passing.
- [x] Manual e2e: `abc warehouse init` + `connect` + `setup` in clean tmp dir → `opencode.json` (valid `{$schema, instructions: []}`) and `CLAUDE.md` exist at project root.
- [x] Coverage: `cli/setup.py` 100%, `apply.py` 89%, `cli/sync.py` 75% — aggregate 85%.
- [ ] CI green
- [ ] opencode-review bot clean

## Out of scope

- Bug 3 (`pending.yaml` script imports) — fixed by [PER-150](https://github.com/Shadowsong27/agentic-beacon/pull/136) (merged).
- Concept docs pages for bundled skills + `pending.yaml` — tracked in [PER-152](https://linear.app/shadowsong-personal/issue/PER-152).