### PR TITLE
docs: Concepts pages for bundled skills + pending.yaml (PER-152)

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -79,6 +79,8 @@ nav:
   - Quick Start: quickstart.md
   - Concepts:
     - How It Works: concepts/how-it-works.md
+    - Bundled Skills: concepts/bundled-skills.md
+    - Pending & Adoption: concepts/pending-and-adoption.md
     - Artifact Types: concepts/artifact-types.md
   - Guides:
     - Creating a Warehouse: guides/warehouse-creation.md

--- a/site-docs/concepts/bundled-skills.md
+++ b/site-docs/concepts/bundled-skills.md
@@ -1,0 +1,148 @@
+# Bundled Skills
+
+> This page covers skills shipped inside `abc` itself. For user-authored warehouse skills, see [Creating Skills](../guides/creating-skills.md).
+
+Agentic Beacon ships two skills inside the `abc` package. These **bundled skills** are available in every project the moment you run `abc adopt` — no warehouse content required. Their purpose is to bootstrap content authoring: on a fresh project, before your warehouse has any skills, you can still invoke `/record-knowledge` and `/record-skill` to start building it.
+
+---
+
+## The Two Bundled Skills
+
+### `record-knowledge`
+
+Captures a decision, lesson, or fact into the warehouse's `knowledge/` directory and appends a `pending.yaml` entry in your project.
+
+**What it does:**
+
+1. Agent prompts you for a topic, title, and content summary
+2. Writes a markdown file to `<warehouse>/knowledge/<topic>/<slug>.md`
+3. Calls `scripts/append_pending.py` to append a `context` entry to `.agentic-beacon/pending.yaml`
+4. You run `abc adopt` to wire the knowledge file into your project
+
+**When to invoke:** after a notable decision, a hard-won lesson, or a fact worth sharing across teams.
+
+---
+
+### `record-skill`
+
+Scaffolds a new skill in the warehouse's `skills/<name>/` directory and appends a `pending.yaml` entry.
+
+**What it does:**
+
+1. Agent prompts you for a skill name, description, and initial process steps
+2. Writes `<warehouse>/skills/<name>/SKILL.md` with the correct frontmatter
+3. Calls `scripts/append_pending.py` to append a `skill` entry to `.agentic-beacon/pending.yaml`
+4. You run `abc adopt` to wire the new skill into your project
+
+**When to invoke:** when you want to formalize a repeatable agent workflow and share it via the warehouse.
+
+---
+
+## Where Skills Are Wired
+
+After `abc adopt` (or `abc sync`) runs, each bundled skill appears in three locations in your project:
+
+```
+my-project/
+├── .claude/
+│   ├── commands/record-knowledge.md   # Claude Code slash-command stub
+│   └── skills/record-knowledge/
+│       └── SKILL.md
+└── .opencode/
+    ├── command/record-knowledge.md    # OpenCode slash-command stub
+    └── skills/record-knowledge/
+        └── SKILL.md
+```
+
+Both tools discover skills identically — a file at `skills/<name>/SKILL.md` under their config directory. You do not need separate configuration for each tool.
+
+---
+
+## When Wiring Happens
+
+Two commands wire bundled skills:
+
+- **`abc sync`** — wires bundled skills as part of its normal artifact-sync flow.
+- **`abc adopt`** — also wires bundled skills after its commit step (added in PER-151). This means the standard first-run sequence `connect → setup → adopt` leaves bundled skills fully available without a separate `abc sync`.
+
+```bash
+abc warehouse connect --path ~/my-org-warehouse
+abc setup          # auto-creates CLAUDE.md and opencode.json if missing
+abc adopt          # select warehouse artifacts; bundled skills wired here too
+# → "Wired bundled skills: record-knowledge, record-skill"
+```
+
+---
+
+## How Bundled Skills Differ from Warehouse Skills
+
+| | Bundled skills | Warehouse skills |
+|---|---|---|
+| **Source** | Shipped inside the `abc` package | Authored in `<warehouse>/skills/` |
+| **Versioning** | Locked to the `abc` CLI release | Evolves with your warehouse git history |
+| **Declared in `beacon.yaml`?** | No — always available | Yes — must be explicitly adopted |
+| **Editable by your team?** | No | Yes |
+| **How discovered by agents** | Same: `skills/<name>/SKILL.md` in tool directories | Same |
+
+Warehouse skills are distributed to teammates via `abc sync`. Bundled skills follow the developer — wherever `abc` is installed, those two skills are available.
+
+---
+
+## Self-Contained Scripts (PER-150)
+
+The `scripts/append_pending.py` script inside each bundled skill has **no dependency on the `beacon` package**. It declares `pyyaml>=6.0` in a PEP 723 inline header and inlines all the YAML read-merge-write logic it needs.
+
+This means the `record-* → pending.yaml → abc adopt` loop works for any `abc` installation — pipx, pip, or uv tool install. You do not need to be working inside the agentic-beacon source checkout.
+
+---
+
+## Full Walkthrough: `record-skill`
+
+This walkthrough assumes you have already run `abc warehouse connect`, `abc setup`, and `abc adopt` at least once.
+
+```bash
+# 1. In your project, invoke the bundled skill
+#    (inside a Claude Code or OpenCode session)
+/record-skill
+
+# Agent prompts you:
+#   Skill name?      → python-type-hints
+#   Description?     → Enforce Python type annotation standards in new code.
+#   Initial steps?   → (you describe the workflow)
+
+# Agent writes the warehouse file:
+#   <warehouse>/skills/python-type-hints/SKILL.md
+
+# Agent appends to project:
+#   .agentic-beacon/pending.yaml
+
+# 2. Back in your shell — notice the pending alert:
+abc warehouse status
+# → "[yellow]Pending:[/yellow] 1 unadopted artifact (run 'abc adopt')"
+
+# 3. Review and accept the pending entry
+abc adopt
+# TUI opens, shows "python-type-hints" as a pending skill entry
+# Press Space to select, Enter to confirm
+# → Confirm screen shows: "+ skills/python-type-hints/ → beacon.yaml"
+# → Press Enter to commit
+
+# 4. The skill is now wired:
+#   .agentic-beacon/beacon.yaml updated
+#   .claude/skills/python-type-hints/SKILL.md   (symlink)
+#   .opencode/skills/python-type-hints/SKILL.md (symlink)
+#   .agentic-beacon/pending.yaml cleared
+
+# 5. Invoke the new skill immediately:
+/python-type-hints
+```
+
+For the storage model behind step 2 and 3 (`pending.yaml` lifecycle, confirm screen, atomic rollback), see [Pending & Adoption](pending-and-adoption.md).
+
+---
+
+## Next Steps
+
+- **[Pending & Adoption](pending-and-adoption.md)** — the full `pending.yaml` lifecycle
+- **[Creating Skills](../guides/creating-skills.md)** — authoring warehouse skills manually
+- **[Interactive Adoption](../guides/interactive-adoption.md)** — the `abc adopt` TUI in depth

