### PR TITLE
fix(warehouse): include artifacts.agents in get_tracked_paths

### DIFF
--- a/libs/beacon/src/beacon/data/skills/contribute-warehouse/scripts/summarize_changes.py
+++ b/libs/beacon/src/beacon/data/skills/contribute-warehouse/scripts/summarize_changes.py
@@ -80,11 +80,18 @@ def get_tracked_paths(warehouse: Path, beacon_yaml: Path) -> list[str]:
     artifacts = raw.get("artifacts") or {}
     skills_patterns: list[str] = artifacts.get("skills") or []
     contexts_patterns: list[str] = artifacts.get("contexts") or []
+    agents_patterns: list[str] = artifacts.get("agents") or []
 
     paths: list[str] = []
+    # Walk all three artifact types: skills, contexts, agents.
+    # Matches beacon.core.manifest.beacon.ArtifactsConfig (extra=forbid).
+    # Knowledge files are intentionally NOT walked here — they auto-derive
+    # during abc sync / abc adopt from context+skill references.
     for pattern in skills_patterns:
         paths.extend(_expand_pattern(warehouse, pattern))
     for pattern in contexts_patterns:
+        paths.extend(_expand_pattern(warehouse, pattern))
+    for pattern in agents_patterns:
         paths.extend(_expand_pattern(warehouse, pattern))
     return paths
 

--- a/libs/beacon/src/beacon/domains/warehouse/_tracked_paths.py
+++ b/libs/beacon/src/beacon/domains/warehouse/_tracked_paths.py
@@ -14,10 +14,17 @@ def get_tracked_paths(warehouse_path: Path, beacon_yaml: Path) -> list[str]:
     beacon_settings = BeaconManifest.from_yaml(beacon_yaml)
     paths: list[str] = []
 
+    # Walk all three artifact types declared by ArtifactsConfig: skills, contexts, agents.
+    # The schema (core/manifest/beacon.py) has `extra: forbid`, so these are the
+    # exhaustive set — knowledge files are intentionally NOT here; they are
+    # auto-derived during `abc sync` / `abc adopt` from context+skill references.
     for pattern in beacon_settings.artifacts.skills:
         paths.extend(_expand_pattern(warehouse_path, pattern))
 
     for pattern in beacon_settings.artifacts.contexts:
+        paths.extend(_expand_pattern(warehouse_path, pattern))
+
+    for pattern in beacon_settings.artifacts.agents:
         paths.extend(_expand_pattern(warehouse_path, pattern))
 
     return paths

--- a/libs/beacon/tests/unit/data/skills/contribute_warehouse/test_summarize_changes.py
+++ b/libs/beacon/tests/unit/data/skills/contribute_warehouse/test_summarize_changes.py
@@ -522,3 +522,163 @@ class TestPep723Dependencies:
         assert not beacon_imports, (
             f"Script still imports from beacon package: {beacon_imports}"
         )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# PER-183: get_tracked_paths must walk artifacts.agents (not just skills + contexts)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _write_beacon_yaml_full(
