### PR TITLE
feat(beacon): add sync helper + pre-commit guard for record-skill/record-knowledge (PER-154)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,3 +25,12 @@ repos:
     - id: ruff-format
       types_or: [ python, pyi ]
       args: [--config=pyproject.toml]
+
+- repo: local
+  hooks:
+  - id: sync-skill-scripts-check
+    name: Check record-skill/record-knowledge scripts are byte-identical
+    language: python
+    entry: python libs/beacon/scripts/sync_skill_scripts.py --check
+    pass_filenames: false
+    files: ^libs/beacon/src/beacon/data/skills/(record-skill|record-knowledge)/scripts/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -154,6 +154,18 @@ from beacon.core.manifest import BeaconManifest
 2. Update any docs that show the structure diagram
 3. Test `abc warehouse init` and `abc setup` end-to-end
 
+### Editing shared bundled-skill scripts
+
+`record-skill` and `record-knowledge` each carry identical copies of `append_pending.py` and
+`resolve_warehouse.py`. Edit one copy, then propagate the change with:
+
+```bash
+python libs/beacon/scripts/sync_skill_scripts.py --from <skill-you-edited>
+```
+
+The pre-commit hook runs `--check` automatically on any commit touching either skill's `scripts/`
+directory and will block the commit if the copies have diverged.
+
 ---
 
 ## Release Process

--- a/libs/beacon/scripts/sync_skill_scripts.py
+++ b/libs/beacon/scripts/sync_skill_scripts.py
@@ -1,0 +1,90 @@
+"""One-way sync helper for shared scripts between record-skill and record-knowledge.
+
+Usage:
+    python libs/beacon/scripts/sync_skill_scripts.py --from record-skill
+    python libs/beacon/scripts/sync_skill_scripts.py --from record-knowledge
+    python libs/beacon/scripts/sync_skill_scripts.py --check
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import shutil
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+SKILLS_DIR = REPO_ROOT / "libs" / "beacon" / "src" / "beacon" / "data" / "skills"
+SYNCED_SCRIPTS = ["append_pending.py", "resolve_warehouse.py"]
+SKILL_NAMES = ["record-skill", "record-knowledge"]
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def check(skills_dir: Path = SKILLS_DIR) -> bool:
+    """Return True if all synced scripts are byte-identical across both skills."""
+    diverged: list[str] = []
+    for script in SYNCED_SCRIPTS:
+        paths = [skills_dir / skill / "scripts" / script for skill in SKILL_NAMES]
+        hashes = {p: _sha256(p) for p in paths}
+        unique = set(hashes.values())
+        if len(unique) > 1:
+            diverged.append(script)
+            for path, digest in hashes.items():
+                print(
+                    f"  {path.relative_to(skills_dir.parent.parent.parent.parent)}: {digest[:16]}...",
+                    flush=True,
+                )
+    if diverged:
+        print(f"DRIFT DETECTED in: {', '.join(diverged)}", file=sys.stderr, flush=True)
+        return False
+    return True
+
+
+def sync_from(source_skill: str, skills_dir: Path = SKILLS_DIR) -> None:
+    """Copy synced scripts from source_skill to the other skill."""
+    if source_skill not in SKILL_NAMES:
+        print(
+            f"Unknown skill: {source_skill!r}. Choose from: {SKILL_NAMES}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    targets = [s for s in SKILL_NAMES if s != source_skill]
+    for script in SYNCED_SCRIPTS:
+        src = skills_dir / source_skill / "scripts" / script
+        for target_skill in targets:
+            dst = skills_dir / target_skill / "scripts" / script
+            shutil.copy2(src, dst)
+            print(f"Copied {src.name} → {dst.parent.parent.name}/scripts/")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Sync shared scripts between record-skill and record-knowledge."
+    )
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument(
+        "--from",
+        dest="from_skill",
+        metavar="SKILL",
+        help="Copy scripts from this skill to the other (e.g. record-skill).",
+    )
+    group.add_argument(
+        "--check",
+        action="store_true",
+        help="Return exit code 0 if scripts are byte-identical, 1 if they diverge.",
+    )
+    args = parser.parse_args()
+
+    if args.check:
+        ok = check()
+        sys.exit(0 if ok else 1)
+    else:
+        sync_from(args.from_skill)
+
+
+if __name__ == "__main__":
+    main()

--- a/libs/beacon/tests/unit/test_append_pending_inline.py
+++ b/libs/beacon/tests/unit/test_append_pending_inline.py
@@ -493,6 +493,12 @@ def test_main_success_path_writes_pending(mod, monkeypatch, tmp_path):
 
 
 def test_both_script_copies_byte_identical():
+    """Assert both append_pending.py copies are byte-identical.
+
+    If this test fails, run:
+        python libs/beacon/scripts/sync_skill_scripts.py --from <skill-with-correct-copy>
+    to propagate the fix to the other skill's copy.
+    """
     # Arrange
     skill_path = _SKILLS_DIR / "record-skill" / "scripts" / "append_pending.py"
     knowledge_path = _SKILLS_DIR / "record-knowledge" / "scripts" / "append_pending.py"
@@ -505,6 +511,45 @@ def test_both_script_copies_byte_identical():
     assert _sha256(skill_path) == _sha256(knowledge_path), (
         "record-skill and record-knowledge append_pending.py copies have diverged"
     )
+
+
+def test_sync_skill_scripts_detects_drift(tmp_path: Path):
+    """The sync tool's check() returns False when copies diverge."""
+    # Arrange: create a controlled pair of script dirs under tmp_path
+
+    sync_module_path = (
+        Path(__file__).resolve().parent.parent.parent
+        / "scripts"
+        / "sync_skill_scripts.py"
+    )
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location(
+        "sync_skill_scripts", sync_module_path
+    )
+    sync_mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(sync_mod)
+
+    skills_dir = tmp_path / "skills"
+    for skill in ["record-skill", "record-knowledge"]:
+        (skills_dir / skill / "scripts").mkdir(parents=True)
+        (skills_dir / skill / "scripts" / "append_pending.py").write_text("# shared\n")
+        (skills_dir / skill / "scripts" / "resolve_warehouse.py").write_text(
+            "# shared\n"
+        )
+
+    # Act: identical copies → check returns True
+    assert sync_mod.check(skills_dir) is True
+
+    # Act: tamper one copy → check returns False
+    (skills_dir / "record-skill" / "scripts" / "append_pending.py").write_text(
+        "# TAMPERED\n"
+    )
+    assert sync_mod.check(skills_dir) is False
+
+    # Act: sync from the tampered skill → the other copy now matches
+    sync_mod.sync_from("record-skill", skills_dir)
+    assert sync_mod.check(skills_dir) is True
 
 
 # ----