--- a/site-docs/concepts/bundled-skills.md
+++ b/site-docs/concepts/bundled-skills.md
@@ -16,7 +16,7 @@ Captures a decision, lesson, or fact into the warehouse's `knowledge/` directory
 
 1. Agent prompts you for a topic, title, and content summary
 2. Writes a markdown file to `<warehouse>/knowledge/<topic>/<type>s/<slug>.md` (with `--topic`), or `<warehouse>/knowledge/<type>s/<slug>.md` (without topic), where `<type>` is `decision`, `lesson`, or `fact`
-3. Knowledge files are auto-derived during `abc sync` / `abc adopt` — no `pending.yaml` entry is created and no explicit accept step is required
+3. No `pending.yaml` entry is created — but knowledge files are **not** synced automatically. They appear under `.agentic-beacon/artifacts/knowledge/` only when a context or skill already wired into your project (via `beacon.yaml`) links to the new knowledge file's path. If no such link exists yet, adopt or hand-edit a context that references the path first.
 
 **When to invoke:** after a notable decision, a hard-won lesson, or a fact worth sharing across teams.
 

--- a/site-docs/concepts/bundled-skills.md
+++ b/site-docs/concepts/bundled-skills.md
@@ -39,12 +39,11 @@ Scaffolds a new skill in the warehouse's `skills/<name>/` directory and appends 
 
 ## Where Skills Are Wired
 
-After `abc adopt` (or `abc sync`) runs, each bundled skill appears in three locations in your project:
+After `abc adopt` (or `abc sync`) runs, each bundled skill appears in these locations in your project:
 
 ```
 my-project/
 ├── .claude/
-│   ├── commands/record-knowledge.md   # Claude Code slash-command stub
 │   └── skills/record-knowledge/
 │       └── SKILL.md
 └── .opencode/
@@ -53,7 +52,11 @@ my-project/
         └── SKILL.md
 ```
 
-Both tools discover skills identically — a file at `skills/<name>/SKILL.md` under their config directory. You do not need separate configuration for each tool.
+- `.opencode/command/<skill>.md` — OpenCode slash-command stub
+- `.opencode/skills/<skill>/SKILL.md` — OpenCode skill copy
+- `.claude/skills/<skill>/SKILL.md` — Claude Code skill copy
+
+Claude Code discovers skills directly from `.claude/skills/` — there's no equivalent of the `.opencode/command/` stub file.
 
 ---
 

--- a/site-docs/concepts/bundled-skills.md
+++ b/site-docs/concepts/bundled-skills.md
@@ -65,7 +65,7 @@ Claude Code discovers skills directly from `.claude/skills/` — there's no equi
 Two commands wire bundled skills:
 
 - **`abc sync`** — wires bundled skills as part of its normal artifact-sync flow.
-- **`abc adopt`** — also wires bundled skills after its commit step (added in PER-151). This means the standard first-run sequence `connect → setup → adopt` leaves bundled skills fully available without a separate `abc sync`.
+- **`abc adopt`** — also wires bundled skills after its commit step (added in PER-151). This means the standard first-run sequence `connect → setup → adopt` leaves bundled skills fully available without a separate `abc sync`. Note: `abc adopt` only triggers bundled wiring when at least one entry is committed in the TUI. If you open `abc adopt` and exit without any accept/reject changes, the commit doesn't fire and bundled skills won't be wired — run `abc sync` instead in that case.
 
 ```bash
 abc warehouse connect --path ~/my-org-warehouse

--- a/site-docs/concepts/bundled-skills.md
+++ b/site-docs/concepts/bundled-skills.md
@@ -2,7 +2,7 @@
 
 > This page covers skills shipped inside `abc` itself. For user-authored warehouse skills, see [Creating Skills](../guides/creating-skills.md).
 
-Agentic Beacon ships two skills inside the `abc` package. These **bundled skills** are available in every project the moment you run `abc adopt` — no warehouse content required. Their purpose is to bootstrap content authoring: on a fresh project, before your warehouse has any skills, you can still invoke `/record-knowledge` and `/record-skill` to start building it.
+Agentic Beacon ships two skills inside the `abc` package. These **bundled skills** become available in a project after `abc sync` runs (always wires them), or after `abc adopt` (only when an adoption commit fires — see [When Wiring Happens](#when-wiring-happens) below) — no warehouse content required. Their purpose is to bootstrap content authoring: on a fresh project, before your warehouse has any skills, you can still invoke `/record-knowledge` and `/record-skill` to start building it.
 
 ---
 
@@ -143,7 +143,7 @@ This walkthrough assumes you have already run `abc warehouse connect`, `abc setu
 
 # 2. Back in your shell — notice the pending alert:
 abc warehouse status
