### PR TITLE
feat(beacon): canonicalize bundled-skill scripts under _shared/ (PER-154)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,9 @@ jobs:
           git config --global user.email "ci@agentic-beacon.test"
           git config --global user.name "Agentic Beacon CI"
 
+      - name: Check shared scripts are in sync
+        run: python libs/beacon/scripts/sync_shared_scripts.py --check
+
       - name: Run unit tests
         run: uv run pytest -m "not integration" -q
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,3 +25,17 @@ repos:
     - id: ruff-format
       types_or: [ python, pyi ]
       args: [--config=pyproject.toml]
+
+- repo: local
+  hooks:
+  - id: sync-shared-scripts-check
+    name: Check shared bundled-skill scripts are in sync
+    language: python
+    entry: python libs/beacon/scripts/sync_shared_scripts.py --check
+    pass_filenames: false
+    files: >-
+      (?x)^(
+        libs/beacon/src/beacon/data/skills/_shared/scripts/.*|
+        libs/beacon/src/beacon/data/skills/record-skill/scripts/.*|
+        libs/beacon/src/beacon/data/skills/record-knowledge/scripts/.*
+      )$

--- a/libs/beacon/scripts/sync_shared_scripts.py
+++ b/libs/beacon/scripts/sync_shared_scripts.py
@@ -1,0 +1,77 @@
+"""Copy (or check) shared scripts from _shared/scripts/ into each skill's scripts/ dir.
+
+Usage:
+    python libs/beacon/scripts/sync_shared_scripts.py           # copy mode
+    python libs/beacon/scripts/sync_shared_scripts.py --check   # check mode (exit 1 on drift)
+"""
+
+import argparse
+import hashlib
+import shutil
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+_CANONICAL_DIR = (
+    _REPO_ROOT
+    / "libs"
+    / "beacon"
+    / "src"
+    / "beacon"
+    / "data"
+    / "skills"
+    / "_shared"
+    / "scripts"
+)
+_SKILL_TARGETS = ["record-skill", "record-knowledge"]
+_SKILLS_BASE = _REPO_ROOT / "libs" / "beacon" / "src" / "beacon" / "data" / "skills"
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def run_copy() -> None:
+    for skill in _SKILL_TARGETS:
+        target_dir = _SKILLS_BASE / skill / "scripts"
+        target_dir.mkdir(parents=True, exist_ok=True)
+        for src in sorted(_CANONICAL_DIR.iterdir()):
+            dst = target_dir / src.name
+            shutil.copy2(src, dst)
+            print(f"COPIED: {dst.relative_to(_REPO_ROOT)}")
+
+
+def run_check() -> int:
+    exit_code = 0
+    for skill in _SKILL_TARGETS:
+        target_dir = _SKILLS_BASE / skill / "scripts"
+        for src in sorted(_CANONICAL_DIR.iterdir()):
+            dst = target_dir / src.name
+            if not dst.exists():
+                print(f"DRIFT: {dst.relative_to(_REPO_ROOT)} (missing)")
+                exit_code = 1
+            elif _sha256(src) != _sha256(dst):
+                print(f"DRIFT: {dst.relative_to(_REPO_ROOT)}")
+                exit_code = 1
+            else:
+                print(f"OK: {dst.relative_to(_REPO_ROOT)}")
+    return exit_code
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Check mode: exit 1 if any skill copy diverges from canonical.",
+    )
+    args = parser.parse_args()
+
+    if args.check:
+        sys.exit(run_check())
+    else:
+        run_copy()
+
+
+if __name__ == "__main__":
+    main()

