### PR TITLE
fix(warehouse): make contribute + summarize warehouse-scoped (PER-202, PER-203)

### DIFF
--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -14,7 +14,7 @@ jobs:
       github.event.pull_request.draft == false &&
       github.event.pull_request.head.repo.full_name == github.repository
     runs-on: self-hosted
-    timeout-minutes: 20
+    timeout-minutes: 30
 
     permissions:
       contents: read

--- a/libs/beacon/src/beacon/cli/warehouse.py
+++ b/libs/beacon/src/beacon/cli/warehouse.py
@@ -392,20 +392,35 @@ def warehouse_list(*, artifact_type: str | None) -> None:
     type=str,
     help=(
         "Warehouse-relative path to commit (repeatable). When omitted, "
-        "commits all beacon.yaml-tracked dirty paths (current behavior)."
+        "commits every dirty path in the warehouse working tree."
     ),
 )
-def warehouse_contribute(*, message: str, push: bool, paths: tuple[str, ...]) -> None:
+@click.option(
+    "--only-tracked",
+    "only_tracked",
+    is_flag=True,
+    help=(
+        "Restrict the commit to paths declared in this project's beacon.yaml. "
+        "Out-of-scope paths in --paths are rejected. Default is warehouse-scoped: "
+        "any dirty warehouse path is acceptable (PER-203)."
+    ),
+)
+def warehouse_contribute(
+    *, message: str, push: bool, paths: tuple[str, ...], only_tracked: bool
+) -> None:
     """Commit changes in the warehouse working tree.
 
-    Stages and commits files tracked by beacon.yaml that have uncommitted
-    changes in the warehouse clone.
+    By default (PER-203), stages and commits every dirty path in the warehouse —
+    brand-new artifacts and cross-project knowledge are both acceptable.
+    Pass --only-tracked to fall back to the legacy project-scoped invariant
+    (restrict to paths declared in this project's beacon.yaml).
 
     Example:
         abc warehouse contribute -m "Update python standards"
         abc warehouse contribute -m "Fix typo" --push
         abc warehouse contribute -m "Update skill" --paths skills/foo/SKILL.md
         abc warehouse contribute -m "Split commit" --paths a.md --paths b.md
+        abc warehouse contribute -m "Tracked only" --only-tracked
     """
     try:
         result = contribute(
@@ -413,6 +428,7 @@ def warehouse_contribute(*, message: str, push: bool, paths: tuple[str, ...]) ->
             message=message,
             push=push,
             paths=tuple(paths) or None,
+            only_tracked=only_tracked,
         )
     except ValueError as e:
         console.print(f"[red]Error:[/red] {e}")

--- a/libs/beacon/src/beacon/data/skills/contribute-warehouse/SKILL.md
+++ b/libs/beacon/src/beacon/data/skills/contribute-warehouse/SKILL.md
@@ -118,14 +118,14 @@ nothing to contribute and stop cleanly.
 
 ### Step 4: Intent Triage
 
-Present the dirty tracked paths to the user and ask them to classify each as:
+Present the dirty warehouse paths to the user and ask them to classify each as:
 
 - **include** — commit this in the current session
 - **leave-for-later** — skip for now; do not stage, stash, or modify
 
 Example presentation:
 ```
-Dirty tracked paths (3 files):
+Dirty warehouse paths (3 files):
 
   1. contexts/python-standards.md   [M — 12 insertions, 3 deletions]
   2. knowledge/python/lessons/type-hints.md   [A — new file]
@@ -338,7 +338,7 @@ Contribution summary:
 
 - [ ] Run `resolve_warehouse.py` — STOP if exits non-zero
 - [ ] Run `abc warehouse lint <warehouse>` — STOP and surface errors if non-zero
-- [ ] Run `summarize_changes.py` — STOP if no dirty tracked paths
+- [ ] Run `summarize_changes.py` — STOP if no dirty warehouse paths
 - [ ] Triage dirty files with the user (include / leave-for-later)
 - [ ] Dedup scan for `knowledge/` files — flag overlaps before proceeding
 - [ ] Cohesion check — propose split if multiple independent changes

--- a/libs/beacon/src/beacon/data/skills/contribute-warehouse/SKILL.md
+++ b/libs/beacon/src/beacon/data/skills/contribute-warehouse/SKILL.md
@@ -93,7 +93,7 @@ Suggested recovery:
 
 Do NOT stash, do NOT skip lint, do NOT proceed on a lint failure.
 
-### Step 3: Summarize Dirty Tracked Paths
+### Step 3: Summarize Dirty Warehouse Paths
 
 Run the summarizer to build a structured view of what has changed:
 
@@ -101,21 +101,17 @@ Run the summarizer to build a structured view of what has changed:
 uv run ${SKILL_DIR}/scripts/summarize_changes.py --warehouse "$WAREHOUSE_ROOT"
 ```
 
-The script auto-detects the project root by walking up from CWD looking for
-`.agentic-beacon/config.toml`. If auto-detection fails (e.g. skill is run from
-an unrelated directory), pass the project root explicitly:
-
-```bash
-uv run ${SKILL_DIR}/scripts/summarize_changes.py \
-  --warehouse "$WAREHOUSE_ROOT" \
-  --project-root /path/to/project
-```
+The summarizer enumerates **every** dirty path in the warehouse working tree
+(PER-202) — no `.agentic-beacon/config.toml` lookup, no `beacon.yaml` filter,
+no project-context dependency. The skill works from any CWD, including a brand
+new warehouse with no projects connected yet.
 
 Parse the JSON output. Each entry in `tracked_paths` contains:
 - `path` — warehouse-relative path
 - `git_status` — porcelain code (e.g. `M`, `A`, `??`)
 - `diff_stat` — one-line diff summary
 - `last_commit_age_days` — days since last commit, or `null`
+- `warehouse_area` — top-level area (`contexts`, `knowledge`, `skills`, `agents`, or `other`)
 
 If the JSON output is empty (`{"tracked_paths": []}`), tell the user there is
 nothing to contribute and stop cleanly.
@@ -358,7 +354,7 @@ Contribution summary:
 | Script | Purpose | Dependencies |
 |---|---|---|
 | `resolve_warehouse.py` | Resolve warehouse path from `.agentic-beacon/config.toml` | stdlib only |
-| `summarize_changes.py` | Build structured JSON view of dirty tracked paths | `agentic-beacon` |
+| `summarize_changes.py` | Build structured JSON view of every dirty warehouse path | `pyyaml` (PEP 723) |
 | `draft_commit_message.py` | Derive deterministic Conventional Commits message | stdlib only |
 | `push_warehouse.py` | Atomic push with recovery-command output on failure | stdlib only |
 

--- a/libs/beacon/src/beacon/data/skills/contribute-warehouse/scripts/summarize_changes.py
+++ b/libs/beacon/src/beacon/data/skills/contribute-warehouse/scripts/summarize_changes.py
@@ -2,27 +2,35 @@
 # requires-python = ">=3.11"
 # dependencies = ["pyyaml>=6.0"]
 # ///
-"""Summarize dirty tracked warehouse paths for the contribute-warehouse skill.
+"""Summarize dirty warehouse paths for the contribute-warehouse skill.
 
 # Self-contained script -- no beacon package required at runtime.
 
-Outputs a single JSON object on stdout:
-  {"tracked_paths": [{"path": str, "git_status": str, "diff_stat": str, "last_commit_age_days": int|null}]}
+By default (PER-202), enumerates EVERY dirty path under the warehouse working
+tree via `git status --porcelain`, regardless of project context. Pass
+`--only-project-artifacts` to fall back to the legacy beacon.yaml-filtered
+behavior.
 
-Only dirty (modified/added/untracked) tracked paths appear in the output.
-Clean paths are filtered out.
+Outputs a single JSON object on stdout:
+  {"tracked_paths": [{"path": str, "git_status": str, "diff_stat": str,
+                      "last_commit_age_days": int|null,
+                      "warehouse_area": str}]}
+
+Only dirty (modified/added/untracked/deleted) paths appear in the output.
 
 Usage:
-    uv run summarize_changes.py --warehouse <path> [--beacon-yaml <path>]
-    uv run summarize_changes.py --warehouse <path> [--project-root <path>]
+    # Default: enumerate ALL dirty warehouse paths (PER-202)
+    uv run summarize_changes.py --warehouse <path>
 
-beacon.yaml resolution order:
+    # Opt-in legacy behavior: filter through invoking project's beacon.yaml
+    uv run summarize_changes.py --warehouse <path> --only-project-artifacts
+    uv run summarize_changes.py --warehouse <path> --only-project-artifacts --project-root <path>
+    uv run summarize_changes.py --warehouse <path> --only-project-artifacts --beacon-yaml <path>
+
+beacon.yaml resolution order (only when --only-project-artifacts is set):
   1. --beacon-yaml (explicit path) takes highest precedence.
   2. --project-root / auto-detected project root → <project_root>/.agentic-beacon/beacon.yaml.
   3. If neither is discoverable, exits non-zero with a clear message.