-# → "[yellow]Pending:[/yellow] 1 unadopted artifact (run 'abc adopt')"
+# → "⚠ 1 pending artifacts. Run 'abc adopt' to wire them."
 
 # 3. Review and accept the pending entry
 abc adopt

--- a/site-docs/concepts/bundled-skills.md
+++ b/site-docs/concepts/bundled-skills.md
@@ -15,7 +15,7 @@ Captures a decision, lesson, or fact into the warehouse's `knowledge/` directory
 **What it does:**
 
 1. Agent prompts you for a topic, title, and content summary
-2. Writes a markdown file to `<warehouse>/knowledge/<topic>/<slug>.md`
+2. Writes a markdown file to `<warehouse>/knowledge/<topic>/<type>s/<slug>.md` (with `--topic`), or `<warehouse>/knowledge/<type>s/<slug>.md` (without topic), where `<type>` is `decision`, `lesson`, or `fact`
 3. Knowledge files are auto-derived during `abc sync` / `abc adopt` — no `pending.yaml` entry is created and no explicit accept step is required
 
 **When to invoke:** after a notable decision, a hard-won lesson, or a fact worth sharing across teams.
@@ -65,7 +65,7 @@ Claude Code discovers skills directly from `.claude/skills/` — there's no equi
 Two commands wire bundled skills:
 
 - **`abc sync`** — wires bundled skills as part of its normal artifact-sync flow.