--- a/libs/beacon/src/beacon/data/skills/_shared/scripts/append_pending.py
+++ b/libs/beacon/src/beacon/data/skills/_shared/scripts/append_pending.py
@@ -1,0 +1,237 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["pyyaml>=6.0"]
+# ///
+# Self-contained script -- no beacon package required at runtime.
+"""Append an entry to .agentic-beacon/pending.yaml.
+
+Usage:
+    uv run append_pending.py --path <path> --type <type> --action <action> --source <source>
+"""
+
+import argparse
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+
+import yaml
+
+VALID_TYPES = ("skill", "context", "agent")
+VALID_ACTIONS = ("created", "modified")
+ERROR_NO_WAREHOUSE = (
+    "Error: no warehouse connected. Run 'abc warehouse connect <path>' first."
+)
+
+
+def find_project_root(start: Path) -> Path | None:
+    """Walk up from start to find a directory containing .agentic-beacon/config.toml."""
+    current = start.resolve()
+    while True:
+        if (current / ".agentic-beacon" / "config.toml").exists():
+            return current
+        parent = current.parent
+        if parent == current:
+            return None
+        current = parent
+
+
+def _canonicalize_entry(entry: dict) -> dict:
+    """Return a new dict with created_at normalized to canonical Z string form."""
+    created_at = entry.get("created_at")
+    if isinstance(created_at, datetime):
+        if created_at.tzinfo is None:
+            ts = created_at.replace(tzinfo=UTC)
+        else:
+            ts = created_at.astimezone(UTC)
+        return {**entry, "created_at": ts.strftime("%Y-%m-%dT%H:%M:%SZ")}
+    return entry
+
+
+def _validate_entry(entry: dict, index: int) -> dict:
+    """Validate a pending.yaml entry; exit 1 with a clear message on failure."""
+    if not isinstance(entry, dict):
+        print(
+            f"Error: pending.yaml entry #{index}: must be a mapping,"
+            f" got {type(entry).__name__}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    required_fields = ("path", "type", "action", "source", "created_at")
+    for field in required_fields:
+        if field not in entry:
+            print(
+                f"Error: pending.yaml entry #{index}: missing required field '{field}'",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+
+    if entry["type"] not in VALID_TYPES:
+        print(
+            f"Error: pending.yaml entry #{index}: invalid type {entry['type']!r},"
+            f" must be one of {VALID_TYPES}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    if entry["action"] not in VALID_ACTIONS:
+        print(
+            f"Error: pending.yaml entry #{index}: invalid action {entry['action']!r},"
+            f" must be one of {VALID_ACTIONS}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    if not isinstance(entry["path"], str):
+        print(
+            f"Error: pending.yaml entry #{index}: 'path' must be a string",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    if not isinstance(entry["source"], str):
+        print(
+            f"Error: pending.yaml entry #{index}: 'source' must be a string",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    created_at = entry["created_at"]
+    if isinstance(created_at, datetime):
+        pass
+    elif isinstance(created_at, str):
+        try:
+            parsed = datetime.strptime(created_at, "%Y-%m-%dT%H:%M:%SZ")
+        except ValueError as exc:
+            print(
+                f"Error: pending.yaml entry #{index}: 'created_at' is not a valid"
+                f" UTC timestamp in '%Y-%m-%dT%H:%M:%SZ' format ({exc})",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        canonical = parsed.strftime("%Y-%m-%dT%H:%M:%SZ")
+        if canonical != created_at:
+            print(
+                f"Error: pending.yaml entry #{index}: 'created_at' {created_at!r}"
+                f" is not in canonical '%Y-%m-%dT%H:%M:%SZ' form"
+                f" (expected {canonical!r}; check zero-padding)",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+    else:
+        print(
+            f"Error: pending.yaml entry #{index}: 'created_at' must be a datetime"
+            f" or a string in '%Y-%m-%dT%H:%M:%SZ' format",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    return entry
+
+
+def append_pending_entry(
+    project_root: Path,
+    path: str,
+    type_: str,
+    action: str,
+    source: str,
+) -> None:
+    """Append a pending entry to .agentic-beacon/pending.yaml."""
+    pending_path = project_root / ".agentic-beacon" / "pending.yaml"
+
+    entries: list[dict] = []
+    if pending_path.exists():
+        try:
+            with open(pending_path, encoding="utf-8") as f:
+                data = yaml.safe_load(f)
+        except yaml.YAMLError as e:
+            print(f"Error: invalid YAML in {pending_path}: {e}", file=sys.stderr)
+            sys.exit(1)
+
+        if data is None:
+            entries = []
+        elif not isinstance(data, dict):
+            print(
+                f"Error: pending.yaml must be a YAML mapping, got {type(data).__name__}",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        else:
+            raw_entries = data.get("pending", [])
+            if raw_entries is None:
+                entries = []
+            elif not isinstance(raw_entries, list):
+                print(
+                    "Error: 'pending' field must be a list",
+                    file=sys.stderr,
+                )
+                sys.exit(1)
+            else:
+                validated = [_validate_entry(e, i) for i, e in enumerate(raw_entries)]
+                entries = [_canonicalize_entry(e) for e in validated]
+
+    created_at_str = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+    new_entry = {
+        "path": path,
+        "type": type_,
+        "action": action,
+        "source": source,
+        "created_at": created_at_str,
+    }
+    entries.append(new_entry)
+
+    pending_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(pending_path, "w", encoding="utf-8") as f:
+        yaml.dump(
+            {"pending": entries},
+            f,
+            default_flow_style=False,
+            sort_keys=False,
+            allow_unicode=True,
+        )
+
+
+def main() -> None:
+    """Parse args and append a pending artifact entry."""
+    parser = argparse.ArgumentParser(
+        description="Append a pending artifact entry to .agentic-beacon/pending.yaml."
+    )
+    parser.add_argument(
+        "--path", required=True, help="Artifact path (warehouse-relative)"
+    )
+    parser.add_argument(
+        "--type",
+        dest="type_",
+        required=True,
+        choices=VALID_TYPES,
+        metavar="TYPE",
+        help=f"Artifact type: one of {', '.join(VALID_TYPES)}",
+    )
+    parser.add_argument(
+        "--action",
+        required=True,
+        choices=VALID_ACTIONS,
+        metavar="ACTION",
+        help=f"Action: one of {', '.join(VALID_ACTIONS)}",
+    )
+    parser.add_argument(
+        "--source", required=True, help="Source skill name (free-form string)"
+    )
+    args = parser.parse_args()
+
+    project_root = find_project_root(Path.cwd())
+    if project_root is None:
+        print(ERROR_NO_WAREHOUSE, file=sys.stderr)
+        sys.exit(1)
+
+    append_pending_entry(
+        project_root=project_root,
+        path=args.path,
+        type_=args.type_,
+        action=args.action,
+        source=args.source,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/libs/beacon/src/beacon/data/skills/_shared/scripts/resolve_warehouse.py
+++ b/libs/beacon/src/beacon/data/skills/_shared/scripts/resolve_warehouse.py
@@ -1,0 +1,70 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
+"""Walk up from $PWD to resolve the warehouse path from .agentic-beacon/config.toml.
+
+Exits 0 with the warehouse absolute path on stdout if found.
+Exits non-zero with an error message on stderr if not found or misconfigured.
+"""
+
+import sys
+import tomllib
+from pathlib import Path
+
+ERROR_NO_WAREHOUSE = (
+    "Error: no warehouse connected. Run 'abc warehouse connect <path>' first."
+)
+
+
+def find_project_root(start: Path) -> Path | None:
+    """Walk up from start to find a directory containing .agentic-beacon/config.toml."""
+    current = start.resolve()
+    while True:
+        if (current / ".agentic-beacon" / "config.toml").exists():
+            return current
+        parent = current.parent
+        if parent == current:
+            return None
+        current = parent
+
+
+def get_warehouse_path(cwd: Path) -> str:
+    """Return the resolved warehouse local_path for the project at cwd.
+
+    Prints error to stderr and raises SystemExit(1) on any failure.
+    """
+    project_root = find_project_root(cwd)
+    if project_root is None:
+        print(ERROR_NO_WAREHOUSE, file=sys.stderr)
+        sys.exit(1)
+
+    config_path = project_root / ".agentic-beacon" / "config.toml"
+    with open(config_path, "rb") as f:
+        data = tomllib.load(f)
+
+    if "warehouse" not in data:
+        print(
+            f"Error: {config_path} is missing [warehouse] section.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    if "local_path" not in data["warehouse"]:
+        print(
+            f"Error: {config_path} is missing warehouse.local_path field.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    return str(Path(data["warehouse"]["local_path"]).resolve())
+
+
+def main() -> None:
+    """Resolve warehouse path from project config and print to stdout."""
+    warehouse_path = get_warehouse_path(Path.cwd())
+    print(warehouse_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/libs/beacon/tests/unit/test_append_pending_inline.py
+++ b/libs/beacon/tests/unit/test_append_pending_inline.py
@@ -494,16 +494,25 @@ def test_main_success_path_writes_pending(mod, monkeypatch, tmp_path):
 
 def test_both_script_copies_byte_identical():
     # Arrange
+    canonical_path = _SKILLS_DIR / "_shared" / "scripts" / "append_pending.py"
     skill_path = _SKILLS_DIR / "record-skill" / "scripts" / "append_pending.py"
     knowledge_path = _SKILLS_DIR / "record-knowledge" / "scripts" / "append_pending.py"
 
-    # Act
     def _sha256(p: Path) -> str:
         return hashlib.sha256(p.read_bytes()).hexdigest()
 
-    # Assert
+    canonical_hash = _sha256(canonical_path)
+
+    # Assert both skill copies match each other (regression check)
     assert _sha256(skill_path) == _sha256(knowledge_path), (
         "record-skill and record-knowledge append_pending.py copies have diverged"
+    )
+    # Assert each skill copy matches the canonical source
+    assert _sha256(skill_path) == canonical_hash, (
+        "record-skill append_pending.py diverged from _shared/scripts/append_pending.py"
+    )
+    assert _sha256(knowledge_path) == canonical_hash, (
+        "record-knowledge append_pending.py diverged from _shared/scripts/append_pending.py"
     )
 
 


### PR DESCRIPTION
## Summary

Implements PER-154 — picks **Option 1** from the ticket (source-then-copy at build time).

- Canonical source lives at `libs/beacon/src/beacon/data/skills/_shared/scripts/{append_pending,resolve_warehouse}.py`.
- `libs/beacon/scripts/sync_shared_scripts.py` with default (copy) and `--check` modes.
- Pre-commit + CI run `--check`; fail on drift.
- Existing byte-identity test extended to also verify each per-skill copy matches canonical (3-way SHA check).

Closes PER-154.

## Notes on the diff

- The delegate authored `_shared/` by **copying** (not `git mv`'ing) the canonical bytes. The original per-skill paths still hold byte-identical files, so git history won't show renames — the SHA-identity test guarantees they stay in lockstep going forward. Functionally equivalent to a move; flagging for future spelunkers.
- Sync tool invocation in the pre-commit hook and CI step uses bare `python`. Works in both (pre-commit manages its own python env; CI uses `actions/setup-python@v5`). On macOS without a `python` alias, run as `python3 libs/beacon/scripts/sync_shared_scripts.py --check`.

## Test plan

- [x] `pytest libs/beacon/tests/unit/test_append_pending_inline.py -q` — 67/67 passing (re-run by supervisor in main repo's uv env)
- [x] `python3 libs/beacon/scripts/sync_shared_scripts.py --check` — exits 0
- [x] Drift smoke: append a byte to `_shared/...`, `--check` exits 1; revert, exits 0
- [x] SHA-256 across all three append_pending.py copies match
- [ ] CI green
- [ ] opencode-review bot clean

---

This PR is part of the **PER-157 acceptance run** — sibling PRs:
- A diligent-supervisor take on PER-154 using **Option 3 + sync helper** (different design choice; provides head-to-head comparison).
- A diligent-supervisor take on PER-153 (offline-aware integration-test skip).