-
-NOTE: The default does NOT fall back to <warehouse>/.agentic-beacon/beacon.yaml —
-warehouses do not contain this file; beacon.yaml lives in the project root.
 """
 
 import argparse
@@ -229,8 +237,99 @@ def is_dirty(status_code: str) -> bool:
     return bool(stripped)
 
 
+# ─────────────────────────────────────────────────────────────────────────────
+# Warehouse-wide enumeration (PER-202 default)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+_AREA_PREFIXES = ("contexts", "knowledge", "skills", "agents")
+
+
+def classify_warehouse_area(path: str) -> str:
+    """Return the warehouse area for `path` ('contexts'/'knowledge'/'skills'/'agents'/'other').
+
+    Top-level directory of the warehouse-relative path determines the area.
+    """
+    head = path.split("/", 1)[0] if path else ""
+    return head if head in _AREA_PREFIXES else "other"
+
+
+def enumerate_dirty_paths(warehouse: Path) -> list[tuple[str, str]]:
+    """Return [(path, status_code)] for every dirty path in the warehouse working tree.
+
+    Parses `git status --porcelain` directly — no beacon.yaml lookup, no project
+    context required. Handles renames by reporting the destination path. Skips
+    submodule directory entries (status starts with 'C ') and any path that
+    happens to fall under .git/.
+    """
+    # --untracked-files=all expands untracked directories to their constituent
+    # files; the default (--untracked-files=normal) reports only the directory
+    # name, which loses the path we need to commit.
+    rc, stdout, stderr = _run_git(
+        warehouse, ["status", "--porcelain", "--untracked-files=all"]
+    )
+    if rc != 0:
+        raise RuntimeError(f"git status failed in {warehouse}: {stderr.strip()}")
+
+    entries: list[tuple[str, str]] = []
+    for line in stdout.splitlines():
+        if len(line) < 4:
+            continue
+        code = line[:2]
+        rest = line[3:]
+        # Rename / copy: 'R  old -> new' or 'C  old -> new'
+        if " -> " in rest:
+            path = rest.split(" -> ", 1)[1]
+        else:
+            path = rest
+        # Strip git's quoting of paths containing special characters
+        if path.startswith('"') and path.endswith('"'):
+            try:
+                path = path[1:-1].encode("utf-8").decode("unicode_escape")
+            except UnicodeDecodeError:
+                pass
+        if ".git" in Path(path).parts:
+            continue
+        entries.append((path, code))
+    return entries
+
+
+def summarize_all(warehouse: Path) -> dict:
+    """Build the summary dict of every dirty path in the warehouse working tree."""
+    try:
+        entries = enumerate_dirty_paths(warehouse)
+    except Exception as e:
+        print(f"Error enumerating dirty paths: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    results = []
+    for path, status in sorted(entries, key=lambda e: e[0]):
+        diff_stat = get_diff_stat(warehouse, path)
+        age = get_last_commit_age_days(warehouse, path)
+        results.append(
+            {
+                "path": path,
+                "git_status": status,
+                "diff_stat": diff_stat,
+                "last_commit_age_days": age,
+                "warehouse_area": classify_warehouse_area(path),
+            }
+        )
+
+    return {"tracked_paths": results}
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# beacon.yaml-filtered enumeration (--only-project-artifacts opt-in)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
 def summarize(warehouse: Path, beacon_yaml: Path) -> dict:
-    """Build the summary dict of dirty tracked paths."""
+    """Build the summary dict of dirty paths filtered through beacon.yaml.
+
+    Used by `--only-project-artifacts`. Returns the same JSON shape as
+    `summarize_all`, including `warehouse_area`.
+    """
     if not beacon_yaml.exists():
         return {"tracked_paths": []}
 
@@ -261,6 +360,7 @@ def summarize(warehouse: Path, beacon_yaml: Path) -> dict:
                 "git_status": status,
                 "diff_stat": diff_stat,
                 "last_commit_age_days": age,
+                "warehouse_area": classify_warehouse_area(path),
             }
         )
 
@@ -269,7 +369,7 @@ def summarize(warehouse: Path, beacon_yaml: Path) -> dict:
 
 def main() -> None:
     parser = argparse.ArgumentParser(
-        description="Summarize dirty tracked warehouse paths as JSON."
+        description="Summarize dirty warehouse paths as JSON."
     )
     parser.add_argument(
         "--warehouse",
@@ -277,11 +377,20 @@ def main() -> None:
         help="Absolute path to the warehouse root.",
     )
     parser.add_argument(
+        "--only-project-artifacts",
+        action="store_true",
+        help=(
+            "Restore legacy behavior: filter dirty paths through the invoking "
+            "project's beacon.yaml. Requires --beacon-yaml or a resolvable "
+            "project root."
+        ),
+    )
+    parser.add_argument(
         "--beacon-yaml",
         default=None,
         help=(
-            "Explicit path to beacon.yaml. When provided, takes precedence over "
-            "--project-root and auto-detection."
+            "Explicit path to beacon.yaml. Only honored with --only-project-artifacts. "
+            "Takes precedence over --project-root and auto-detection."
         ),
     )
     parser.add_argument(
@@ -289,7 +398,8 @@ def main() -> None:
         default=None,
         help=(
             "Path to the project root (the directory containing .agentic-beacon/). "
-            "When omitted, auto-detected by walking up from the current directory."
+            "Only honored with --only-project-artifacts. When omitted, "
+            "auto-detected by walking up from the current directory."
         ),
     )
     args = parser.parse_args()
@@ -299,7 +409,17 @@ def main() -> None:
         print(f"Error: warehouse path does not exist: {warehouse}", file=sys.stderr)
         sys.exit(1)
 
-    # Resolve beacon.yaml path
+    # Default (PER-202): enumerate ALL dirty warehouse paths, no project context.
+    if not args.only_project_artifacts:
+        try:
+            result = summarize_all(warehouse)
+        except Exception as e:
+            print(f"Error: {e}", file=sys.stderr)
+            sys.exit(1)
+        print(json.dumps(result, indent=2))
+        sys.exit(0)
+
+    # Opt-in legacy: filter through invoking project's beacon.yaml.
     if args.beacon_yaml:
         beacon_yaml = Path(args.beacon_yaml)
     else:
@@ -310,7 +430,7 @@ def main() -> None:
 
         if project_root is None:
             print(
-                "Error: could not auto-detect a project root "
+                "Error: --only-project-artifacts requires a resolvable project root "
                 "(.agentic-beacon/config.toml not found in current directory or any parent). "
                 "Pass --project-root <path> or --beacon-yaml <path> explicitly.",
                 file=sys.stderr,

--- a/libs/beacon/src/beacon/data/skills/contribute-warehouse/scripts/summarize_changes.py
+++ b/libs/beacon/src/beacon/data/skills/contribute-warehouse/scripts/summarize_changes.py
@@ -317,6 +317,23 @@ def _run_git_bytes(
     return result.returncode, result.stdout, result.stderr
 
 
+def _untracked_diff_stat(warehouse: Path, path: str) -> str:
+    """Synthesize a diff_stat for an untracked (``??``) file.
+
+    ``git diff --stat`` returns nothing for untracked files, so without this
+    the summarizer's triage output is degraded for the very entries PER-202
+    made first-class (brand-new artifacts not yet adopted by any project).
+    Mirror the shape of git's "1 file changed, N insertions(+)" summary.
+    """
+    full_path = warehouse / path
+    try:
+        with open(full_path, "rb") as f:
+            line_count = sum(1 for _ in f)
+    except OSError:
+        return "new file"
+    return f"new file, {line_count} insertion{'s' if line_count != 1 else ''}(+)"
+
+
 def summarize_all(warehouse: Path) -> dict:
     """Build the summary dict of every dirty path in the warehouse working tree."""
     try:
@@ -327,7 +344,13 @@ def summarize_all(warehouse: Path) -> dict:
 
     results = []
     for path, status in sorted(entries, key=lambda e: e[0]):
-        diff_stat = get_diff_stat(warehouse, path)
+        # Untracked files ('??') have no git-diff representation. Synthesize
+        # a line-count summary so the triage UI has something to show
+        # (PR#156 round 8).
+        if status.strip() == "??":
+            diff_stat = _untracked_diff_stat(warehouse, path)
+        else:
+            diff_stat = get_diff_stat(warehouse, path)
         age = get_last_commit_age_days(warehouse, path)
         results.append(
             {

--- a/libs/beacon/src/beacon/data/skills/contribute-warehouse/scripts/summarize_changes.py
+++ b/libs/beacon/src/beacon/data/skills/contribute-warehouse/scripts/summarize_changes.py
@@ -277,8 +277,10 @@ def enumerate_dirty_paths(warehouse: Path) -> list[tuple[str, str]]:
             continue
         code = line[:2]
         rest = line[3:]
-        # Rename / copy: 'R  old -> new' or 'C  old -> new'
-        if " -> " in rest:
+        # Rename / copy: 'R  old -> new' or 'C  old -> new'. Gate the split on
+        # the status code rather than the literal ' -> ' substring — a regular
+        # untracked filename can contain ' -> ' and must not be misparsed.
+        if code[0] in ("R", "C") and " -> " in rest:
             path = rest.split(" -> ", 1)[1]
         else:
             path = rest

--- a/libs/beacon/src/beacon/data/skills/contribute-warehouse/scripts/summarize_changes.py
+++ b/libs/beacon/src/beacon/data/skills/contribute-warehouse/scripts/summarize_changes.py
@@ -257,43 +257,64 @@ def classify_warehouse_area(path: str) -> str:
 def enumerate_dirty_paths(warehouse: Path) -> list[tuple[str, str]]:
     """Return [(path, status_code)] for every dirty path in the warehouse working tree.
 