-- **`abc adopt`** — also wires bundled skills after its commit step (added in PER-151). This means the standard first-run sequence `connect → setup → adopt` leaves bundled skills fully available without a separate `abc sync`. Note: `abc adopt` only triggers bundled wiring when at least one entry is committed in the TUI. If you open `abc adopt` and exit without any accept/reject changes, the commit doesn't fire and bundled skills won't be wired — run `abc sync` instead in that case.
+- **`abc adopt`** — also wires bundled skills after its commit step (added in PER-151). This means the standard first-run sequence `connect → setup → adopt` leaves bundled skills fully available without a separate `abc sync`. Note: `abc adopt` only triggers bundled wiring when at least one entry is accepted in the TUI (reject-only or defer-only commits do not fire post-sync wiring). If you open `abc adopt` and exit without accepting anything, run `abc sync` to wire bundled skills.
 
 ```bash
 abc warehouse connect --path ~/my-org-warehouse

--- a/site-docs/concepts/bundled-skills.md
+++ b/site-docs/concepts/bundled-skills.md
@@ -10,14 +10,13 @@ Agentic Beacon ships two skills inside the `abc` package. These **bundled skills
 
 ### `record-knowledge`
 
-Captures a decision, lesson, or fact into the warehouse's `knowledge/` directory and appends a `pending.yaml` entry in your project.
+Captures a decision, lesson, or fact into the warehouse's `knowledge/` directory.
 
 **What it does:**
 
 1. Agent prompts you for a topic, title, and content summary
 2. Writes a markdown file to `<warehouse>/knowledge/<topic>/<slug>.md`
-3. Calls `scripts/append_pending.py` to append a `context` entry to `.agentic-beacon/pending.yaml`
-4. You run `abc adopt` to wire the knowledge file into your project
+3. Knowledge files are auto-derived during `abc sync` / `abc adopt` — no `pending.yaml` entry is created and no explicit accept step is required
 
 **When to invoke:** after a notable decision, a hard-won lesson, or a fact worth sharing across teams.
 
@@ -85,6 +84,29 @@ abc adopt          # select warehouse artifacts; bundled skills wired here too
 | **How discovered by agents** | Same: `skills/<name>/SKILL.md` in tool directories | Same |
 
 Warehouse skills are distributed to teammates via `abc sync`. Bundled skills follow the developer — wherever `abc` is installed, those two skills are available.
+
+> **Note:** `abc warehouse init` copies each bundled skill into the new warehouse's `skills/` directory as a starting-point template. This means a freshly initialised warehouse will contain `skills/record-knowledge/` and `skills/record-skill/` entries that look like ordinary warehouse skills — but the canonical version used for project wiring is always the one inside the `abc` package. See [Bundled Skills in the Warehouse Template](#bundled-skills-in-the-warehouse-template) below.
+
+---
+
+## Bundled Skills in the Warehouse Template
+
+When you run `abc warehouse init`, the initializer copies each bundled skill from the `abc` package into the new warehouse's `skills/` directory (via `_install_bundled_skills`). This produces real files — not symlinks — at paths like:
+
+```
+my-warehouse/
+└── skills/
+    ├── record-knowledge/
+    │   └── SKILL.md
+    └── record-skill/
+        └── SKILL.md
+```
+
+These copies exist so teams have a visible, editable starting point. You can modify `<warehouse>/skills/record-knowledge/SKILL.md` to adjust the workflow for your organisation and commit that change into the warehouse.
+
+However, **the copies are not automatically used for project wiring**. When `abc sync` or `abc adopt` wires bundled skills into a project, it always reads from the `abc` package source — the warehouse copy is informational unless you explicitly adopt it as a regular warehouse skill via `beacon.yaml`. There is currently no automatic override mechanism that promotes a customised warehouse copy back into the wiring pipeline.
+
+In practice this means: a fresh warehouse visually contains bundled skills alongside other warehouse content, but teams that want to distribute a customised variant should treat it as a new warehouse skill (with a different name) rather than expecting the warehouse copy to shadow the bundled version.
 
 ---
 

--- a/site-docs/concepts/how-it-works.md
+++ b/site-docs/concepts/how-it-works.md
@@ -66,7 +66,7 @@ artifacts:
 
 `config.toml` stores the local path to the warehouse (e.g. `~/my-org-warehouse`). It is gitignored because warehouse paths vary per machine.
 
-`pending.yaml` records project-wired artifacts (contexts, skills, agents) written to the warehouse by authoring skills that have not yet been wired into `beacon.yaml`. Knowledge files are auto-derived during sync/adopt and are not tracked here. It is absent or `pending: []` when nothing is pending. Use `abc adopt` to accept, reject, or defer each entry. The file is gitignored — it represents per-developer working state.
+`pending.yaml` records project-wired artifacts (contexts, skills, agents) written to the warehouse by authoring skills that have not yet been wired into `beacon.yaml`. Knowledge files are auto-derived during sync/adopt and are not tracked here. It is absent or `pending: []` when nothing is pending. Use `abc adopt` to accept, reject, or defer each entry. The file is gitignored — it represents per-developer working state. See [Pending & Adoption](pending-and-adoption.md) for the full lifecycle.
 
 `.last-adopt` is a single-line ISO-8601 UTC timestamp recording when `abc adopt` last committed successfully. It enables `abc adopt` to detect hand-edited warehouse files (files modified after `.last-adopt` but not tracked in `pending.yaml`). The file is gitignored.
 

--- a/site-docs/concepts/pending-and-adoption.md
+++ b/site-docs/concepts/pending-and-adoption.md
@@ -33,7 +33,7 @@ pending:
 | `source` | skill name | Which bundled skill wrote the entry |
 | `created_at` | `YYYY-MM-DDTHH:MM:SSZ` (UTC) | When the entry was appended |
 
-Knowledge files are **not** tracked in `pending.yaml`. They are auto-derived during sync/adopt by scanning context and skill markdown for links into `knowledge/`.
+Knowledge files are **not** tracked in `pending.yaml`. The knowledge resolver scans contexts and skills that are already wired into your project for markdown links into `knowledge/`; only reachable files are synced.
 
 ---
 
@@ -55,7 +55,9 @@ Knowledge files are **not** tracked in `pending.yaml`. They are auto-derived dur
 
 The script walks up the directory tree from the calling agent's working directory to find the project root (the nearest ancestor containing `.agentic-beacon/config.toml`), then appends a `PendingEntry` to `pending.yaml` after validating field types and enum values. Duplicate entries are not detected — if the same artifact path is recorded twice, both entries will land in the file.
 
-**Knowledge files are a special case.** `record-knowledge` writes to `<warehouse>/knowledge/` but does **not** append to `pending.yaml`. Knowledge files are auto-derived during `abc sync` / `abc adopt` — they appear in your project's `.agentic-beacon/artifacts/knowledge/` as symlinks the next time you sync, with no explicit accept step required.
+**Knowledge files are a special case.** `record-knowledge` writes to `<warehouse>/knowledge/` but does **not** append to `pending.yaml`. Knowledge files are also **not** synced automatically. The knowledge resolver scans contexts and skills that are already wired into your project (via `beacon.yaml`) and follows their markdown links into `<warehouse>/knowledge/`. Only knowledge files reachable from an adopted context or skill appear under `.agentic-beacon/artifacts/knowledge/` after `abc sync` / `abc adopt`.
+
+So in practice: if `record-knowledge` writes a new lesson and a context already adopted in your project links to that lesson's path, the lesson will sync automatically on the next `abc sync`. If no adopted context or skill links to it yet, you'll need to author or adopt a context first (or hand-edit an existing one) that references the new knowledge path.
 
 ---
 
@@ -111,7 +113,7 @@ Press `Enter` to commit. Press `Escape` or `q` to return to the TUI without writ
 
 ## Atomic Commit with Rollback
 
-The write step is atomic. If anything fails mid-commit — a permission error, an unexpected exception, a signal — Agentic Beacon restores `beacon.yaml`, `pending.yaml`, and `.last-adopt` to their exact pre-commit state. No partial changes are left behind.
+The write step is atomic. If the commit raises an unhandled exception mid-write — disk full, permission error, malformed `beacon.yaml` after the change — the rollback restores `beacon.yaml`, `pending.yaml`, and `.last-adopt` to their pre-commit state. **Limit:** rollback handles caught Python exceptions only. A hard process kill (`SIGKILL`, system crash, or Ctrl-C delivered to an unprotected operation) could leave the commit half-applied. Re-running `abc adopt` is safe and the inconsistency is usually limited to `pending.yaml` vs `beacon.yaml` drift.
 
 ---
 

--- a/site-docs/concepts/pending-and-adoption.md
+++ b/site-docs/concepts/pending-and-adoption.md
@@ -18,7 +18,7 @@ The file is absent or contains `pending: []` when nothing is pending. It is rege
 
 ```yaml
 pending:
-  - path: skills/python-type-hints/SKILL.md
+  - path: skills/python-type-hints/
     type: skill
     action: created
     source: record-skill
@@ -53,7 +53,7 @@ Knowledge files are **not** tracked in `pending.yaml`. They are auto-derived dur
 
 `scripts/append_pending.py` is a self-contained script with no dependency on the `beacon` package — it only requires `pyyaml>=6.0`. This makes the pipeline work for any `abc` installation (pipx, pip, uv tool install) without needing the agentic-beacon source checkout.
 