+    warehouse: Path,
+    *,
+    skills: list[str] | None = None,
+    contexts: list[str] | None = None,
+    agents: list[str] | None = None,
+) -> Path:
+    """Write a beacon.yaml that can declare any of the three artifact types.
+
+    Mirrors the shape of beacon.core.manifest.beacon.ArtifactsConfig.
+    """
+    ab_dir = warehouse / ".agentic-beacon"
+    ab_dir.mkdir(exist_ok=True)
+    beacon_yaml = ab_dir / "beacon.yaml"
+
+    def _section(name: str, items: list[str] | None) -> str:
+        if not items:
+            return f"  {name}: []\n"
+        lines = "\n".join(f"    - {p}" for p in items)
+        return f"  {name}:\n{lines}\n"
+
+    body = (
+        "version: 1\nartifacts:\n"
+        + _section("skills", skills)
+        + _section("contexts", contexts)
+        + _section("agents", agents)
+    )
+    beacon_yaml.write_text(body)
+    return beacon_yaml
+
+
+class TestPer183AgentsAreTracked:
+    """PER-183: agents artifact type must appear in get_tracked_paths output.
+
+    Regression for PR #146's third-dogfood test, which exposed that the inline
+    helper (faithful copy of beacon.domains.warehouse._tracked_paths.get_tracked_paths)
+    only walked artifacts.skills + artifacts.contexts, silently dropping
+    artifacts.agents — making /contribute-warehouse unusable for any agent
+    contribution.
+    """
+
+    def test_dirty_agent_in_beacon_yaml_appears_in_summary(self, tmp_path):
+        """Dirty file under agents/, declared in beacon.yaml.agents → appears in tracked_paths."""
+        warehouse = _make_git_warehouse(tmp_path)
+        # Create + commit so it exists as tracked-and-clean baseline
+        (warehouse / "agents").mkdir(exist_ok=True)
+        agent_file = warehouse / "agents" / "my-agent.md"
+        agent_file.write_text("---\nname: my-agent\n---\nbody v1\n")
+        _initial_commit(warehouse, [agent_file])
+
+        # beacon.yaml tracks the agent
+        beacon_yaml = _write_beacon_yaml_full(warehouse, agents=["agents/my-agent.md"])
+
+        # Make it dirty
+        agent_file.write_text("---\nname: my-agent\n---\nbody v2 modified\n")
+
+        mod = _load_script()
+        result = mod.summarize(warehouse, beacon_yaml)
+        paths = [e["path"] for e in result["tracked_paths"]]
+        assert "agents/my-agent.md" in paths, (
+            f"PER-183 regression: dirty agent should appear in tracked_paths. Got: {paths}"
+        )
+
+    def test_agents_dir_pattern_walks_recursively(self, tmp_path):
+        """Pattern `agents/` in beacon.yaml.agents picks up dirty files inside."""
+        warehouse = _make_git_warehouse(tmp_path)
+        (warehouse / "agents").mkdir(exist_ok=True)
+        a1 = warehouse / "agents" / "alpha.md"
+        a2 = warehouse / "agents" / "beta.md"
+        a1.write_text("---\nname: alpha\n---\nv1\n")
+        a2.write_text("---\nname: beta\n---\nv1\n")
+        _initial_commit(warehouse, [a1, a2])
+
+        # Pattern matches the directory
+        beacon_yaml = _write_beacon_yaml_full(warehouse, agents=["agents/"])
+
+        # Make alpha dirty, leave beta clean
+        a1.write_text("---\nname: alpha\n---\nv2\n")
+
+        mod = _load_script()
+        result = mod.summarize(warehouse, beacon_yaml)
+        paths = [e["path"] for e in result["tracked_paths"]]
+        assert "agents/alpha.md" in paths
+        assert "agents/beta.md" not in paths, "clean agent should be filtered out"
+
+    def test_all_three_artifact_types_walked_together(self, tmp_path):
+        """skills + contexts + agents all populated → each dirty file appears."""
+        warehouse = _make_git_warehouse(tmp_path)
+        (warehouse / "agents").mkdir(exist_ok=True)
+        (warehouse / "skills" / "s1").mkdir(parents=True, exist_ok=True)
+
+        ctx = warehouse / "contexts" / "c1.md"
+        skill = warehouse / "skills" / "s1" / "SKILL.md"
+        agent = warehouse / "agents" / "a1.md"
+        for f, body in [
+            (ctx, "ctx v1\n"),
+            (skill, "---\nname: s1\n---\nv1\n"),
+            (agent, "---\nname: a1\n---\nv1\n"),
+        ]:
+            f.write_text(body)
+        _initial_commit(warehouse, [ctx, skill, agent])
+
+        beacon_yaml = _write_beacon_yaml_full(
+            warehouse,
+            skills=["skills/s1/SKILL.md"],
+            contexts=["contexts/c1.md"],
+            agents=["agents/a1.md"],
+        )
+
+        # Dirty all three
+        ctx.write_text("ctx v2 modified\n")
+        skill.write_text("---\nname: s1\n---\nv2 modified\n")
+        agent.write_text("---\nname: a1\n---\nv2 modified\n")
+
+        mod = _load_script()
+        result = mod.summarize(warehouse, beacon_yaml)
+        paths = sorted(e["path"] for e in result["tracked_paths"])
+        assert paths == sorted(
+            ["contexts/c1.md", "skills/s1/SKILL.md", "agents/a1.md"]
+        ), f"all three artifact types should appear, got: {paths}"
+
+    def test_empty_agents_section_no_error(self, tmp_path):
+        """beacon.yaml with agents: [] is valid and walks the other two."""
+        warehouse = _make_git_warehouse(tmp_path)
+        ctx = warehouse / "contexts" / "c1.md"
+        ctx.write_text("v1\n")
+        _initial_commit(warehouse, [ctx])
+        beacon_yaml = _write_beacon_yaml_full(
+            warehouse,
+            contexts=["contexts/c1.md"],
+            agents=None,  # no agents key
+        )
+        ctx.write_text("v2 modified\n")
+        mod = _load_script()
+        result = mod.summarize(warehouse, beacon_yaml)
+        assert any(e["path"] == "contexts/c1.md" for e in result["tracked_paths"])
+
+    def test_missing_agents_key_treated_as_empty(self, tmp_path):
+        """If artifacts.agents key is missing entirely (older beacon.yaml), no crash."""
+        warehouse = _make_git_warehouse(tmp_path)
+        ctx = warehouse / "contexts" / "c1.md"
+        ctx.write_text("v1\n")
+        _initial_commit(warehouse, [ctx])
+        # Hand-write a minimal beacon.yaml WITHOUT the agents key
+        beacon_yaml = warehouse / ".agentic-beacon" / "beacon.yaml"
+        beacon_yaml.parent.mkdir(exist_ok=True)
+        beacon_yaml.write_text(
+            "version: 1\nartifacts:\n  skills: []\n  contexts:\n    - contexts/c1.md\n"
+        )
+        ctx.write_text("v2 modified\n")
+        mod = _load_script()
+        result = mod.summarize(warehouse, beacon_yaml)
+        assert any(e["path"] == "contexts/c1.md" for e in result["tracked_paths"])

