### PR TITLE
feat(beacon): offline-aware skipif for bundled-skill integration tests (PER-153)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,9 @@ jobs:
           git config --global user.email "ci@agentic-beacon.test"
           git config --global user.name "Agentic Beacon CI"
 
+      - name: Pre-warm uv cache for PEP 723 deps
+        run: uv run --no-project --isolated --with pyyaml python -c "import yaml"
+
       - name: Run e2e integration tests
         run: uv run pytest -m integration -v
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,20 @@ pytest                     # run from repo root (testpaths configured in root py
 
 Never `cd libs/beacon` to run tests. Never create a venv inside `libs/beacon/`.
 
+### Skipping integration tests offline
+
+Some integration tests invoke `uv run --no-project --isolated`, which resolves `pyyaml`
+from the package index on a cache-cold machine. Set `BEACON_OFFLINE=1` to skip them:
+
+```bash
+BEACON_OFFLINE=1 pytest -m integration   # skips uv-network-dependent tests
+pytest -m integration                    # runs all integration tests (default)
+```
+
+When to set it: working on a plane, on a flaky network, or deliberately running the
+suite without registry access. CI pre-warms the uv cache before the integration-test
+step, so cache-cold flakiness is eliminated there automatically.
+
 ---
 
 ## Architecture

--- a/libs/beacon/tests/integration/_offline_guard.py
+++ b/libs/beacon/tests/integration/_offline_guard.py
@@ -1,0 +1,18 @@
+"""Offline/cache-cold guard for integration tests that invoke uv with PEP 723 deps.
+
+Policy: set BEACON_OFFLINE=1 to skip network-dependent integration tests.
+When to set it: working offline, on a flaky network, or deliberately running the
+suite without hitting any package registry.
+
+Future extension point: a pytest fixture with autouse=True could add a cache-warm
+probe behind a second env var, but ship only the env-var path for now.
+"""
+
+from __future__ import annotations
+
+import os
+
+
+def _is_offline_or_cache_cold() -> bool:
+    """Return True if BEACON_OFFLINE=1 is set in the environment."""
+    return os.environ.get("BEACON_OFFLINE") == "1"

--- a/libs/beacon/tests/integration/test_append_pending_standalone.py
+++ b/libs/beacon/tests/integration/test_append_pending_standalone.py
@@ -18,6 +18,16 @@ from pathlib import Path
 import pytest
 from beacon.core.manifest.pending import PendingManifest
 
+from tests.integration._offline_guard import _is_offline_or_cache_cold
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        _is_offline_or_cache_cold(),
+        reason="BEACON_OFFLINE=1 set; skipping uv-network-dependent integration test",
+    ),
+]
+
 _SKILLS_DIR = (
     Path(__file__).resolve().parent.parent.parent / "src" / "beacon" / "data" / "skills"
 )
@@ -52,7 +62,6 @@ def _make_project(root: Path) -> None:
 # ----
 
 
-@pytest.mark.integration
 @pytest.mark.parametrize("skill_name", ["record-skill", "record-knowledge"])
 def test_uv_run_pep723_executes_script_without_beacon(
     skill_name: str, tmp_path: Path

--- a/libs/beacon/tests/integration/test_record_write_subprocess.py
+++ b/libs/beacon/tests/integration/test_record_write_subprocess.py
@@ -16,6 +16,8 @@ from pathlib import Path
 
 import pytest
 
+from tests.integration._offline_guard import _is_offline_or_cache_cold
+
 _SKILLS_DIR = (
     Path(__file__).resolve().parent.parent.parent / "src" / "beacon" / "data" / "skills"
 )
@@ -167,6 +169,10 @@ _APPEND_PENDING_SKILL = _SKILLS_DIR / "record-skill" / "scripts" / "append_pendi
 
 
 @pytest.mark.integration
+@pytest.mark.skipif(
+    _is_offline_or_cache_cold(),
+    reason="BEACON_OFFLINE=1 set; skipping uv-network-dependent integration test",
+)
 def test_record_skill_e2e_write_then_append_pending(tmp_path: Path) -> None:
     """Full record-skill flow: write_skill.py then append_pending.py via uv run.
 


### PR DESCRIPTION
## Summary

Implements PER-153 — adds an env-var-gated `skipif` so the two `uv run --no-project --isolated` integration tests can be skipped deterministically on cache-cold / offline hosts.

- `libs/beacon/tests/integration/_offline_guard.py` exposes `_is_offline_or_cache_cold()` (env-var only; no TCP probe to avoid network coupling).
- Both affected test files (`test_append_pending_standalone.py`, `test_record_write_subprocess.py`) gain `pytest.mark.skipif(_is_offline_or_cache_cold(), ...)` via `pytestmark`.
- CI workflow gains a pre-warm step that exercises `uv run --no-project --isolated --with pyyaml python -c "import yaml"` before integration tests run — eliminates first-run flakiness on cache-cold runners.
- `AGENTS.md` documents the env-var workflow.

**Closes PER-153.**

## Design notes

- **Env var, not TCP probe.** A TCP probe to homelab PyPI couples test execution to network behavior, which is precisely what the bot wanted us to avoid in [PR #136 round-6 review](https://github.com/Shadowsong27/agentic-beacon/pull/136). An explicit `BEACON_OFFLINE=1` env var is deterministic and easy to set in CI matrices.
- **Skipif augments `pytest.mark.integration`** — the marker still selects/deselects at suite level; the skipif only fires when the user opts in.

## Delegate correction

The prompt suggested `from libs.beacon.tests.integration._offline_guard import ...`. The delegate noticed `libs/` and `libs/beacon/` lack `__init__.py`, so pytest's package root is `libs/beacon/` — making the correct import `from tests.integration._offline_guard ...`. The delegate flagged this in its structured response. Good catch.

## Test plan

- [x] `BEACON_OFFLINE=1 uv run pytest <target tests> -m integration -q` → `3 skipped` (supervisor re-verified in main env)
- [x] `uv run pytest libs/beacon/tests/integration/ -m integration --collect-only -q` → 78 tests collected, no auto-skip
- [x] `python -c "from tests.integration._offline_guard import _is_offline_or_cache_cold"` → import OK
- [ ] CI green (including the new pre-warm step)
- [ ] opencode-review bot clean

---

Part of the **PER-157 acceptance run** — sibling PRs:
- [#139](https://github.com/Shadowsong27/agentic-beacon/pull/139) (impl-supervisor's Option 1 take on PER-154)
- [#140](https://github.com/Shadowsong27/agentic-beacon/pull/140) (diligent-supervisor's Option 3 take on PER-154)