-The script walks up the directory tree from the calling agent's working directory to find the project root (the nearest ancestor containing `.agentic-beacon/config.toml`), then appends or de-duplicates the entry.
+The script walks up the directory tree from the calling agent's working directory to find the project root (the nearest ancestor containing `.agentic-beacon/config.toml`), then appends a `PendingEntry` to `pending.yaml` after validating field types and enum values. Duplicate entries are not detected — if the same artifact path is recorded twice, both entries will land in the file.
 
 **Knowledge files are a special case.** `record-knowledge` writes to `<warehouse>/knowledge/` but does **not** append to `pending.yaml`. Knowledge files are auto-derived during `abc sync` / `abc adopt` — they appear in your project's `.agentic-beacon/artifacts/knowledge/` as symlinks the next time you sync, with no explicit accept step required.
 
@@ -145,7 +145,7 @@ abc warehouse status
 # 3. Inspect the pending file directly if you like:
 cat .agentic-beacon/pending.yaml
 # pending:
-# - path: skills/python-type-hints/SKILL.md
+# - path: skills/python-type-hints/
 #   type: skill
 #   action: created
 #   source: record-skill

--- a/site-docs/concepts/pending-and-adoption.md
+++ b/site-docs/concepts/pending-and-adoption.md
@@ -23,12 +23,6 @@ pending:
     action: created
     source: record-skill
     created_at: '2026-05-13T14:32:07Z'
-
-  - path: knowledge/python-standards/lessons/type-hints.md
-    type: context
-    action: created
-    source: record-knowledge
-    created_at: '2026-05-13T14:45:22Z'
 ```
 
 | Field | Values | Meaning |
@@ -45,7 +39,7 @@ Knowledge files are **not** tracked in `pending.yaml`. They are auto-derived dur
 
 ## The Author → Pending Pipeline
 
-The bundled skills (`record-knowledge`, `record-skill`) write to two places in a single agent action:
+`record-skill` (and `record-context`, `record-agent` for other artifact types) writes to two places in a single agent action:
 
 ```
 /record-skill
@@ -60,6 +54,8 @@ The bundled skills (`record-knowledge`, `record-skill`) write to two places in a
 `scripts/append_pending.py` is a self-contained script with no dependency on the `beacon` package — it only requires `pyyaml>=6.0`. This makes the pipeline work for any `abc` installation (pipx, pip, uv tool install) without needing the agentic-beacon source checkout.
 
 The script walks up the directory tree from the calling agent's working directory to find the project root (the nearest ancestor containing `.agentic-beacon/config.toml`), then appends or de-duplicates the entry.
+
+**Knowledge files are a special case.** `record-knowledge` writes to `<warehouse>/knowledge/` but does **not** append to `pending.yaml`. Knowledge files are auto-derived during `abc sync` / `abc adopt` — they appear in your project's `.agentic-beacon/artifacts/knowledge/` as symlinks the next time you sync, with no explicit accept step required.
 
 ---
 
@@ -101,7 +97,7 @@ Proposed changes
     + .agentic-beacon/pending.yaml (1 entry removed)
 
   Rejecting:
-    - knowledge/python-standards/lessons/type-hints.md (removed from pending)
+    ~ (nothing)
 
   Deferring:
     ~ (nothing)
@@ -134,13 +130,13 @@ It is gitignored. Future `abc adopt` invocations use it to detect hand-edited wa
 ## Full Walkthrough
 
 ```bash
-# 1. Author a knowledge file via the bundled skill
+# 1. Author a new skill via the bundled skill
 #    (inside a Claude Code or OpenCode agent session)
-/record-knowledge
-# Agent prompts: topic, title, content summary
+/record-skill
+# Agent prompts: skill name, description, initial process steps
 # Agent writes:
-#   <warehouse>/knowledge/python-standards/lessons/type-hints.md
-#   .agentic-beacon/pending.yaml  (appended)
+#   <warehouse>/skills/python-type-hints/SKILL.md
+#   .agentic-beacon/pending.yaml  (appended with type: skill)
 
 # 2. Pending alert appears on every abc command from now on:
 abc warehouse status
@@ -149,10 +145,10 @@ abc warehouse status
 # 3. Inspect the pending file directly if you like:
 cat .agentic-beacon/pending.yaml
 # pending:
-# - path: knowledge/python-standards/lessons/type-hints.md
-#   type: context
+# - path: skills/python-type-hints/SKILL.md
+#   type: skill
 #   action: created
-#   source: record-knowledge
+#   source: record-skill
 #   created_at: '2026-05-13T14:32:07Z'
 
 # 4. Run adopt — TUI opens, pending entry shown alongside warehouse artifacts
@@ -162,13 +158,13 @@ abc adopt
 # → press y to commit
 
 # After commit (accept path):
-#   .agentic-beacon/beacon.yaml   ← knowledge path added
+#   .agentic-beacon/beacon.yaml   ← skills/python-type-hints/ added
 #   .agentic-beacon/pending.yaml  ← entry removed (or empty)
 #   .agentic-beacon/.last-adopt   ← timestamp updated
-#   .agentic-beacon/artifacts/knowledge/python-standards/lessons/type-hints.md  ← symlink
+#   .agentic-beacon/artifacts/skills/python-type-hints/SKILL.md  ← symlink
 ```
 