--- a/libs/beacon/tests/unit/warehouse/test_tracked_paths.py
+++ b/libs/beacon/tests/unit/warehouse/test_tracked_paths.py
@@ -1,0 +1,124 @@
+"""Direct unit tests for beacon.domains.warehouse._tracked_paths.get_tracked_paths.
+
+PER-183 regression: the function must walk all three artifact types declared
+by ArtifactsConfig (skills, contexts, agents). Before PER-183 was fixed, only
+skills + contexts were walked, silently dropping agent contributions from the
+contribute flow.
+
+Knowledge files are intentionally NOT in scope — they are auto-derived during
+abc sync / abc adopt from context+skill references and are not part of the
+beacon.yaml-tracked manifest.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from beacon.domains.warehouse._tracked_paths import get_tracked_paths
+
+
+def _write_beacon_yaml(
+    warehouse: Path,
+    *,
+    skills: list[str] | None = None,
+    contexts: list[str] | None = None,
+    agents: list[str] | None = None,
+) -> Path:
+    """Write a minimal beacon.yaml with the requested artifact sections."""
+    ab_dir = warehouse / ".agentic-beacon"
+    ab_dir.mkdir(exist_ok=True)
+    beacon_yaml = ab_dir / "beacon.yaml"
+
+    def _section(name: str, items: list[str] | None) -> str:
+        if items is None:
+            return f"  {name}: []\n"
+        if not items:
+            return f"  {name}: []\n"
+        lines = "\n".join(f"    - {p}" for p in items)
+        return f"  {name}:\n{lines}\n"
+
+    body = (
+        "version: 1\nartifacts:\n"
+        + _section("skills", skills)
+        + _section("contexts", contexts)
+        + _section("agents", agents)
+    )
+    beacon_yaml.write_text(body)
+    return beacon_yaml
+
+
+class TestGetTrackedPathsArtifactsCoverage:
+    """PER-183: walking artifacts.skills + contexts + agents — all three."""
+
+    def test_agents_listed_returns_agent_path(self, tmp_path):
+        """Agent declared in artifacts.agents → returned by get_tracked_paths."""
+        wh = tmp_path / "warehouse"
+        (wh / "agents").mkdir(parents=True)
+        (wh / "agents" / "alpha.md").write_text("---\nname: alpha\n---\n")
+        beacon_yaml = _write_beacon_yaml(wh, agents=["agents/alpha.md"])
+
+        result = get_tracked_paths(wh, beacon_yaml)
+        assert "agents/alpha.md" in result, (
+            f"PER-183 regression: agent should appear in tracked paths. Got: {result}"
+        )
+
+    def test_all_three_types_returned_together(self, tmp_path):
+        """skills + contexts + agents all populated → all paths returned."""
+        wh = tmp_path / "warehouse"
+        (wh / "agents").mkdir(parents=True)
+        (wh / "contexts").mkdir(parents=True)
+        (wh / "skills" / "s1").mkdir(parents=True)
+        (wh / "agents" / "a1.md").write_text("---\nname: a1\n---\n")
+        (wh / "contexts" / "c1.md").write_text("# c1\n")
+        (wh / "skills" / "s1" / "SKILL.md").write_text("---\nname: s1\n---\n")
+
+        beacon_yaml = _write_beacon_yaml(
+            wh,
+            skills=["skills/s1/SKILL.md"],
+            contexts=["contexts/c1.md"],
+            agents=["agents/a1.md"],
+        )
+
+        result = sorted(get_tracked_paths(wh, beacon_yaml))
+        assert result == sorted(
+            ["skills/s1/SKILL.md", "contexts/c1.md", "agents/a1.md"]
+        ), f"all three artifact types should appear, got: {result}"
+
+    def test_empty_agents_section_returns_only_skills_and_contexts(self, tmp_path):
+        """artifacts.agents: [] → only the other two types are returned."""
+        wh = tmp_path / "warehouse"
+        (wh / "contexts").mkdir(parents=True)
+        (wh / "contexts" / "c1.md").write_text("# c1\n")
+        beacon_yaml = _write_beacon_yaml(wh, contexts=["contexts/c1.md"], agents=[])
+
+        result = get_tracked_paths(wh, beacon_yaml)
+        assert result == ["contexts/c1.md"]
+
+    def test_only_agents_section_returns_just_agents(self, tmp_path):
+        """artifacts: agents only (skills + contexts empty) → only agents."""
+        wh = tmp_path / "warehouse"
+        (wh / "agents").mkdir(parents=True)
+        (wh / "agents" / "solo.md").write_text("---\nname: solo\n---\n")
+        beacon_yaml = _write_beacon_yaml(wh, agents=["agents/solo.md"])
+
+        result = get_tracked_paths(wh, beacon_yaml)
+        assert result == ["agents/solo.md"]
+
+    def test_agents_directory_pattern_walks_recursively(self, tmp_path):
+        """artifacts.agents: [agents/] picks up every file inside the directory."""
+        wh = tmp_path / "warehouse"
+        (wh / "agents").mkdir(parents=True)
+        (wh / "agents" / "one.md").write_text("---\nname: one\n---\n")
+        (wh / "agents" / "two.md").write_text("---\nname: two\n---\n")
+        beacon_yaml = _write_beacon_yaml(wh, agents=["agents/"])
+
+        result = sorted(get_tracked_paths(wh, beacon_yaml))
+        assert "agents/one.md" in result
+        assert "agents/two.md" in result
+
+    def test_missing_beacon_yaml_returns_empty(self, tmp_path):
+        """No beacon.yaml at the given path → returns [] (existing behavior unchanged)."""
+        wh = tmp_path / "warehouse"
+        wh.mkdir()
+        result = get_tracked_paths(wh, wh / "no-such-beacon.yaml")
+        assert result == []


### PR DESCRIPTION
## Summary

`get_tracked_paths()` walked only `artifacts.skills` and `artifacts.contexts`, silently dropping `artifacts.agents` even though it's part of the `ArtifactsConfig` schema. Result: every contribute flow — including the newly-shipped `/contribute-warehouse` skill from PR #146 — silently couldn't see dirty agent files.

Closes PER-183.

### Discovered via dogfood

Local-install testing of PR #146 (`uv tool install --reinstall ./libs/beacon`) — `/contribute-warehouse` returned `{"tracked_paths": []}` despite 3 dirty agents in the agentic-beacon project's own `beacon.yaml.agents` list. The lint gate passed; the summarizer just didn't walk that section.

### Change

- `libs/beacon/src/beacon/domains/warehouse/_tracked_paths.py`: adds the `agents` walk
- `libs/beacon/src/beacon/data/skills/contribute-warehouse/scripts/summarize_changes.py`: same fix in the inline helper (round-3 self-contained version)
- `libs/beacon/tests/unit/warehouse/test_tracked_paths.py` (NEW): direct unit tests for `get_tracked_paths` covering all 3 artifact types, empty sections, directory patterns, and missing beacon.yaml
- `libs/beacon/tests/unit/data/skills/contribute_warehouse/test_summarize_changes.py`: PER-183 regression tests + a `_write_beacon_yaml_full` helper that supports all 3 artifact types

### Knowledge files — out of scope

`artifacts.knowledge` does NOT exist in `ArtifactsConfig` (schema has `extra=forbid`). Knowledge files are auto-derived during `abc sync`/`abc adopt` from context+skill references. This PR doesn't change that behavior.

### Test plan

- [x] `BEACON_OFFLINE=1 uv run pytest -q` → 1336 passed, 15 skipped (was 1325 before — 11 new tests)
- [x] Targeted: `pytest libs/beacon/tests/unit/warehouse/test_tracked_paths.py libs/beacon/tests/unit/data/skills/contribute_warehouse/test_summarize_changes.py libs/beacon/tests/unit/warehouse/test_contribute.py -q` → 44 passed
- [x] Smoke test against real warehouse (hl-knowledge-market): `/contribute-warehouse` now correctly surfaces all 3 dirty agents tracked in the project's beacon.yaml
- [ ] CI green
- [ ] opencode-review bot clean

🤖 Hand-patched by implementation-supervisor (no delegation — single-function bug fix). Discovered via local-install dogfood pattern.