-    Parses `git status --porcelain` directly — no beacon.yaml lookup, no project
-    context required. Handles renames by reporting the destination path. Skips
-    submodule directory entries (status starts with 'C ') and any path that
-    happens to fall under .git/.
+    Uses `git status --porcelain=v1 -z` so the parser is immune to:
+      * substring collisions on ` -> ` in regular filenames
+      * git's C-style quoting of paths containing spaces or special chars
+      * rename source paths that themselves contain ` -> `
+
+    The `-z` format emits NUL-delimited records with no escaping. A normal
+    entry is one record `XY <path>\\0`; rename / copy entries occupy two
+    records `XY <new>\\0<old>\\0`. We report the destination path for
+    rename/copy entries (the same convention as the human-readable format).
+
+    `--untracked-files=all` is required so a brand-new directory (e.g.
+    `skills/never-adopted/`) expands to its constituent files rather than
+    appearing as a single directory entry.
     """
-    # --untracked-files=all expands untracked directories to their constituent
-    # files; the default (--untracked-files=normal) reports only the directory
-    # name, which loses the path we need to commit.
-    rc, stdout, stderr = _run_git(
-        warehouse, ["status", "--porcelain", "--untracked-files=all"]
+    rc, stdout_bytes, stderr_bytes = _run_git_bytes(
+        warehouse, ["status", "--porcelain=v1", "-z", "--untracked-files=all"]
     )
     if rc != 0:
-        raise RuntimeError(f"git status failed in {warehouse}: {stderr.strip()}")
+        raise RuntimeError(
+            f"git status failed in {warehouse}: "
+            f"{stderr_bytes.decode('utf-8', errors='replace').strip()}"
+        )
+
+    # Split on NUL; trailing NUL produces an empty final record.
+    records = stdout_bytes.split(b"\0")
+    if records and records[-1] == b"":
+        records.pop()
 
     entries: list[tuple[str, str]] = []
-    for line in stdout.splitlines():
-        if len(line) < 4:
+    i = 0
+    while i < len(records):
+        rec = records[i]
+        if len(rec) < 3:
+            i += 1
             continue
-        code = line[:2]
-        rest = line[3:]
-        # Rename / copy: 'R  old -> new' or 'C  old -> new'. Gate the split on
-        # the status code rather than the literal ' -> ' substring — a regular
-        # untracked filename can contain ' -> ' and must not be misparsed.
-        if code[0] in ("R", "C") and " -> " in rest:
-            path = rest.split(" -> ", 1)[1]
+        code = rec[:2].decode("utf-8", errors="replace")
+        new_path = rec[3:].decode("utf-8", errors="replace")
+        if code[0] in ("R", "C") and i + 1 < len(records):
+            # Rename/copy: also consume the old-path record.
+            i += 2
         else:
-            path = rest
-        # Strip git's quoting of paths containing special characters
-        if path.startswith('"') and path.endswith('"'):
-            try:
-                path = path[1:-1].encode("utf-8").decode("unicode_escape")
-            except UnicodeDecodeError:
-                pass
-        if ".git" in Path(path).parts:
+            i += 1
+        if ".git" in Path(new_path).parts:
             continue
-        entries.append((path, code))
+        entries.append((new_path, code))
     return entries
+
+
+def _run_git_bytes(
+    warehouse: Path, args: list[str], timeout: int = 30
+) -> tuple[int, bytes, bytes]:
+    """Run a git command inside warehouse, return (rc, stdout_bytes, stderr_bytes)."""
+    result = subprocess.run(
+        ["git", "-C", str(warehouse)] + args,
+        capture_output=True,
+        timeout=timeout,
+    )
+    return result.returncode, result.stdout, result.stderr
 
 
 def summarize_all(warehouse: Path) -> dict:

--- a/libs/beacon/src/beacon/domains/warehouse/contribute.py
+++ b/libs/beacon/src/beacon/domains/warehouse/contribute.py
@@ -163,6 +163,20 @@ def _expand_rename_sources(warehouse_path: Path, user_paths: list[str]) -> list[
     return expanded
 
 
+def _literal_pathspec(path: str) -> str:
+    """Wrap ``path`` in git's ``:(literal)`` pathspec magic.
+
+    Without this, git interprets every CLI path argument as a pathspec —
+    so ``--paths '*.md'`` or ``--paths ':(glob)**/*.md'`` would expand to
+    multiple files even though the abc warehouse contribute CLI documents
+    ``--paths`` as a single warehouse-relative filename. The ``(literal)``
+    magic disables wildcards, attr matchers, and the rest of the pathspec
+    DSL, so a glob argument either matches an actual file with that exact
+    name or fails the dirty-check (PR#156 round 6).
+    """
+    return f":(literal){path}"
+
+
 def _validate_dirty(warehouse_path: Path, candidate_paths: list[str]) -> None:
     """Raise ValueError if any candidate path has no porcelain status.
 
@@ -173,7 +187,9 @@ def _validate_dirty(warehouse_path: Path, candidate_paths: list[str]) -> None:
     """
     not_dirty: list[str] = []
     for p in candidate_paths:
-        status = _run_git(warehouse_path, ["status", "--porcelain", "--", p])
+        status = _run_git(
+            warehouse_path, ["status", "--porcelain", "--", _literal_pathspec(p)]
+        )
         if status.returncode != 0 or not status.stdout.strip():
             not_dirty.append(p)
     if not_dirty:
@@ -291,9 +307,16 @@ def contribute(
                 status="committed", committed_sha=committed_sha, message=message
             )
 
+    # Wrap every commit path in :(literal) magic before handing to git, so a
+    # user passing `--paths '*.md'` or any other pathspec wildcard cannot
+    # match additional files (PR#156 round 6). Pathspecs that originate from
+    # beacon.yaml expansion in only_tracked mode are already literal filenames
+    # but get the same treatment for uniformity / defense-in-depth.
+    git_pathspecs = [_literal_pathspec(p) for p in commit_paths]
+
     # Check git status for the paths we intend to commit
     status_result = _run_git(
-        warehouse_path, ["status", "--porcelain", "--", *commit_paths]
+        warehouse_path, ["status", "--porcelain", "--", *git_pathspecs]
     )
     if not status_result.stdout.strip():
         if only_tracked:
@@ -308,11 +331,11 @@ def contribute(
         return ContributeResult(status="no_changes")
 
     # Stage the paths we intend to commit
-    _run_git(warehouse_path, ["add", "--", *commit_paths])
+    _run_git(warehouse_path, ["add", "--", *git_pathspecs])
 
     # Commit
     commit_result = _run_git(
-        warehouse_path, ["commit", "-m", message, "--", *commit_paths]
+        warehouse_path, ["commit", "-m", message, "--", *git_pathspecs]
     )
     if commit_result.returncode != 0:
         logger.error("Git commit failed: {}", commit_result.stderr)

--- a/libs/beacon/src/beacon/domains/warehouse/contribute.py
+++ b/libs/beacon/src/beacon/domains/warehouse/contribute.py
@@ -1,7 +1,10 @@
 """Warehouse contribute domain logic.
 
-Encapsulates git add + git commit inside the warehouse clone,
-driven by a project's .agentic-beacon/config.toml and beacon.yaml.
+Encapsulates git add + git commit inside the warehouse clone. By default
+(PER-203), accepts any dirty path in the warehouse working tree — the
+invariant is "is this a real dirty warehouse path?", not "is this in the
+invoking project's beacon.yaml?". Pass ``only_tracked=True`` to restore the
+legacy beacon.yaml-filtered behavior.
 """
 
 import subprocess
@@ -52,28 +55,86 @@ def _count_dirty_outside_scope(warehouse_path: Path, tracked: list[str]) -> int:
     return max(0, total_lines - filtered_lines)
 
 
+def _all_dirty_paths(warehouse_path: Path) -> list[str]:
+    """Return every dirty path in the warehouse working tree.
+
+    Parses ``git status --porcelain`` directly. Handles renames by emitting the
+    destination path. Skips entries under ``.git/``.
+
+    ``--untracked-files=all`` is required so that a brand-new directory (e.g.
+    ``skills/never-adopted/``) expands to its constituent files rather than
+    appearing as a single directory entry.
+    """
+    full = _run_git(warehouse_path, ["status", "--porcelain", "--untracked-files=all"])
+    if full.returncode != 0:
+        return []
+    paths: list[str] = []
+    for line in full.stdout.splitlines():
+        if len(line) < 4:
+            continue
+        rest = line[3:]
+        if " -> " in rest:
+            path = rest.split(" -> ", 1)[1]
+        else:
+            path = rest
+        if path.startswith('"') and path.endswith('"'):
+            try:
+                path = path[1:-1].encode("utf-8").decode("unicode_escape")
+            except UnicodeDecodeError:
+                pass
+        if ".git" in Path(path).parts:
+            continue
+        paths.append(path)
+    return paths
+
+
+def _validate_dirty(warehouse_path: Path, candidate_paths: list[str]) -> None:
+    """Raise ValueError if any candidate path has no porcelain status.
+
+    A path is acceptable when ``git status --porcelain -- <path>`` returns a
+    non-empty line. This covers modified (M), added (A), untracked (??),
+    deleted (D), renamed (R), and copied (C) — i.e. anything dirty in the
+    warehouse working tree.
+    """
+    not_dirty: list[str] = []
+    for p in candidate_paths:
+        status = _run_git(warehouse_path, ["status", "--porcelain", "--", p])
+        if status.returncode != 0 or not status.stdout.strip():
+            not_dirty.append(p)
+    if not_dirty:
+        raise ValueError(
+            "The following paths are not dirty in the warehouse working tree "
+            "(no uncommitted change) and cannot be committed: "
+            f"{', '.join(repr(p) for p in not_dirty)}"
+        )
+
+
 def contribute(
     project_root: Path,
     *,
     message: str,
     push: bool = False,
     paths: tuple[str, ...] | None = None,
+    only_tracked: bool = False,
 ) -> ContributeResult:
     """Contribute local changes to the warehouse.
 
-    Stages and commits files tracked by beacon.yaml that have uncommitted
-    changes in the warehouse working tree.
+    Stages and commits dirty paths in the warehouse working tree.
 
     Args:
-        project_root: Path to the project root.
+        project_root: Path to the project root (used to resolve the connected
+            warehouse via ``.agentic-beacon/config.toml``).
         message: Commit message (must be non-empty).
         push: Whether to push after committing.
         paths: Optional tuple of warehouse-relative paths to restrict the commit
-            to. When None (the default), all beacon.yaml-tracked dirty paths are
-            committed (existing behaviour). When provided, every path must be a
-            member of the beacon.yaml-tracked set; paths outside that set raise
-            ValueError. An empty tuple is rejected — omit the argument to commit
-            all tracked paths.
+            to. When None (the default), every dirty path in the warehouse
+            working tree is committed.
+        only_tracked: When True, restore the legacy project-scoped invariant —
+            commits are restricted to paths declared in the invoking project's
+            ``beacon.yaml`` and out-of-scope paths in ``paths`` raise
+            ValueError. When False (the default, PER-203), any dirty warehouse
+            path is acceptable, including brand-new artifacts and cross-project
+            knowledge that no ``beacon.yaml`` lists.
 
     Returns:
         ContributeResult indicating the outcome.
@@ -83,47 +144,64 @@ def contribute(
 
     if paths is not None and len(paths) == 0:
         raise ValueError(
-            "--paths must not be empty when provided; omit the flag to commit all tracked paths"
+            "--paths must not be empty when provided; omit the flag to commit all dirty paths"
         )
 
     warehouse_path, _ = ensure_sync_ready(project_root)
 
-    beacon_yaml = project_root / ".agentic-beacon" / "beacon.yaml"
-    tracked_paths = get_tracked_paths(warehouse_path, beacon_yaml)
+    if only_tracked:
+        beacon_yaml = project_root / ".agentic-beacon" / "beacon.yaml"
+        tracked_paths = get_tracked_paths(warehouse_path, beacon_yaml)
 
-    if paths is not None:
-        normalized_paths = [normalize_relative_path(p) for p in paths]
-        tracked_set = set(tracked_paths)
-        untracked = [p for p in normalized_paths if p not in tracked_set]
-        if untracked:
-            raise ValueError(
-                f"The following paths are not tracked by beacon.yaml and cannot be committed: "
-                f"{', '.join(repr(p) for p in untracked)}"
+        if paths is not None:
+            normalized_paths = [normalize_relative_path(p) for p in paths]
+            tracked_set = set(tracked_paths)
+            untracked = [p for p in normalized_paths if p not in tracked_set]
+            if untracked:
+                raise ValueError(
+                    "The following paths are not tracked by beacon.yaml and cannot be committed: "
+                    f"{', '.join(repr(p) for p in untracked)}"
+                )
+            commit_paths = normalized_paths
+        else:
+            commit_paths = tracked_paths
+
+        if not commit_paths:
+            count = (
+                _count_dirty_outside_scope(warehouse_path, tracked_paths)
+                if paths is None
+                else 0
             )
-        # Use the caller-supplied paths (preserving their order), scoped within tracked_paths
-        commit_paths = normalized_paths
+            return ContributeResult(
+                status="no_changes", dirty_outside_scope_count=count
+            )
     else:
-        commit_paths = tracked_paths
+        # PER-203 default: warehouse-scoped — accept any dirty warehouse path.
+        if paths is not None:
+            normalized_paths = [normalize_relative_path(p) for p in paths]
+            _validate_dirty(warehouse_path, normalized_paths)
+            commit_paths = normalized_paths
+        else:
+            commit_paths = _all_dirty_paths(warehouse_path)
 
-    if not commit_paths:
-        count = (
-            _count_dirty_outside_scope(warehouse_path, tracked_paths)
-            if paths is None
-            else 0
-        )
-        return ContributeResult(status="no_changes", dirty_outside_scope_count=count)
+        if not commit_paths:
+            return ContributeResult(status="no_changes")
 
     # Check git status for the paths we intend to commit
     status_result = _run_git(
         warehouse_path, ["status", "--porcelain", "--", *commit_paths]
     )
     if not status_result.stdout.strip():
-        count = (
-            _count_dirty_outside_scope(warehouse_path, tracked_paths)
-            if paths is None
-            else 0
-        )
-        return ContributeResult(status="no_changes", dirty_outside_scope_count=count)
+        if only_tracked:
+            count = (
+                _count_dirty_outside_scope(warehouse_path, tracked_paths)
+                if paths is None
+                else 0
+            )
+            return ContributeResult(
+                status="no_changes", dirty_outside_scope_count=count
+            )
+        return ContributeResult(status="no_changes")
 
     # Stage the paths we intend to commit
     _run_git(warehouse_path, ["add", "--", *commit_paths])

--- a/libs/beacon/src/beacon/domains/warehouse/contribute.py
+++ b/libs/beacon/src/beacon/domains/warehouse/contribute.py
@@ -68,6 +68,63 @@ def _has_any_dirty_path(warehouse_path: Path) -> bool:
     return any(line.strip() for line in full.stdout.splitlines())
 
 
+def _expand_rename_sources(warehouse_path: Path, user_paths: list[str]) -> list[str]:
+    """For each user path that is the destination of a rename or copy, also
+    include the source path in the returned list.
+
+    Porcelain reports renames as ``R  old -> new`` and copies as ``C  old ->
+    new``. When the caller asks to commit only ``new``, git would commit the
+    new file but leave the old-side deletion staged. Including both sides in
+    the pathspec keeps the commit atomic.
+
+    The source path appears immediately after its destination in the returned
+    list to keep ordering predictable. Duplicate sources (when multiple
+    destinations map to the same source — unusual but valid for copies) are
+    only added once.
+    """
+    rc, stdout, _ = _run_git_inner(
+        warehouse_path, ["status", "--porcelain", "--untracked-files=all"]
+    )
+    if rc != 0:
+        return user_paths
+
+    rename_sources_by_dest: dict[str, str] = {}
+    for line in stdout.splitlines():
+        if len(line) < 4:
+            continue
+        code = line[:2]
+        rest = line[3:]
+        # Gate the ' -> ' split on R/C status codes (PR#156 M2 lesson).
+        if code[0] in ("R", "C") and " -> " in rest:
+            src, dst = rest.split(" -> ", 1)
+            rename_sources_by_dest[dst] = src
+
+    expanded: list[str] = []
+    seen: set[str] = set()
+    for p in user_paths:
+        if p not in seen:
+            expanded.append(p)
+            seen.add(p)
+        src = rename_sources_by_dest.get(p)
+        if src and src not in seen:
+            expanded.append(src)
+            seen.add(src)
+    return expanded
+
+
+def _run_git_inner(
+    warehouse_path: Path, args: list[str], timeout: int = 30
+) -> tuple[int, str, str]:
+    """Internal git runner returning a (rc, stdout, stderr) tuple."""
+    result = subprocess.run(
+        ["git", "-C", str(warehouse_path), *args],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+    return result.returncode, result.stdout, result.stderr
+
+
 def _validate_dirty(warehouse_path: Path, candidate_paths: list[str]) -> None:
     """Raise ValueError if any candidate path has no porcelain status.
 
@@ -160,7 +217,11 @@ def contribute(
         if paths is not None:
             normalized_paths = [normalize_relative_path(p) for p in paths]
             _validate_dirty(warehouse_path, normalized_paths)
-            commit_paths = normalized_paths
+            # If any user path is the destination of a rename, transparently
+            # include the source so the commit captures both sides (PR#156
+            # round-2 review). Without this, `git commit -- dest` would
+            # commit the new file but leave the old-side deletion staged.
+            commit_paths = _expand_rename_sources(warehouse_path, normalized_paths)
         else:
             # paths=None: commit the entire working tree. We deliberately do
             # NOT enumerate-then-restrict here — `git add -A` + an unrestricted

--- a/libs/beacon/src/beacon/domains/warehouse/contribute.py
+++ b/libs/beacon/src/beacon/domains/warehouse/contribute.py
@@ -68,54 +68,82 @@ def _has_any_dirty_path(warehouse_path: Path) -> bool:
     return any(line.strip() for line in full.stdout.splitlines())
 
 
-def _unquote_porcelain_path(path: str) -> str:
-    """Unquote a ``git status --porcelain`` path.
+def _parse_porcelain_z(stdout_bytes: bytes) -> list[tuple[str, str, str | None]]:
+    """Parse ``git status --porcelain=v1 -z`` output.
 
-    Git wraps paths containing whitespace, control chars, or non-ASCII in
-    double quotes and C-escapes the contents. Unwrap them so dict keys match
-    user-supplied (unquoted) ``--paths`` arguments. Plain ASCII paths pass
-    through unchanged.
+    The ``-z`` format emits NUL-delimited records with no quoting or escaping.
+    Each normal entry is one record ``XY <path>\\0``. Rename and copy entries
+    occupy *two* records: ``XY <new-path>\\0<old-path>\\0``. The XY status
+    code is the first two bytes; byte 2 is a space; the path starts at byte 3.
+
+    Returns ``(code, new_path, old_path)`` tuples. ``old_path`` is ``None``
+    for non-R/C entries.
+
+    Using ``-z`` sidesteps every variant of the string-split parsing bug:
+    substring ``' -> '`` in untracked filenames, C-quoted paths with spaces
+    or special chars, and rename source paths that themselves contain
+    ``' -> '`` (PR#156 review rounds 1-4).
     """
-    if path.startswith('"') and path.endswith('"'):
-        try:
-            return path[1:-1].encode("utf-8").decode("unicode_escape")
-        except UnicodeDecodeError:
-            return path
-    return path
+    records = stdout_bytes.split(b"\0")
+    # The terminating NUL produces an empty trailing record.
+    if records and records[-1] == b"":
+        records.pop()
+
+    result: list[tuple[str, str, str | None]] = []
+    i = 0
+    while i < len(records):
+        rec = records[i]
+        if len(rec) < 3:
+            i += 1
+            continue
+        code = rec[:2].decode("utf-8", errors="replace")
+        new_path = rec[3:].decode("utf-8", errors="replace")
+        if code[0] in ("R", "C") and i + 1 < len(records):
+            old_path = records[i + 1].decode("utf-8", errors="replace")
+            result.append((code, new_path, old_path))
+            i += 2
+        else:
+            result.append((code, new_path, None))
+            i += 1
+    return result
+
+
+def _run_git_bytes(
+    warehouse_path: Path, args: list[str], timeout: int = 30
+) -> tuple[int, bytes, bytes]:
+    """Internal git runner returning raw bytes (required for ``-z`` parsing)."""
+    result = subprocess.run(
+        ["git", "-C", str(warehouse_path), *args],
+        capture_output=True,
+        timeout=timeout,
+    )
+    return result.returncode, result.stdout, result.stderr
 
 
 def _expand_rename_sources(warehouse_path: Path, user_paths: list[str]) -> list[str]:
     """For each user path that is the destination of a rename or copy, also
     include the source path in the returned list.
 
-    Porcelain reports renames as ``R  old -> new`` and copies as ``C  old ->
-    new``. When the caller asks to commit only ``new``, git would commit the
-    new file but leave the old-side deletion staged. Including both sides in
-    the pathspec keeps the commit atomic.
+    Uses ``git status --porcelain=v1 -z`` so the parser is immune to:
+      * substring collisions on ``' -> '`` in regular filenames
+      * git's C-style quoting of paths containing spaces or special chars
+      * rename source paths that themselves contain ``' -> '``
 
     The source path appears immediately after its destination in the returned
-    list to keep ordering predictable. Duplicate sources (when multiple
-    destinations map to the same source — unusual but valid for copies) are
-    only added once.
+    list. Duplicate sources (when multiple destinations map to the same source
+    — unusual but valid for copies) are only added once.
     """
-    rc, stdout, _ = _run_git_inner(
-        warehouse_path, ["status", "--porcelain", "--untracked-files=all"]
+    rc, stdout, _ = _run_git_bytes(
+        warehouse_path,
+        ["status", "--porcelain=v1", "-z", "--untracked-files=all"],
     )
     if rc != 0:
         return user_paths
 
     rename_sources_by_dest: dict[str, str] = {}
-    for line in stdout.splitlines():
-        if len(line) < 4:
-            continue
-        code = line[:2]
-        rest = line[3:]
-        # Gate the ' -> ' split on R/C status codes (PR#156 M2 lesson).
-        if code[0] in ("R", "C") and " -> " in rest:
-            src, dst = rest.split(" -> ", 1)
-            rename_sources_by_dest[_unquote_porcelain_path(dst)] = (
-                _unquote_porcelain_path(src)
-            )
+    for code, new_path, old_path in _parse_porcelain_z(stdout):
+        if code[0] in ("R", "C") and old_path is not None:
+            rename_sources_by_dest[new_path] = old_path
 
     expanded: list[str] = []
     seen: set[str] = set()
@@ -128,19 +156,6 @@ def _expand_rename_sources(warehouse_path: Path, user_paths: list[str]) -> list[
             expanded.append(src)
             seen.add(src)
     return expanded
-
-
-def _run_git_inner(
-    warehouse_path: Path, args: list[str], timeout: int = 30
-) -> tuple[int, str, str]:
-    """Internal git runner returning a (rc, stdout, stderr) tuple."""
-    result = subprocess.run(
-        ["git", "-C", str(warehouse_path), *args],
-        capture_output=True,
-        text=True,
-        timeout=timeout,
-    )
-    return result.returncode, result.stdout, result.stderr
 
 
 def _validate_dirty(warehouse_path: Path, candidate_paths: list[str]) -> None:

--- a/libs/beacon/src/beacon/domains/warehouse/contribute.py
+++ b/libs/beacon/src/beacon/domains/warehouse/contribute.py
@@ -55,37 +55,17 @@ def _count_dirty_outside_scope(warehouse_path: Path, tracked: list[str]) -> int:
     return max(0, total_lines - filtered_lines)
 
 
-def _all_dirty_paths(warehouse_path: Path) -> list[str]:
-    """Return every dirty path in the warehouse working tree.
+def _has_any_dirty_path(warehouse_path: Path) -> bool:
+    """Return True iff the warehouse working tree contains at least one dirty path.
 
-    Parses ``git status --porcelain`` directly. Handles renames by emitting the
-    destination path. Skips entries under ``.git/``.
-
-    ``--untracked-files=all`` is required so that a brand-new directory (e.g.
-    ``skills/never-adopted/``) expands to its constituent files rather than
-    appearing as a single directory entry.
+    Used as a non-empty-changes gate for the default-mode commit. The actual
+    staging path uses ``git add -A`` directly, so we no longer need to
+    enumerate or parse porcelain entries here.
     """
     full = _run_git(warehouse_path, ["status", "--porcelain", "--untracked-files=all"])
     if full.returncode != 0:
-        return []
-    paths: list[str] = []
-    for line in full.stdout.splitlines():
-        if len(line) < 4:
-            continue
-        rest = line[3:]
-        if " -> " in rest:
-            path = rest.split(" -> ", 1)[1]
-        else:
-            path = rest
-        if path.startswith('"') and path.endswith('"'):
-            try:
-                path = path[1:-1].encode("utf-8").decode("unicode_escape")
-            except UnicodeDecodeError:
-                pass
-        if ".git" in Path(path).parts:
-            continue
-        paths.append(path)
-    return paths
+        return False
+    return any(line.strip() for line in full.stdout.splitlines())
 
 
 def _validate_dirty(warehouse_path: Path, candidate_paths: list[str]) -> None:
@@ -182,10 +162,35 @@ def contribute(
             _validate_dirty(warehouse_path, normalized_paths)
             commit_paths = normalized_paths
         else:
-            commit_paths = _all_dirty_paths(warehouse_path)
-
-        if not commit_paths:
-            return ContributeResult(status="no_changes")
+            # paths=None: commit the entire working tree. We deliberately do
+            # NOT enumerate-then-restrict here — `git add -A` + an unrestricted
+            # commit handles renames (R old -> new) and deletions correctly,
+            # whereas an explicit pathspec list silently drops one side of a
+            # rename and is fragile against unusual filenames.
+            if not _has_any_dirty_path(warehouse_path):
+                return ContributeResult(status="no_changes")
+            _run_git(warehouse_path, ["add", "-A"])
+            commit_result = _run_git(warehouse_path, ["commit", "-m", message])
+            if commit_result.returncode != 0:
+                logger.error("Git commit failed: {}", commit_result.stderr)
+                raise RuntimeError(
+                    f"Git commit failed in warehouse: {commit_result.stderr.strip()}"
+                )
+            sha_result = _run_git(warehouse_path, ["rev-parse", "HEAD"])
+            committed_sha = (
+                sha_result.stdout.strip() if sha_result.returncode == 0 else None
+            )
+            if push:
+                push_result = _run_git(warehouse_path, ["push"])
+                if push_result.returncode != 0:
+                    return ContributeResult(
+                        status="push_failed",
+                        committed_sha=committed_sha,
+                        message=push_result.stderr,
+                    )
+            return ContributeResult(
+                status="committed", committed_sha=committed_sha, message=message
+            )
 
     # Check git status for the paths we intend to commit
     status_result = _run_git(

--- a/libs/beacon/src/beacon/domains/warehouse/contribute.py
+++ b/libs/beacon/src/beacon/domains/warehouse/contribute.py
@@ -140,10 +140,15 @@ def _expand_rename_sources(warehouse_path: Path, user_paths: list[str]) -> list[
     if rc != 0:
         return user_paths
 
-    rename_sources_by_dest: dict[str, str] = {}
+    # Bidirectional rename map: passing EITHER side of a rename in --paths
+    # must pull in the OTHER side so the commit is atomic. Without the
+    # source -> dest direction, --paths <old-path> would commit only the
+    # deletion and leave the new file staged (PR#156 round 5).
+    rename_counterpart: dict[str, str] = {}
     for code, new_path, old_path in _parse_porcelain_z(stdout):
         if code[0] in ("R", "C") and old_path is not None:
-            rename_sources_by_dest[new_path] = old_path
+            rename_counterpart[new_path] = old_path
+            rename_counterpart[old_path] = new_path
 
     expanded: list[str] = []
     seen: set[str] = set()
@@ -151,10 +156,10 @@ def _expand_rename_sources(warehouse_path: Path, user_paths: list[str]) -> list[
         if p not in seen:
             expanded.append(p)
             seen.add(p)
-        src = rename_sources_by_dest.get(p)
-        if src and src not in seen:
-            expanded.append(src)
-            seen.add(src)
+        counterpart = rename_counterpart.get(p)
+        if counterpart and counterpart not in seen:
+            expanded.append(counterpart)
+            seen.add(counterpart)
     return expanded
 
 

--- a/libs/beacon/src/beacon/domains/warehouse/contribute.py
+++ b/libs/beacon/src/beacon/domains/warehouse/contribute.py
@@ -68,6 +68,22 @@ def _has_any_dirty_path(warehouse_path: Path) -> bool:
     return any(line.strip() for line in full.stdout.splitlines())
 
 
+def _unquote_porcelain_path(path: str) -> str:
+    """Unquote a ``git status --porcelain`` path.
+
+    Git wraps paths containing whitespace, control chars, or non-ASCII in
+    double quotes and C-escapes the contents. Unwrap them so dict keys match
+    user-supplied (unquoted) ``--paths`` arguments. Plain ASCII paths pass
+    through unchanged.
+    """
+    if path.startswith('"') and path.endswith('"'):
+        try:
+            return path[1:-1].encode("utf-8").decode("unicode_escape")
+        except UnicodeDecodeError:
+            return path
+    return path
+
+
 def _expand_rename_sources(warehouse_path: Path, user_paths: list[str]) -> list[str]:
     """For each user path that is the destination of a rename or copy, also
     include the source path in the returned list.
@@ -97,7 +113,9 @@ def _expand_rename_sources(warehouse_path: Path, user_paths: list[str]) -> list[
         # Gate the ' -> ' split on R/C status codes (PR#156 M2 lesson).
         if code[0] in ("R", "C") and " -> " in rest:
             src, dst = rest.split(" -> ", 1)
-            rename_sources_by_dest[dst] = src
+            rename_sources_by_dest[_unquote_porcelain_path(dst)] = (
+                _unquote_porcelain_path(src)
+            )
 
     expanded: list[str] = []
     seen: set[str] = set()

--- a/libs/beacon/src/beacon/domains/warehouse/contribute.py
+++ b/libs/beacon/src/beacon/domains/warehouse/contribute.py
@@ -284,7 +284,12 @@ def contribute(
             # rename and is fragile against unusual filenames.
             if not _has_any_dirty_path(warehouse_path):
                 return ContributeResult(status="no_changes")
-            _run_git(warehouse_path, ["add", "-A"])
+            add_result = _run_git(warehouse_path, ["add", "-A"])
+            if add_result.returncode != 0:
+                logger.error("Git add -A failed: {}", add_result.stderr)
+                raise RuntimeError(
+                    f"Git add -A failed in warehouse: {add_result.stderr.strip()}"
+                )
             commit_result = _run_git(warehouse_path, ["commit", "-m", message])
             if commit_result.returncode != 0:
                 logger.error("Git commit failed: {}", commit_result.stderr)

--- a/libs/beacon/src/beacon/utils/paths.py
+++ b/libs/beacon/src/beacon/utils/paths.py
@@ -11,10 +11,16 @@ def normalize_relative_path(path: str) -> str:
     * Removes leading './' segments.
     * Collapses redundant separators (e.g. 'skills//foo' -> 'skills/foo').
     * Rejects absolute paths and parent-directory traversal.
+    * Rejects empty strings and bare ``.`` / ``./`` so a caller cannot pass
+      an empty path that normalizes to ``.`` and is later interpreted as
+      "the entire warehouse" by git (PR#156 round 8).
 
     Raises:
-        ValueError: if the path is absolute or contains a '..' component.
+        ValueError: if the path is absolute, contains a '..' component, or
+            normalizes to an empty / current-directory reference.
     """
+    if not path or not path.strip():
+        raise ValueError(f"Empty path is not allowed: {path!r}")
     p = Path(path)
     if p.is_absolute():
         raise ValueError(f"Absolute paths are not allowed: {path!r}")
@@ -25,4 +31,9 @@ def normalize_relative_path(path: str) -> str:
     normalized = os.path.normpath(path)
     # Ensure POSIX-style forward slashes for cross-platform consistency
     normalized = normalized.replace(os.sep, "/")
+    if normalized in ("", "."):
+        raise ValueError(
+            f"Path normalizes to the warehouse root ({normalized!r}); "
+            f"pass a specific file path or omit --paths to commit everything: {path!r}"
+        )
     return normalized

--- a/libs/beacon/tests/unit/data/skills/contribute_warehouse/test_summarize_changes.py
+++ b/libs/beacon/tests/unit/data/skills/contribute_warehouse/test_summarize_changes.py
@@ -1073,6 +1073,51 @@ class TestWarehouseScopedDefault:
             f"Rename should appear with destination path. Got: {paths}"
         )
 
+    def test_summarize_all_untracked_file_has_synthetic_diff_stat(self, tmp_path):
+        """Brand-new untracked files get a synthesized 'new file, N insertions' stat.
+
+        Regression for opencode-review PR#156 round 8: PER-202 made
+        untracked files a default summarizer case, but git diff --stat
+        returns nothing for ?? entries. The triage UI now gets a
+        line-count summary instead of an empty string.
+        """
+        warehouse = _make_git_warehouse(tmp_path)
+        subprocess.run(
+            ["git", "-C", str(warehouse), "commit", "--allow-empty", "-m", "init"],
+            check=True,
+            capture_output=True,
+        )
+        new_file = warehouse / "knowledge" / "fresh.md"
+        new_file.parent.mkdir(exist_ok=True)
+        new_file.write_text("line 1\nline 2\nline 3\n")
+
+        mod = _load_script()
+        result = mod.summarize_all(warehouse)
+        entries = {e["path"]: e for e in result["tracked_paths"]}
+        assert "knowledge/fresh.md" in entries
+        stat = entries["knowledge/fresh.md"]["diff_stat"]
+        # Should NOT be empty (regression).
+        assert stat, f"Untracked file must have a synthesized diff_stat, got: {stat!r}"
+        assert "new file" in stat
+        assert "3" in stat  # line count
+
+    def test_summarize_all_single_line_untracked_uses_singular(self, tmp_path):
+        """One-line untracked file pluralization is correct."""
+        warehouse = _make_git_warehouse(tmp_path)
+        subprocess.run(
+            ["git", "-C", str(warehouse), "commit", "--allow-empty", "-m", "init"],
+            check=True,
+            capture_output=True,
+        )
+        one_liner = warehouse / "notes.md"
+        one_liner.write_text("just one line\n")
+
+        mod = _load_script()
+        result = mod.summarize_all(warehouse)
+        entries = {e["path"]: e for e in result["tracked_paths"]}
+        assert "notes.md" in entries
+        assert "1 insertion(+)" in entries["notes.md"]["diff_stat"]
+
     def test_summarize_all_skips_dot_git_entries(self, tmp_path):
         """Anything under .git/ is never reported."""
         warehouse = _make_git_warehouse(tmp_path)

--- a/libs/beacon/tests/unit/data/skills/contribute_warehouse/test_summarize_changes.py
+++ b/libs/beacon/tests/unit/data/skills/contribute_warehouse/test_summarize_changes.py
@@ -350,7 +350,12 @@ class TestFilterCleanPaths:
 
 
 class TestBeaconYamlDefault:
-    """Tests for Finding 2 fix: beacon.yaml resolution uses project root, not warehouse."""
+    """Project-root resolution helpers used by the --only-project-artifacts opt-in.
+
+    PER-202 made the default warehouse-scoped (see TestWarehouseScopedDefault),
+    but the legacy beacon.yaml-filtered path still depends on these helpers to
+    locate the invoking project's beacon.yaml.
+    """
 
     def _make_project_with_beacon_yaml(
         self, tmp_path: Path, patterns: list[str]
@@ -843,3 +848,162 @@ class TestPer183AgentsAreTracked:
         mod = _load_script()
         result = mod.summarize(warehouse, beacon_yaml)
         assert any(e["path"] == "contexts/c1.md" for e in result["tracked_paths"])
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# PER-202: warehouse-scoped enumeration is the new default
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestWarehouseScopedDefault:
+    """PER-202: default mode enumerates every dirty warehouse path with no project context.
+
+    The skill must work from any CWD, including a directory with no
+    ``.agentic-beacon/config.toml`` and against warehouses with no
+    ``beacon.yaml`` anywhere.
+    """
+
+    def test_summarize_all_returns_dirty_path_with_no_beacon_yaml(self, tmp_path):
+        """No beacon.yaml anywhere → dirty path still appears."""
+        warehouse = _make_git_warehouse(tmp_path)
+        ctx_file = warehouse / "contexts" / "python-standards.md"
+        ctx_file.write_text("# Python Standards\n")
+        _initial_commit(warehouse, [ctx_file])
+        ctx_file.write_text("# Python Standards\nmodified\n")
+
+        mod = _load_script()
+        result = mod.summarize_all(warehouse)
+        paths = [e["path"] for e in result["tracked_paths"]]
+        assert "contexts/python-standards.md" in paths
+
+    def test_summarize_all_includes_brand_new_untracked_skill(self, tmp_path):
+        """Untracked file under skills/never-adopted/ appears in tracked_paths."""
+        warehouse = _make_git_warehouse(tmp_path)
+        # Initial empty commit so HEAD exists
+        subprocess.run(
+            ["git", "-C", str(warehouse), "commit", "--allow-empty", "-m", "init"],
+            check=True,
+            capture_output=True,
+        )
+        skill_dir = warehouse / "skills" / "never-adopted"
+        skill_dir.mkdir(parents=True)
+        skill_file = skill_dir / "SKILL.md"
+        skill_file.write_text("---\nname: never-adopted\n---\nhello\n")
+
+        mod = _load_script()
+        result = mod.summarize_all(warehouse)
+        paths = [e["path"] for e in result["tracked_paths"]]
+        assert "skills/never-adopted/SKILL.md" in paths, (
+            f"PER-202: brand-new untracked skill should appear. Got: {paths}"
+        )
+        entry = next(
+            e
+            for e in result["tracked_paths"]
+            if e["path"] == "skills/never-adopted/SKILL.md"
+        )
+        assert entry["git_status"].strip() == "??"
+        assert entry["warehouse_area"] == "skills"
+
+    def test_summarize_all_classifies_warehouse_area(self, tmp_path):
+        """warehouse_area is derived from the top-level directory."""
+        warehouse = _make_git_warehouse(tmp_path)
+        subprocess.run(
+            ["git", "-C", str(warehouse), "commit", "--allow-empty", "-m", "init"],
+            check=True,
+            capture_output=True,
+        )
+        # Create one dirty file in each known area + one in "other"
+        (warehouse / "contexts").mkdir(exist_ok=True)
+        (warehouse / "knowledge").mkdir(exist_ok=True)
+        (warehouse / "skills" / "s").mkdir(parents=True, exist_ok=True)
+        (warehouse / "agents").mkdir(exist_ok=True)
+        (warehouse / "docs").mkdir(exist_ok=True)
+
+        (warehouse / "contexts" / "c.md").write_text("c\n")
+        (warehouse / "knowledge" / "k.md").write_text("k\n")
+        (warehouse / "skills" / "s" / "SKILL.md").write_text("s\n")
+        (warehouse / "agents" / "a.md").write_text("a\n")
+        (warehouse / "docs" / "d.md").write_text("d\n")
+
+        mod = _load_script()
+        result = mod.summarize_all(warehouse)
+        by_path = {e["path"]: e["warehouse_area"] for e in result["tracked_paths"]}
+        assert by_path.get("contexts/c.md") == "contexts"
+        assert by_path.get("knowledge/k.md") == "knowledge"
+        assert by_path.get("skills/s/SKILL.md") == "skills"
+        assert by_path.get("agents/a.md") == "agents"
+        assert by_path.get("docs/d.md") == "other"
+
+    def test_summarize_all_excludes_clean_files(self, tmp_path):
+        """Committed-and-untouched files do not appear."""
+        warehouse = _make_git_warehouse(tmp_path)
+        ctx_file = warehouse / "contexts" / "clean.md"
+        ctx_file.write_text("# clean\n")
+        _initial_commit(warehouse, [ctx_file])
+
+        mod = _load_script()
+        result = mod.summarize_all(warehouse)
+        paths = [e["path"] for e in result["tracked_paths"]]
+        assert "contexts/clean.md" not in paths
+        assert paths == []
+
+    def test_summarize_all_includes_deleted_file(self, tmp_path):
+        """Unstaged deletion appears with a D status (PER-186 regression in new path)."""
+        warehouse = _make_git_warehouse(tmp_path)
+        ctx_file = warehouse / "contexts" / "to-delete.md"
+        ctx_file.write_text("# delete me\n")
+        _initial_commit(warehouse, [ctx_file])
+        ctx_file.unlink()
+
+        mod = _load_script()
+        result = mod.summarize_all(warehouse)
+        entries = {e["path"]: e for e in result["tracked_paths"]}
+        assert "contexts/to-delete.md" in entries
+        assert "D" in entries["contexts/to-delete.md"]["git_status"]
+
+    def test_classify_warehouse_area_helper(self):
+        """classify_warehouse_area maps top-level directory to area string."""
+        mod = _load_script()
+        assert mod.classify_warehouse_area("contexts/foo.md") == "contexts"
+        assert mod.classify_warehouse_area("knowledge/python/lesson.md") == "knowledge"
+        assert mod.classify_warehouse_area("skills/foo/SKILL.md") == "skills"
+        assert mod.classify_warehouse_area("agents/foo.md") == "agents"
+        assert mod.classify_warehouse_area("docs/README.md") == "other"
+        assert mod.classify_warehouse_area("") == "other"
+
+    def test_summarize_all_no_project_context_required(self, tmp_path, monkeypatch):
+        """Invocation from a CWD with no .agentic-beacon/config.toml succeeds."""
+        warehouse = _make_git_warehouse(tmp_path)
+        ctx_file = warehouse / "contexts" / "f.md"
+        ctx_file.write_text("# f\n")
+        _initial_commit(warehouse, [ctx_file])
+        ctx_file.write_text("# f modified\n")
+
+        # CWD is a bare directory with no beacon config in the tree
+        bare = tmp_path / "elsewhere"
+        bare.mkdir()
+        monkeypatch.chdir(bare)
+
+        mod = _load_script()
+        # Must not raise, must not depend on project root resolution
+        result = mod.summarize_all(warehouse)
+        paths = [e["path"] for e in result["tracked_paths"]]
+        assert "contexts/f.md" in paths
+
+    def test_summarize_all_skips_dot_git_entries(self, tmp_path):
+        """Anything under .git/ is never reported."""
+        warehouse = _make_git_warehouse(tmp_path)
+        subprocess.run(
+            ["git", "-C", str(warehouse), "commit", "--allow-empty", "-m", "init"],
+            check=True,
+            capture_output=True,
+        )
+        # Write a junk file inside .git/ — porcelain would never list it,
+        # but the filter is defensive in case of unusual configurations.
+        junk = warehouse / ".git" / "spurious.txt"
+        junk.write_text("nope\n")
+
+        mod = _load_script()
+        result = mod.summarize_all(warehouse)
+        for e in result["tracked_paths"]:
+            assert not e["path"].startswith(".git/")

--- a/libs/beacon/tests/unit/data/skills/contribute_warehouse/test_summarize_changes.py
+++ b/libs/beacon/tests/unit/data/skills/contribute_warehouse/test_summarize_changes.py
@@ -990,6 +990,56 @@ class TestWarehouseScopedDefault:
         paths = [e["path"] for e in result["tracked_paths"]]
         assert "contexts/f.md" in paths
 
+    def test_summarize_all_handles_filename_with_arrow_literal(self, tmp_path):
+        """File literally named 'notes/a -> b.md' is not misparsed as a rename.
+
+        Regression for opencode-review PR #156 finding M2: the ' -> ' substring
+        must not trigger rename-style splitting on non-R/C status codes.
+        """
+        warehouse = _make_git_warehouse(tmp_path)
+        subprocess.run(
+            ["git", "-C", str(warehouse), "commit", "--allow-empty", "-m", "init"],
+            check=True,
+            capture_output=True,
+        )
+        (warehouse / "notes").mkdir(exist_ok=True)
+        weird = warehouse / "notes" / "a -> b.md"
+        weird.write_text("# weird\n")
+
+        mod = _load_script()
+        result = mod.summarize_all(warehouse)
+        paths = [e["path"] for e in result["tracked_paths"]]
+        # The literal filename must round-trip; it must NOT be reduced to 'b.md'.
+        # Git porcelain quotes paths containing special chars, so the path may
+        # come back wrapped in quotes — accept either form.
+        assert "b.md" not in paths, (
+            f"opencode PR#156 M2: ' -> ' substring split must not fire for non-R/C codes. Got: {paths}"
+        )
+        assert any("a -> b.md" in p for p in paths), (
+            f"Original filename must round-trip. Got: {paths}"
+        )
+
+    def test_summarize_all_rename_uses_destination_path(self, tmp_path):
+        """A staged rename 'R old -> new' reports the new path."""
+        warehouse = _make_git_warehouse(tmp_path)
+        orig = warehouse / "contexts" / "old.md"
+        orig.write_text("# orig\n")
+        _initial_commit(warehouse, [orig])
+
+        # git mv to trigger an R record
+        subprocess.run(
+            ["git", "-C", str(warehouse), "mv", "contexts/old.md", "contexts/new.md"],
+            check=True,
+            capture_output=True,
+        )
+
+        mod = _load_script()
+        result = mod.summarize_all(warehouse)
+        paths = [e["path"] for e in result["tracked_paths"]]
+        assert "contexts/new.md" in paths, (
+            f"Rename should appear with destination path. Got: {paths}"
+        )
+
     def test_summarize_all_skips_dot_git_entries(self, tmp_path):
         """Anything under .git/ is never reported."""
         warehouse = _make_git_warehouse(tmp_path)

--- a/libs/beacon/tests/unit/data/skills/contribute_warehouse/test_summarize_changes.py
+++ b/libs/beacon/tests/unit/data/skills/contribute_warehouse/test_summarize_changes.py
@@ -1019,6 +1019,39 @@ class TestWarehouseScopedDefault:
             f"Original filename must round-trip. Got: {paths}"
         )
 
+    def test_summarize_all_rename_with_arrow_in_source_path(self, tmp_path):
+        """Rename where the SOURCE path contains ' -> ' is parsed correctly.
+
+        Regression for opencode-review PR#156 round 4: the previous
+        ' -> '-split-based parser would split on the substring inside the
+        source path, mapping the rename incorrectly. The -z parser is
+        immune.
+        """
+        warehouse = _make_git_warehouse(tmp_path)
+        (warehouse / "notes").mkdir(exist_ok=True)
+        weird_src = warehouse / "notes" / "a -> b.md"
+        weird_src.write_text("# weird src\n")
+        _initial_commit(warehouse, [weird_src])
+
+        # Rename the file with ' -> ' in its name to a plain destination
+        subprocess.run(
+            ["git", "-C", str(warehouse), "mv", "notes/a -> b.md", "notes/c.md"],
+            check=True,
+            capture_output=True,
+        )
+
+        mod = _load_script()
+        result = mod.summarize_all(warehouse)
+        paths = [e["path"] for e in result["tracked_paths"]]
+        # The destination must be the real new path 'notes/c.md', NOT 'b.md'
+        # (which would result from naively splitting on ' -> ').
+        assert "notes/c.md" in paths, (
+            f"Rename with arrow-in-source should report 'notes/c.md'. Got: {paths}"
+        )
+        assert "b.md" not in paths, (
+            f"' -> ' substring split must not corrupt rename dest. Got: {paths}"
+        )
+
     def test_summarize_all_rename_uses_destination_path(self, tmp_path):
         """A staged rename 'R old -> new' reports the new path."""
         warehouse = _make_git_warehouse(tmp_path)

--- a/libs/beacon/tests/unit/warehouse/test_contribute.py
+++ b/libs/beacon/tests/unit/warehouse/test_contribute.py
@@ -808,6 +808,44 @@ class TestPer203WarehouseScopedDefault:
         )
         assert "renamed.md" in out
 
+    def test_default_paths_empty_string_rejected(self, contrib_project):
+        """--paths "" must not commit the entire warehouse.
+
+        Regression for opencode-review PR#156 round 8: previously
+        normalize_relative_path("") returned "." which became the literal
+        pathspec :(literal). and matched everything dirty in the warehouse.
+        """
+        project, wh = contrib_project
+        (wh / "contexts" / "test.md").write_text("# modified\n")
+
+        with pytest.raises(ValueError) as exc_info:
+            contribute(
+                project,
+                message="should fail",
+                push=False,
+                paths=("",),
+            )
+        assert "empty" in str(exc_info.value).lower()
+
+    def test_default_paths_dot_rejected(self, contrib_project):
+        """--paths "." must not commit the entire warehouse.
+
+        Companion to test_default_paths_empty_string_rejected — same root
+        cause, alternative payload. ".", "./", and "" all collapse to the
+        warehouse root and must be rejected by normalize_relative_path.
+        """
+        project, wh = contrib_project
+        (wh / "contexts" / "test.md").write_text("# modified\n")
+
+        with pytest.raises(ValueError) as exc_info:
+            contribute(
+                project,
+                message="should fail",
+                push=False,
+                paths=(".",),
+            )
+        assert "warehouse root" in str(exc_info.value).lower()
+
     def test_default_paths_glob_pattern_rejected_not_expanded(self, contrib_project):
         """--paths '*.md' is treated as a literal filename, not a glob.
 

--- a/libs/beacon/tests/unit/warehouse/test_contribute.py
+++ b/libs/beacon/tests/unit/warehouse/test_contribute.py
@@ -808,6 +808,54 @@ class TestPer203WarehouseScopedDefault:
         )
         assert "renamed.md" in out
 
+    def test_default_paths_glob_pattern_rejected_not_expanded(self, contrib_project):
+        """--paths '*.md' is treated as a literal filename, not a glob.
+
+        Regression for opencode-review PR#156 round 6: without :(literal)
+        pathspec magic, git would expand the glob and commit multiple files
+        even though the CLI documents --paths as a single warehouse-relative
+        filename. With the literal pathspec wrapping, '*.md' is looked up as
+        an actual file with that exact name — which does not exist, so the
+        dirty-check rejects it.
+        """
+        project, wh = contrib_project
+
+        # Several real .md files are dirty
+        (wh / "contexts" / "test.md").write_text("# modified\n")
+        (wh / "scratch.md").write_text("# new\n")
+
+        # Pre-fix: '*.md' would glob-expand to both files and commit them all.
+        # Post-fix: the literal pathspec lookup fails the dirty check.
+        with pytest.raises(ValueError) as exc_info:
+            contribute(
+                project,
+                message="exploit attempt",
+                push=False,
+                paths=("*.md",),
+            )
+        assert "*.md" in str(exc_info.value)
+        assert "not dirty" in str(exc_info.value)
+
+    def test_default_paths_pathspec_magic_rejected_not_expanded(self, contrib_project):
+        """--paths ':(glob)**/*.md' is treated as a literal filename, not pathspec magic.
+
+        Regression for opencode-review PR#156 round 6: defends against the
+        more explicit git-pathspec-DSL injection variant.
+        """
+        project, wh = contrib_project
+
+        (wh / "contexts" / "test.md").write_text("# modified\n")
+        (wh / "scratch.md").write_text("# new\n")
+
+        with pytest.raises(ValueError) as exc_info:
+            contribute(
+                project,
+                message="exploit attempt",
+                push=False,
+                paths=(":(glob)**/*.md",),
+            )
+        assert "not dirty" in str(exc_info.value)
+
     def test_default_paths_rename_source_in_paths_commits_both_sides(
         self, contrib_project
     ):

--- a/libs/beacon/tests/unit/warehouse/test_contribute.py
+++ b/libs/beacon/tests/unit/warehouse/test_contribute.py
@@ -808,6 +808,76 @@ class TestPer203WarehouseScopedDefault:
         )
         assert "renamed.md" in out
 
+    def test_default_paths_rename_with_spaces_commits_both_sides(self, contrib_project):
+        """--paths <dest-with-spaces> for a rename auto-expands source path.
+
+        Regression for opencode-review PR#156 round 3: porcelain quotes paths
+        containing whitespace (e.g. ``"contexts/new name.md"``), so the dict
+        lookup in _expand_rename_sources must unquote them before matching
+        against the user's unquoted --paths argument. Without unquoting, the
+        rename source (`contexts/old name.md`) is never added to the commit
+        pathspec and its staged deletion is left dangling.
+        """
+        project, wh = contrib_project
+        env = _git_env()
+
+        # Set up a tracked file with a space in the name
+        spaced_old = wh / "contexts" / "old name.md"
+        spaced_old.write_text("# spaced\n")
+        subprocess.run(
+            ["git", "-C", str(wh), "add", "contexts/old name.md"],
+            cwd=wh,
+            env=env,
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(wh), "commit", "-m", "add spaced file"],
+            cwd=wh,
+            env=env,
+            check=True,
+            capture_output=True,
+        )
+
+        # git mv to a new name (also with a space)
+        subprocess.run(
+            [
+                "git",
+                "-C",
+                str(wh),
+                "mv",
+                "contexts/old name.md",
+                "contexts/new name.md",
+            ],
+            cwd=wh,
+            env=env,
+            check=True,
+            capture_output=True,
+        )
+
+        result = contribute(
+            project,
+            message="rename spaced file via --paths",
+            push=False,
+            paths=("contexts/new name.md",),
+        )
+        assert result.status == "committed"
+
+        # Working tree + index must be clean — the old-side deletion is
+        # NOT left dangling.
+        post_status = subprocess.run(
+            ["git", "status", "--porcelain"],
+            cwd=wh,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        assert post_status.stdout.strip() == "", (
+            f"After spaced rename commit, tree must be clean. "
+            f"Got: {post_status.stdout!r}"
+        )
+
     def test_default_paths_explicit_rename_dest_commits_both_sides(
         self, contrib_project
     ):

--- a/libs/beacon/tests/unit/warehouse/test_contribute.py
+++ b/libs/beacon/tests/unit/warehouse/test_contribute.py
@@ -808,6 +808,70 @@ class TestPer203WarehouseScopedDefault:
         )
         assert "renamed.md" in out
 
+    def test_default_paths_rename_with_arrow_in_source_commits_both_sides(
+        self, contrib_project
+    ):
+        """--paths <dest> for a rename whose SOURCE contains ' -> '.
+
+        Regression for opencode-review PR#156 round 4: the prior parser would
+        split on the ' -> ' substring inside the source path, producing the
+        wrong source name and leaving the actual source's deletion staged.
+        The -z parser handles this correctly.
+        """
+        project, wh = contrib_project
+        env = _git_env()
+
+        # Create + commit a file whose name contains ' -> '
+        (wh / "notes").mkdir(exist_ok=True)
+        weird_src = wh / "notes" / "a -> b.md"
+        weird_src.write_text("# weird\n")
+        subprocess.run(
+            ["git", "-C", str(wh), "add", "notes/a -> b.md"],
+            cwd=wh,
+            env=env,
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(wh), "commit", "-m", "add weird-named file"],
+            cwd=wh,
+            env=env,
+            check=True,
+            capture_output=True,
+        )
+
+        # Rename via git mv to a plain destination
+        subprocess.run(
+            ["git", "-C", str(wh), "mv", "notes/a -> b.md", "notes/c.md"],
+            cwd=wh,
+            env=env,
+            check=True,
+            capture_output=True,
+        )
+
+        result = contribute(
+            project,
+            message="rename arrow-source file via --paths",
+            push=False,
+            paths=("notes/c.md",),
+        )
+        assert result.status == "committed"
+
+        # Working tree + index clean: the deletion of 'notes/a -> b.md' was
+        # picked up as part of the rename, not left dangling.
+        post_status = subprocess.run(
+            ["git", "status", "--porcelain"],
+            cwd=wh,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        assert post_status.stdout.strip() == "", (
+            f"After arrow-source rename commit, tree must be clean. "
+            f"Got: {post_status.stdout!r}"
+        )
+
     def test_default_paths_rename_with_spaces_commits_both_sides(self, contrib_project):
         """--paths <dest-with-spaces> for a rename auto-expands source path.
 

--- a/libs/beacon/tests/unit/warehouse/test_contribute.py
+++ b/libs/beacon/tests/unit/warehouse/test_contribute.py
@@ -759,6 +759,98 @@ class TestPer203WarehouseScopedDefault:
             )
         assert "absolute" in str(exc_info.value).lower()
 
+    def test_default_paths_none_commits_rename_with_both_sides(self, contrib_project):
+        """Default mode commits a rename cleanly — old deletion + new add.
+
+        Regression for opencode-review PR #156 finding M1: enumerating dirty
+        paths and committing only the destination of 'R old -> new' would
+        leave the old-side deletion staged. The default path uses
+        'git add -A' + unrestricted commit, which captures both sides.
+        """
+        project, wh = contrib_project
+        env = _git_env()
+
+        # git mv the tracked file → triggers an R record in porcelain
+        subprocess.run(
+            ["git", "-C", str(wh), "mv", "contexts/test.md", "contexts/renamed.md"],
+            cwd=wh,
+            env=env,
+            check=True,
+            capture_output=True,
+        )
+
+        result = contribute(project, message="rename test.md to renamed.md", push=False)
+        assert result.status == "committed"
+
+        committed_files = subprocess.run(
+            ["git", "show", "--name-status", "--format=", "HEAD"],
+            cwd=wh,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        # Both sides must appear: the deletion of the old name and the
+        # addition of the new name (or a single rename record covering both).
+        out = committed_files.stdout
+        # After commit, the working tree + index must be clean — no leftover
+        # staged deletion of the old path.
+        post_status = subprocess.run(
+            ["git", "status", "--porcelain"],
+            cwd=wh,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        assert post_status.stdout.strip() == "", (
+            f"After rename commit, tree must be clean. Got: {post_status.stdout!r}"
+        )
+        assert "renamed.md" in out
+
+    def test_default_paths_none_handles_filename_with_arrow(self, contrib_project):
+        """Default mode commits a file literally named 'a -> b.md' without misparsing.
+
+        Regression for opencode-review PR #156 finding M2: the previous
+        path-enumeration code would treat ' -> ' as a rename separator and
+        produce the wrong pathspec, leaving the real file uncommitted.
+        Switching the default to 'git add -A' sidesteps the parsing entirely.
+        """
+        project, wh = contrib_project
+        env = _git_env()
+
+        (wh / "notes").mkdir(exist_ok=True)
+        weird = wh / "notes" / "a -> b.md"
+        weird.write_text("# weird\n")
+
+        result = contribute(project, message="add notes/a -> b.md", push=False)
+        assert result.status == "committed"
+
+        committed = subprocess.run(
+            ["git", "show", "--name-only", "--format=", "HEAD"],
+            cwd=wh,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        # Git quotes the special-char path in show output, so check substring.
+        assert "a -> b.md" in committed.stdout, (
+            f"Weird filename must be committed verbatim. Got: {committed.stdout!r}"
+        )
+        # Working tree must be clean — the real file is not left dangling.
+        post_status = subprocess.run(
+            ["git", "status", "--porcelain"],
+            cwd=wh,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        assert post_status.stdout.strip() == "", (
+            f"Tree must be clean after commit. Got: {post_status.stdout!r}"
+        )
+
     def test_default_excludes_dot_git_paths(self, contrib_project):
         """Default (paths=None): contents of .git/ never reach the commit."""
         project, wh = contrib_project

--- a/libs/beacon/tests/unit/warehouse/test_contribute.py
+++ b/libs/beacon/tests/unit/warehouse/test_contribute.py
@@ -251,13 +251,20 @@ class TestContribute:
             or "failed" in str(exc_info.value).lower()
         )
 
-    def test_untracked_files_not_staged(self, contrib_project):
-        """TC5: Commit succeeds but edits only non-beacon.yaml paths -> NOT staged."""
+    def test_untracked_files_not_staged_with_only_tracked(self, contrib_project):
+        """only_tracked=True: edits only non-beacon.yaml paths -> NOT staged.
+
+        Under the PER-203 default, an untracked dirty file IS committable
+        (covered by TestWarehouseScopedDefault). This test pins down the
+        legacy project-filter behavior, which now lives behind --only-tracked.
+        """
         project, wh = contrib_project
         # Create a file not in beacon.yaml
         (wh / "untracked.md").write_text("# Untracked\n")
 
-        result = contribute(project, message="Should be no changes", push=False)
+        result = contribute(
+            project, message="Should be no changes", push=False, only_tracked=True
+        )
         assert result.status == "no_changes"
 
         # untracked.md should not be committed
@@ -272,8 +279,15 @@ class TestContribute:
         )
         assert "untracked.md" not in log.stdout
 
-    def test_pre_staged_unrelated_file_not_committed(self, contrib_project):
-        """Pre-staged unrelated changes are left staged, not included in commit."""
+    def test_pre_staged_unrelated_file_not_committed_with_only_tracked(
+        self, contrib_project
+    ):
+        """only_tracked=True: pre-staged unrelated changes left staged, not committed.
+
+        Under the PER-203 default, a dirty unrelated file IS committed (the
+        skill caller is expected to use --paths for fine-grained control).
+        This test pins down the legacy behavior under --only-tracked.
+        """
         project, wh = contrib_project
         env = _git_env()
 
@@ -287,7 +301,9 @@ class TestContribute:
             capture_output=True,
         )
 
-        result = contribute(project, message="Commit tracked only", push=False)
+        result = contribute(
+            project, message="Commit tracked only", push=False, only_tracked=True
+        )
 
         assert result.status == "committed"
         committed_files = subprocess.run(
@@ -357,9 +373,26 @@ class TestContributePaths:
         assert "b.md" in status.stdout
         assert "c.md" in status.stdout
 
-    def test_contribute_paths_validates_membership(self, contrib_project_multi):
-        """paths=(D,) where D is not tracked raises ValueError mentioning D."""
+    def test_contribute_paths_validates_membership_with_only_tracked(
+        self, contrib_project_multi
+    ):
+        """only_tracked=True: paths=(D,) not in beacon.yaml raises ValueError mentioning D."""
         project, wh = contrib_project_multi
+        with pytest.raises(ValueError) as exc_info:
+            contribute(
+                project,
+                message="should fail",
+                push=False,
+                paths=("contexts/d.md",),
+                only_tracked=True,
+            )
+        assert "contexts/d.md" in str(exc_info.value)
+        assert "not tracked by beacon.yaml" in str(exc_info.value)
+
+    def test_contribute_paths_to_nondirty_file_rejected(self, contrib_project_multi):
+        """Default: paths=(D,) where D is not dirty in warehouse → ValueError."""
+        project, wh = contrib_project_multi
+        # contexts/d.md doesn't exist at all, so it has no porcelain status
         with pytest.raises(ValueError) as exc_info:
             contribute(
                 project,
@@ -368,6 +401,7 @@ class TestContributePaths:
                 paths=("contexts/d.md",),
             )
         assert "contexts/d.md" in str(exc_info.value)
+        assert "not dirty" in str(exc_info.value)
 
     def test_contribute_paths_empty_tuple_raises(self, contrib_project_multi):
         """paths=() raises ValueError with a clear message."""
@@ -526,12 +560,18 @@ class TestContributePaths:
 class TestDirtyOutsideScope:
     """Tests for PER-159: out-of-scope dirty file count in contribute."""
 
-    def test_no_changes_with_outside_scope_dirty_returns_count(self, contrib_project):
-        """Dirty file outside beacon.yaml -> no_changes with count >= 1."""
+    def test_no_changes_with_outside_scope_dirty_returns_count_only_tracked(
+        self, contrib_project
+    ):
+        """only_tracked=True: dirty file outside beacon.yaml -> no_changes with count >= 1.
+
+        Under the PER-203 default, the untracked file would be committed, so
+        this signal only makes sense in the legacy project-scoped mode.
+        """
         project, wh = contrib_project
         (wh / "untracked.md").write_text("# Untracked\nmodified\n")
 
-        result = contribute(project, message="x", push=False)
+        result = contribute(project, message="x", push=False, only_tracked=True)
         assert result.status == "no_changes"
         assert result.dirty_outside_scope_count >= 1
 
@@ -552,3 +592,192 @@ class TestDirtyOutsideScope:
         result = contribute(project, message="commit a", push=False)
         assert result.status == "committed"
         assert result.dirty_outside_scope_count == 0
+
+
+class TestPer203WarehouseScopedDefault:
+    """PER-203: default is warehouse-scoped — any dirty warehouse path is committable.
+
+    The legacy beacon.yaml filter survives behind only_tracked=True.
+    """
+
+    def test_brand_new_skill_path_commits_without_beacon_yaml_entry(
+        self, contrib_project
+    ):
+        """A new skill folder not in beacon.yaml is committable via --paths under default."""
+        project, wh = contrib_project
+        env = _git_env()
+
+        skill_dir = wh / "skills" / "brand-new"
+        skill_dir.mkdir(parents=True)
+        skill_file = skill_dir / "SKILL.md"
+        skill_file.write_text("---\nname: brand-new\n---\nbody\n")
+
+        result = contribute(
+            project,
+            message="feat(skills): add brand-new skill",
+            push=False,
+            paths=("skills/brand-new/SKILL.md",),
+        )
+        assert result.status == "committed"
+        assert result.committed_sha
+
+        committed_files = subprocess.run(
+            ["git", "show", "--name-only", "--format=", "HEAD"],
+            cwd=wh,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        assert "skills/brand-new/SKILL.md" in committed_files.stdout
+
+    def test_cross_project_knowledge_commits_without_beacon_yaml_entry(
+        self, contrib_project
+    ):
+        """A knowledge file not in beacon.yaml is committable under default."""
+        project, wh = contrib_project
+        env = _git_env()
+
+        knowledge_dir = wh / "knowledge" / "infrastructure"
+        knowledge_dir.mkdir(parents=True)
+        knowledge_file = knowledge_dir / "router-config.md"
+        knowledge_file.write_text("# Router config\n")
+
+        result = contribute(
+            project,
+            message="docs(knowledge): add router config",
+            push=False,
+            paths=("knowledge/infrastructure/router-config.md",),
+        )
+        assert result.status == "committed"
+
+        committed_files = subprocess.run(
+            ["git", "show", "--name-only", "--format=", "HEAD"],
+            cwd=wh,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        assert "knowledge/infrastructure/router-config.md" in committed_files.stdout
+
+    def test_default_paths_none_commits_all_dirty(self, contrib_project):
+        """Default (paths=None, only_tracked=False) commits ALL dirty paths.
+
+        Includes paths not in beacon.yaml — that's the whole point of PER-203.
+        """
+        project, wh = contrib_project
+        env = _git_env()
+
+        # Dirty an in-beacon.yaml file + an out-of-beacon.yaml file
+        (wh / "contexts" / "test.md").write_text("# Test modified\n")
+        (wh / "scratch.md").write_text("# scratch\n")
+
+        result = contribute(project, message="commit everything", push=False)
+        assert result.status == "committed"
+
+        committed_files = subprocess.run(
+            ["git", "show", "--name-only", "--format=", "HEAD"],
+            cwd=wh,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        assert "contexts/test.md" in committed_files.stdout
+        assert "scratch.md" in committed_files.stdout
+
+    def test_only_tracked_preserves_legacy_filter(self, contrib_project):
+        """only_tracked=True: out-of-beacon.yaml dirty file is NOT committed."""
+        project, wh = contrib_project
+        env = _git_env()
+
+        (wh / "contexts" / "test.md").write_text("# Test modified\n")
+        (wh / "scratch.md").write_text("# scratch\n")
+
+        result = contribute(
+            project, message="commit tracked only", push=False, only_tracked=True
+        )
+        assert result.status == "committed"
+
+        committed_files = subprocess.run(
+            ["git", "show", "--name-only", "--format=", "HEAD"],
+            cwd=wh,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        assert "contexts/test.md" in committed_files.stdout
+        assert "scratch.md" not in committed_files.stdout
+
+    def test_default_paths_none_with_no_dirty_files_returns_no_changes(
+        self, contrib_project
+    ):
+        """Default mode: clean warehouse → no_changes."""
+        project, wh = contrib_project
+        result = contribute(project, message="x", push=False)
+        assert result.status == "no_changes"
+        assert result.dirty_outside_scope_count == 0
+
+    def test_default_paths_to_dirty_brand_new_file_commits(self, contrib_project):
+        """Default: --paths pointing to an untracked but dirty file commits it."""
+        project, wh = contrib_project
+
+        (wh / "fresh.md").write_text("# fresh\n")  # untracked
+
+        result = contribute(
+            project,
+            message="add fresh",
+            push=False,
+            paths=("fresh.md",),
+        )
+        assert result.status == "committed"
+
+    def test_default_paths_normalization_still_applied(self, contrib_project):
+        """Default: leading './' and '//' are normalized before the dirty check."""
+        project, wh = contrib_project
+        (wh / "contexts" / "test.md").write_text("# normalized\n")
+
+        result = contribute(
+            project,
+            message="normalize",
+            push=False,
+            paths=("./contexts//test.md",),
+        )
+        assert result.status == "committed"
+
+    def test_default_paths_absolute_rejected(self, contrib_project):
+        """Default: absolute paths still raise (path-shape validation runs first)."""
+        project, wh = contrib_project
+        with pytest.raises(ValueError) as exc_info:
+            contribute(
+                project,
+                message="x",
+                push=False,
+                paths=("/absolute/foo.md",),
+            )
+        assert "absolute" in str(exc_info.value).lower()
+
+    def test_default_excludes_dot_git_paths(self, contrib_project):
+        """Default (paths=None): contents of .git/ never reach the commit."""
+        project, wh = contrib_project
+        env = _git_env()
+
+        # Trick: write something inside .git/ — git status won't list it,
+        # but defend that _all_dirty_paths drops anything under .git/.
+        (wh / ".git" / "junk.txt").write_text("nope\n")
+        (wh / "contexts" / "test.md").write_text("# test\n")
+
+        result = contribute(project, message="commit", push=False)
+        assert result.status == "committed"
+
+        committed_files = subprocess.run(
+            ["git", "show", "--name-only", "--format=", "HEAD"],
+            cwd=wh,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        assert ".git" not in committed_files.stdout

--- a/libs/beacon/tests/unit/warehouse/test_contribute.py
+++ b/libs/beacon/tests/unit/warehouse/test_contribute.py
@@ -808,6 +808,61 @@ class TestPer203WarehouseScopedDefault:
         )
         assert "renamed.md" in out
 
+    def test_default_paths_explicit_rename_dest_commits_both_sides(
+        self, contrib_project
+    ):
+        """--paths <dest> for a rename auto-expands to include the source.
+
+        Regression for opencode-review PR#156 round 2: previously, passing
+        the destination of a git mv via --paths committed the new file but
+        left the old-side deletion staged. _expand_rename_sources() now
+        transparently includes the source path so the commit is atomic.
+        """
+        project, wh = contrib_project
+        env = _git_env()
+
+        subprocess.run(
+            ["git", "-C", str(wh), "mv", "contexts/test.md", "contexts/renamed.md"],
+            cwd=wh,
+            env=env,
+            check=True,
+            capture_output=True,
+        )
+
+        result = contribute(
+            project,
+            message="rename via --paths",
+            push=False,
+            paths=("contexts/renamed.md",),
+        )
+        assert result.status == "committed"
+
+        # Working tree + index must be clean — the old-side deletion is
+        # NOT left dangling as a staged change.
+        post_status = subprocess.run(
+            ["git", "status", "--porcelain"],
+            cwd=wh,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        assert post_status.stdout.strip() == "", (
+            f"After path-limited rename commit, tree must be clean. "
+            f"Got: {post_status.stdout!r}"
+        )
+
+        # Both sides must appear in the commit.
+        committed = subprocess.run(
+            ["git", "show", "--name-status", "--format=", "HEAD"],
+            cwd=wh,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        assert "renamed.md" in committed.stdout
+
     def test_default_paths_none_handles_filename_with_arrow(self, contrib_project):
         """Default mode commits a file literally named 'a -> b.md' without misparsing.
 

--- a/libs/beacon/tests/unit/warehouse/test_contribute.py
+++ b/libs/beacon/tests/unit/warehouse/test_contribute.py
@@ -808,6 +808,51 @@ class TestPer203WarehouseScopedDefault:
         )
         assert "renamed.md" in out
 
+    def test_default_paths_rename_source_in_paths_commits_both_sides(
+        self, contrib_project
+    ):
+        """--paths <source-of-rename> pulls in the destination too.
+
+        Regression for opencode-review PR#156 round 5: previously only
+        destination -> source was mapped, so passing the rename source path
+        committed just the deletion and left the new file staged. The
+        bidirectional rename map fixes this — passing either side captures
+        both.
+        """
+        project, wh = contrib_project
+        env = _git_env()
+
+        subprocess.run(
+            ["git", "-C", str(wh), "mv", "contexts/test.md", "contexts/renamed.md"],
+            cwd=wh,
+            env=env,
+            check=True,
+            capture_output=True,
+        )
+
+        # User supplies the SOURCE path (now deleted from working tree)
+        result = contribute(
+            project,
+            message="rename via --paths <source>",
+            push=False,
+            paths=("contexts/test.md",),
+        )
+        assert result.status == "committed"
+
+        # Working tree + index must be clean.
+        post_status = subprocess.run(
+            ["git", "status", "--porcelain"],
+            cwd=wh,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        assert post_status.stdout.strip() == "", (
+            f"After source-path rename commit, tree must be clean. "
+            f"Got: {post_status.stdout!r}"
+        )
+
     def test_default_paths_rename_with_arrow_in_source_commits_both_sides(
         self, contrib_project
     ):


### PR DESCRIPTION
## Summary

Both PER-202 (`summarize_changes.py`) and PER-203 (`abc warehouse contribute`) were silently filtering through the invoking project's `beacon.yaml`, making the `/contribute-warehouse` skill unusable for brand-new artifacts, cross-project knowledge, and authoring from a project that doesn't own the artifact.

Both ends are now **warehouse-scoped by default**; the legacy project-filter survives as an opt-in.

- **PER-202** — summarizer default: enumerate every dirty path via `git status --porcelain --untracked-files=all`. No project lookup, no `beacon.yaml` resolution. `--only-project-artifacts` restores the legacy filter. Each entry gains a `warehouse_area` classification (`contexts`/`knowledge`/`skills`/`agents`/`other`).
- **PER-203** — `contribute()` default: any dirty warehouse path is committable. `--only-tracked` restores the prior "must be in beacon.yaml" guard.
- `SKILL.md` Step 3: project-root resolution paragraph removed.

Closes PER-202.
Closes PER-203.

## Test plan

- [x] `uv run pytest libs/beacon/tests/unit/data/skills/contribute_warehouse/test_summarize_changes.py libs/beacon/tests/unit/warehouse/test_contribute.py` → 70 passed
- [x] `uv run pytest libs/beacon/tests/unit/warehouse/ libs/beacon/tests/unit/data/` → 180 passed
- [x] PEP 723 regression guard (`TestPep723Dependencies`) → passed
- [x] PER-186 deletion-handling regression → passed
- [x] PER-183 agents-tracking regression → passed
- [x] Smoke test: invoke `summarize_changes.py` from `/tmp` against a fresh warehouse with `skills/brand-new/SKILL.md` → file appears in `tracked_paths` with `git_status="??"`, `warehouse_area="skills"`
- [ ] Manual end-to-end: run `/contribute-warehouse` from a project whose `beacon.yaml` does not cover the dirty paths (was the original repro scenario)

🤖 Generated with [Claude Code](https://claude.com/claude-code)