--- a/libs/beacon/tests/unit/test_append_pending_inline.py
+++ b/libs/beacon/tests/unit/test_append_pending_inline.py
@@ -512,6 +512,12 @@ def test_both_script_copies_byte_identical():
         "record-skill and record-knowledge append_pending.py copies have diverged"
     )
 
+    skill_rw = _SKILLS_DIR / "record-skill" / "scripts" / "resolve_warehouse.py"
+    knowledge_rw = _SKILLS_DIR / "record-knowledge" / "scripts" / "resolve_warehouse.py"
+    assert _sha256(skill_rw) == _sha256(knowledge_rw), (
+        "record-skill and record-knowledge resolve_warehouse.py copies have diverged"
+    )
+
 
 def test_sync_skill_scripts_detects_drift(tmp_path: Path):
     """The sync tool's check() returns False when copies diverge."""


### PR DESCRIPTION
## Summary

Implements PER-154 — picks **Option 3 + sync helper** from the ticket (status quo + tooling, not canonical-source refactor).

- `libs/beacon/scripts/sync_skill_scripts.py` with `--from <skill>` (copy) and `--check` (drift detection) modes.
- Pre-commit hook runs `--check` on changes to either skill's `scripts/` dir.
- New unit test exercises the drift-detection path.
- `AGENTS.md` documents the edit-one-then-sync workflow.

**Closes PER-154.**

## Design rationale

Three options listed in the ticket:
1. Source-then-copy at build time (new canonical `_shared/` dir).
2. Symlink at install time.
3. Status quo + byte-identity test.

This PR picks **Option 3 augmented with a sync helper** — least invasive. Preserves the bundled-skill self-contained model (each skill keeps its own `scripts/` dir). Eliminates manual dual-edits via the sync tool; pre-commit catches drift at commit time; the byte-identity unit test backstops at CI.

A **sibling PR** ([#139](https://github.com/Shadowsong27/agentic-beacon/pull/139)) implements **Option 1** instead (new canonical source under `_shared/`). The two PRs are deliberate alternatives for PER-157's supervisor-comparison acceptance run.

## Test plan

- [x] `uv run pytest libs/beacon/tests/unit/test_append_pending_inline.py -q` — 68/68 (includes the new drift-detection test)
- [x] `python3 libs/beacon/scripts/sync_skill_scripts.py --check` — exits 0 clean, exits 1 on drift, exits 0 after `--from <skill>` repair
- [ ] CI green
- [ ] opencode-review bot clean

---

Part of the **PER-157 acceptance run** — sibling PRs:
- [#139](https://github.com/Shadowsong27/agentic-beacon/pull/139) (impl-supervisor's Option 1 take on PER-154)
- A diligent take on PER-153 (offline-aware integration-test skip) — coming next.