-For the `/record-skill` walkthrough (authoring a skill through the same pipeline), see [Bundled Skills](bundled-skills.md#full-walkthrough-record-skill).
+For details on how bundled skills are wired into your project after `abc adopt`, see [Bundled Skills](bundled-skills.md).
 
 ---
 

--- a/site-docs/concepts/pending-and-adoption.md
+++ b/site-docs/concepts/pending-and-adoption.md
@@ -1,0 +1,179 @@
+# Pending & Adoption
+
+`pending.yaml` is the staging area between authoring a warehouse artifact and wiring it into your project. This page explains the file format, who writes to it, and how `abc adopt` processes it.
+
+---
+
+## What `pending.yaml` Is
+
+`.agentic-beacon/pending.yaml` is a gitignored per-project file that buffers artifacts written to the warehouse (by the `record-*` bundled skills) that have not yet been wired into `beacon.yaml`.
+
+It exists because authoring and adopting are separate steps. You write a skill into the warehouse with `/record-skill`, but you choose when and whether to pull it into the current project via `abc adopt`.
+
+The file is absent or contains `pending: []` when nothing is pending. It is regenerated on writes and pruned on adopt.
+
+---
+
+## YAML Shape
+
+```yaml
+pending:
+  - path: skills/python-type-hints/SKILL.md
+    type: skill
+    action: created
+    source: record-skill
+    created_at: '2026-05-13T14:32:07Z'
+
+  - path: knowledge/python-standards/lessons/type-hints.md
+    type: context
+    action: created
+    source: record-knowledge
+    created_at: '2026-05-13T14:45:22Z'
+```
+
+| Field | Values | Meaning |
+|---|---|---|
+| `path` | warehouse-relative path | The artifact written to the warehouse |
+| `type` | `skill`, `context`, `agent` | Artifact category (determines adopt behavior) |
+| `action` | `created`, `modified` | Whether this is a new file or an edit |
+| `source` | skill name | Which bundled skill wrote the entry |
+| `created_at` | `YYYY-MM-DDTHH:MM:SSZ` (UTC) | When the entry was appended |
+
+Knowledge files are **not** tracked in `pending.yaml`. They are auto-derived during sync/adopt by scanning context and skill markdown for links into `knowledge/`.
+
+---
+
+## The Author → Pending Pipeline
+
+The bundled skills (`record-knowledge`, `record-skill`) write to two places in a single agent action:
+
+```
+/record-skill
+     │
+     ├── writes  <warehouse>/skills/<name>/SKILL.md
+     │
+     └── calls   scripts/append_pending.py
+                     │
+                     └── appends to  .agentic-beacon/pending.yaml
+```
+
+`scripts/append_pending.py` is a self-contained script with no dependency on the `beacon` package — it only requires `pyyaml>=6.0`. This makes the pipeline work for any `abc` installation (pipx, pip, uv tool install) without needing the agentic-beacon source checkout.
+
+The script walks up the directory tree from the calling agent's working directory to find the project root (the nearest ancestor containing `.agentic-beacon/config.toml`), then appends or de-duplicates the entry.
+
+---
+
+## Pending Alert
+
+Every `abc` subcommand prints a one-line notice to stderr when `pending.yaml` is non-empty:
+
+```
+[yellow]Pending:[/yellow] 2 unadopted artifacts (run 'abc adopt')
+```
+
+This does not affect the subcommand's exit code. It fires on every command — `abc sync`, `abc warehouse status`, `abc doctor` — until you run `abc adopt` and clear the entries.
+
+---
+
+## Three-Way Adopt Actions
+
+`abc adopt` opens the TUI. Pending entries appear alongside warehouse artifacts you have not yet adopted. For each pending entry you can choose one of three actions:
+
+| Action | Effect on `pending.yaml` | Effect on `beacon.yaml` | Warehouse file |
+|---|---|---|---|
+| **accept** | Entry removed | Path appended, symlinks created | Untouched |
+| **reject** | Entry removed | No change | Untouched |
+| **defer** (default) | Entry kept | No change | Untouched |
+
+Rejecting an entry only removes it from `pending.yaml`. The warehouse file remains — it was written by the skill and is part of the warehouse working tree. If you want to delete the warehouse file, do so manually and commit via `abc warehouse contribute`.
+
+---
+
+## Confirm Screen
+
+After you mark all entries in the TUI, a projected-mutations summary appears before any filesystem writes:
+
+```
+Proposed changes
+────────────────────────────────────────
+  Accepting:
+    + skills/python-type-hints/  → beacon.yaml
+    + .agentic-beacon/pending.yaml (1 entry removed)
+
+  Rejecting:
+    - knowledge/python-standards/lessons/type-hints.md (removed from pending)
+
+  Deferring:
+    ~ (nothing)
+
+Apply? [y/N]
+```
+
+Press `y` (or `Enter`) to commit. Press `n` or `Esc` to return to the TUI without writing anything.
+
+---
+
+## Atomic Commit with Rollback
+
+The write step is atomic. If anything fails mid-commit — a permission error, an unexpected exception, a signal — Agentic Beacon restores `beacon.yaml`, `pending.yaml`, and `.last-adopt` to their exact pre-commit state. No partial changes are left behind.
+
+---
+
+## `.last-adopt`
+
+`.agentic-beacon/.last-adopt` is a single-line ISO-8601 UTC timestamp written after each successful `abc adopt` commit:
+
+```
+2026-05-13T14:55:00Z
+```
+
+It is gitignored. Future `abc adopt` invocations use it to detect hand-edited warehouse files: any warehouse file modified after the `.last-adopt` timestamp but not tracked in `pending.yaml` is flagged in the TUI as a potential untracked edit.
+
+---
+
+## Full Walkthrough
+
+```bash
+# 1. Author a knowledge file via the bundled skill
+#    (inside a Claude Code or OpenCode agent session)
+/record-knowledge
+# Agent prompts: topic, title, content summary
+# Agent writes:
+#   <warehouse>/knowledge/python-standards/lessons/type-hints.md
+#   .agentic-beacon/pending.yaml  (appended)
+
+# 2. Pending alert appears on every abc command from now on:
+abc warehouse status
+# → "[yellow]Pending:[/yellow] 1 unadopted artifact (run 'abc adopt')"
+
+# 3. Inspect the pending file directly if you like:
+cat .agentic-beacon/pending.yaml
+# pending:
+# - path: knowledge/python-standards/lessons/type-hints.md
+#   type: context
+#   action: created
+#   source: record-knowledge
+#   created_at: '2026-05-13T14:32:07Z'
+
+# 4. Run adopt — TUI opens, pending entry shown alongside warehouse artifacts
+abc adopt
+# → mark the entry as: accept / reject / defer (↑↓ to navigate, Space to select)
+# → confirm screen shows projected mutations
+# → press y to commit
+
+# After commit (accept path):
+#   .agentic-beacon/beacon.yaml   ← knowledge path added
+#   .agentic-beacon/pending.yaml  ← entry removed (or empty)
+#   .agentic-beacon/.last-adopt   ← timestamp updated
+#   .agentic-beacon/artifacts/knowledge/python-standards/lessons/type-hints.md  ← symlink
+```
+
+For the `/record-skill` walkthrough (authoring a skill through the same pipeline), see [Bundled Skills](bundled-skills.md#full-walkthrough-record-skill).
+
+---
+
+## Next Steps
+
+- **[Bundled Skills](bundled-skills.md)** — the `record-*` skills that write to `pending.yaml`
+- **[Interactive Adoption](../guides/interactive-adoption.md)** — full `abc adopt` TUI reference
+- **[beacon.yaml Reference](../reference/beacon-yaml.md)** — structure of the committed artifact config

--- a/site-docs/concepts/pending-and-adoption.md
+++ b/site-docs/concepts/pending-and-adoption.md
@@ -64,7 +64,7 @@ The script walks up the directory tree from the calling agent's working director
 Every `abc` subcommand prints a one-line notice to stderr when `pending.yaml` is non-empty:
 
 ```
-[yellow]Pending:[/yellow] 2 unadopted artifacts (run 'abc adopt')
+⚠ 2 pending artifacts. Run 'abc adopt' to wire them.
 ```
 
 This does not affect the subcommand's exit code. It fires on every command — `abc sync`, `abc warehouse status`, `abc doctor` — until you run `abc adopt` and clear the entries.
@@ -140,7 +140,7 @@ It is gitignored. Future `abc adopt` invocations use it to detect hand-edited wa
 
 # 2. Pending alert appears on every abc command from now on:
 abc warehouse status
-# → "[yellow]Pending:[/yellow] 1 unadopted artifact (run 'abc adopt')"
+# → "⚠ 1 pending artifacts. Run 'abc adopt' to wire them."
 
 # 3. Inspect the pending file directly if you like:
 cat .agentic-beacon/pending.yaml

--- a/site-docs/concepts/pending-and-adoption.md
+++ b/site-docs/concepts/pending-and-adoption.md
@@ -39,7 +39,7 @@ Knowledge files are **not** tracked in `pending.yaml`. They are auto-derived dur
 
 ## The Author → Pending Pipeline
 
-`record-skill` (and `record-context`, `record-agent` for other artifact types) writes to two places in a single agent action:
+`record-skill` writes to two places in a single agent action (future bundled skills may add `/record-context` and `/record-agent` to author contexts and agents directly; for now, contexts and agents are authored by hand and added to `pending.yaml` manually):
 
 ```
 /record-skill
@@ -102,10 +102,10 @@ Proposed changes
   Deferring:
     ~ (nothing)
 
-Apply? [y/N]
+Enter to proceed  Escape to cancel
 ```
 
-Press `y` (or `Enter`) to commit. Press `n` or `Esc` to return to the TUI without writing anything.
+Press `Enter` to commit. Press `Escape` or `q` to return to the TUI without writing anything.
 
 ---
 
@@ -155,7 +155,7 @@ cat .agentic-beacon/pending.yaml
 abc adopt
 # → mark the entry as: accept / reject / defer (↑↓ to navigate, Space to select)
 # → confirm screen shows projected mutations
-# → press y to commit
+# → press Enter to commit
 
 # After commit (accept path):
 #   .agentic-beacon/beacon.yaml   ← skills/python-type-hints/ added

--- a/site-docs/guides/creating-skills.md
+++ b/site-docs/guides/creating-skills.md
@@ -1,5 +1,7 @@
 # Creating Skills
 
+> This guide covers user-authored **warehouse skills**. For the `record-*` skills shipped with `abc`, see [Bundled Skills](../concepts/bundled-skills.md).
+
 Skills are reusable agent workflows stored in your warehouse. When a project syncs a skill, the agent can invoke it as a slash command to follow a consistent, repeatable process.
 
 ## What Is a Skill?

--- a/site-docs/guides/interactive-adoption.md
+++ b/site-docs/guides/interactive-adoption.md
@@ -49,6 +49,8 @@ When you press `Enter`, `abc adopt` runs a single session-atomic commit:
 
 The entire workflow — select → write config → sync → wire — happens in one step. If anything fails mid-commit, the manifests are restored to their pre-commit state.
 
+For the underlying storage model (`pending.yaml`, `.last-adopt`, atomic rollback), see [Pending & Adoption](../concepts/pending-and-adoption.md).
+
 > Editing `beacon.yaml` manually instead of going through the TUI? Run `abc sync` yourself afterward — the auto-sync described above only fires from the TUI confirm path.
 
 ---

--- a/site-docs/guides/warehouse-creation.md
+++ b/site-docs/guides/warehouse-creation.md
@@ -21,7 +21,9 @@ my-warehouse/
 ├── contexts/
 ├── knowledge/
 ├── skills/
-│   └── record-knowledge/   # bundled starter skill (see Concepts → Bundled Skills)
+│   ├── record-knowledge/   # bundled starter skill (see Concepts → Bundled Skills)
+│   │   └── SKILL.md
+│   └── record-skill/       # bundled starter skill
 │       └── SKILL.md
 ├── docs/
 └── README.md

--- a/site-docs/guides/warehouse-creation.md
+++ b/site-docs/guides/warehouse-creation.md
@@ -21,7 +21,7 @@ my-warehouse/
 ├── contexts/
 ├── knowledge/
 ├── skills/
-│   └── record-knowledge/   # bundled starter skill
+│   └── record-knowledge/   # bundled starter skill (see Concepts → Bundled Skills)
 │       └── SKILL.md
 ├── docs/
 └── README.md

--- a/site-docs/quickstart.md
+++ b/site-docs/quickstart.md
@@ -26,7 +26,8 @@ my-org-warehouse/
 ├── contexts/
 ├── knowledge/
 ├── skills/
-│   └── record-knowledge/   # bundled starter skill (see Concepts → Bundled Skills)
+│   ├── record-knowledge/   # bundled starter skill (see Concepts → Bundled Skills)
+│   └── record-skill/       # bundled starter skill
 ├── docs/
 └── README.md
 ```

--- a/site-docs/quickstart.md
+++ b/site-docs/quickstart.md
@@ -26,7 +26,7 @@ my-org-warehouse/
 ├── contexts/
 ├── knowledge/
 ├── skills/
-│   └── record-knowledge/   # bundled starter skill
+│   └── record-knowledge/   # bundled starter skill (see Concepts → Bundled Skills)
 ├── docs/
 └── README.md
 ```

--- a/site-docs/reference/cli.md
+++ b/site-docs/reference/cli.md
@@ -162,7 +162,7 @@ abc setup
 
 ### `abc adopt`
 
-Open an interactive TUI to browse and select warehouse artifacts. Applying your selection writes the new entries to `beacon.yaml` (clearing matching `pending.yaml` entries) and immediately syncs them — symlinks are created and contexts / skills / agents are wired into the project. In non-interactive contexts (no TTY) the command prints the candidate list and exits; you must edit `beacon.yaml` manually and then run `abc sync`.
+Open an interactive TUI to browse and select warehouse artifacts. Applying your selection writes the new entries to `beacon.yaml` (clearing matching `pending.yaml` entries) and immediately syncs them — symlinks are created and contexts / skills / agents are wired into the project. In non-interactive contexts (no TTY) the command prints the candidate list and exits; you must edit `beacon.yaml` manually and then run `abc sync`. See [Pending & Adoption](../concepts/pending-and-adoption.md) for the underlying file model.
 
 ```bash
 abc adopt [OPTIONS]
@@ -227,7 +227,7 @@ abc status [OPTIONS]
 |--------|-------------|
 | `--project PATH` | Check a specific project directory |
 
-Displays the connected warehouse path, configured contexts/skills (with ✓/✗ for synced status), bundled skills status, and total synced file count.
+Displays the connected warehouse path, configured contexts/skills (with ✓/✗ for synced status), bundled skills status, and total synced file count. See [Bundled Skills](../concepts/bundled-skills.md) for the list and walkthrough.
 
 ---
 


### PR DESCRIPTION
## Summary

Adds two dedicated Concepts pages to the mkdocs site for previously-undocumented mechanisms:

- **`site-docs/concepts/bundled-skills.md`** — what bundled skills are, the two shipped today (`record-knowledge`, `record-skill`), wire locations, when wiring happens (sync + adopt as of PER-151), differences from warehouse skills, post-PER-150 self-contained scripts note, and a full record-skill end-to-end walkthrough.
- **`site-docs/concepts/pending-and-adoption.md`** — what `pending.yaml` is, YAML shape, author → pending pipeline, pending-alert stderr, three-way adopt actions (accept/reject/defer), confirm screen, atomic commit with rollback, `.last-adopt` semantics, and a full author → adopt walkthrough.

Both walkthroughs reflect **current** observable behavior after PER-150 ([#136](https://github.com/Shadowsong27/agentic-beacon/pull/136)) and PER-151 ([#137](https://github.com/Shadowsong27/agentic-beacon/pull/137)) — no stale "uv sync from agentic-beacon repo root" instructions; auto-init of `opencode.json` / `CLAUDE.md` during `abc setup` and bundled-skill wiring during `abc adopt` are both documented.

Closes [PER-152](https://linear.app/shadowsong-personal/issue/PER-152).

## What changed

- `site-docs/concepts/bundled-skills.md` (new, 148 lines)
- `site-docs/concepts/pending-and-adoption.md` (new, 179 lines)
- `mkdocs.yml` — 2 nav entries added under Concepts (between How It Works and Artifact Types)
- `site-docs/concepts/how-it-works.md` — cross-link to pending-and-adoption.md
- `site-docs/guides/creating-skills.md` — top-of-page disambiguation linking to bundled-skills.md
- `site-docs/guides/interactive-adoption.md` — cross-link to pending-and-adoption.md
- `site-docs/guides/warehouse-creation.md` + `site-docs/quickstart.md` — tree-diagram comments updated to reference Concepts → Bundled Skills (plain-text since markdown links don't render in fenced code blocks)
- `site-docs/reference/cli.md` — cross-links on adopt + warehouse status descriptions

## Test plan

- [x] `uv run mkdocs build --strict` — passes, "Documentation built in 0.36 seconds", no warnings or broken links.
- [x] Behavioral accuracy: walkthroughs cite "abc adopt — also wires bundled skills (added in PER-151)" and "abc setup — auto-creates CLAUDE.md and opencode.json if missing". No stale instructions present.
- [x] No code changes outside `site-docs/` and `mkdocs.yml` — purely a docs PR.
- [ ] CI green
- [ ] opencode-review bot clean

## Out of scope

- Restructuring existing pages beyond the listed cross-link additions.
- New screenshots / GIFs / binary assets (text walkthroughs only).
- Any Python source changes.