### PR TITLE
fix(setup): wrap agent partials with disable: true frontmatter (PER-238)

### DIFF
--- a/libs/beacon/src/beacon/domains/setup/wiring.py
+++ b/libs/beacon/src/beacon/domains/setup/wiring.py
@@ -513,6 +513,25 @@ def _build_partial_wrapper(partial_file: Path) -> str:
     return _PARTIAL_WRAPPER_FRONTMATTER + _strip_existing_frontmatter(body)
 
 
+def _is_beacon_owned_partial_wrapper(dest: Path) -> bool:
+    """Return True if ``dest`` is a regular file Beacon previously wrote as a
+    partial wrapper.
+
+    We detect Beacon-owned wrappers by the **exact** frontmatter prefix
+    (``_PARTIAL_WRAPPER_FRONTMATTER``). The body below that prefix may
+    legitimately drift between syncs whenever the warehouse partial body is
+    edited, so refreshing such a file is safe and expected. Any other
+    regular file at the destination — including a hand-edited wrapper whose
+    frontmatter someone changed — is treated as user-owned.
+
+    Returns False on any read error (treat as user-owned, defensively).
+    """
+    try:
+        return dest.read_text(encoding="utf-8").startswith(_PARTIAL_WRAPPER_FRONTMATTER)
+    except OSError:
+        return False
+
+
 def _wire_partial(
     project_root: Path,
     partial_file: Path,
@@ -561,23 +580,34 @@ def _wire_partial(
         # regardless of what it pointed at — the symlink itself is the bug.
         dest.unlink()
     elif dest.exists():
-        # Regular file already there. If it matches the wrapper we'd write,
-        # leave it alone (idempotent). Otherwise it's user-owned content.
+        # Regular file at the destination. Two cases:
+        #   1. It's a Beacon-owned wrapper from a previous sync (recognised
+        #      by the exact wrapper frontmatter prefix). The body may have
+        #      drifted because the warehouse partial body was edited — that
+        #      is expected and we should refresh in place. If the content
+        #      already matches what we'd write, leave it alone to preserve
+        #      mtime (idempotent re-wire).
+        #   2. It's user-authored content that happens to sit at the same
+        #      path. Refuse to overwrite.
         try:
             current = dest.read_text(encoding="utf-8")
         except OSError:
             current = None
         if current == expected:
             return dest
-        raise RegularFileConflictError(
-            conflicts=[
-                AgentWireConflict(
-                    dest=dest,
-                    agent_name=str(rel),
-                    tool=tool,
-                ),
-            ],
-        )
+        if current is not None and current.startswith(_PARTIAL_WRAPPER_FRONTMATTER):
+            # Stale Beacon-owned wrapper — refresh below.
+            pass
+        else:
+            raise RegularFileConflictError(
+                conflicts=[
+                    AgentWireConflict(
+                        dest=dest,
+                        agent_name=str(rel),
+                        tool=tool,
+                    ),
+                ],
+            )
 
     dest.write_text(expected, encoding="utf-8")
     logger.debug(
@@ -676,24 +706,21 @@ def wire_agents_atomically(
 
     # Also check partial destinations (PER-164/PER-238). Unlike top-level
     # agent destinations, a regular file at a partial path is **expected**
-    # post-PER-238 — it's the wrapper we wrote on the previous wire. Flag a
-    # conflict only if the existing file's content does NOT match the wrapper
-    # we'd emit. Otherwise it's idempotent re-wire and we leave it alone.
+    # post-PER-238 — it's a Beacon-owned wrapper from a previous sync. We
+    # recognise wrappers by the exact frontmatter prefix; a stale wrapper
+    # whose body drifted (because the warehouse partial body was edited)
+    # is **not** a conflict and will be refreshed in `_wire_partial`. Only
+    # flag genuinely user-authored regular files.
     for partial_file in partial_files:
         rel = partial_file.relative_to(artifacts_agents_dir)
-        expected_wrapper = _build_partial_wrapper(partial_file)
         for tool, tool_dir in (("claudecode", ".claude"), ("opencode", ".opencode")):
             if tool not in detected_tools:
                 continue
             dest = project_root / tool_dir / "agents" / rel
             if not (dest.is_file() and not dest.is_symlink()):
                 continue
-            try:
-                current = dest.read_text(encoding="utf-8")
-            except OSError:
-                current = None
-            if current == expected_wrapper:
-                continue  # idempotent: our own previously-written wrapper
+            if _is_beacon_owned_partial_wrapper(dest):
+                continue  # Beacon-owned wrapper — idempotent or refresh.
             pre_conflicts.append(
                 AgentWireConflict(
                     dest=dest,

--- a/libs/beacon/src/beacon/domains/setup/wiring.py
+++ b/libs/beacon/src/beacon/domains/setup/wiring.py
@@ -462,39 +462,113 @@ def wire_agent_opencode(project_root: Path, artifact_file: Path) -> Path:
     return dest
 
 
+# PER-238 stopgap: partials co-distributed under .{tool}/agents/_partials/
+# get auto-discovered by opencode (and likely Claude Code) as full subagents,
+# polluting `@`-autocomplete and the LLM's Task-tool agent listing. Wrapping
+# each partial in a `disable: true` frontmatter block at wire time hides the
+# file from both empirically (verified against opencode 1.14.31 — see PER-238
+# comment thread for the test matrix). The partial body is inlined verbatim
+# below the frontmatter so agents that reference the partial via a relative
+# markdown link (e.g. `[checklist](_partials/deep-review-checklist.md)`) still
+# see the full content when they follow the link.
+#
+# Long-term fix (Option C in PER-238) is to stop co-distributing partials
+# entirely once PER-206's canonical-link form lands.
+_PARTIAL_WRAPPER_FRONTMATTER = (
+    "---\n"
+    "description: >-\n"
+    "  Internal fragment referenced by other agents — not a real agent.\n"
+    "  Disabled at wire time by Beacon (PER-238).\n"
+    "mode: subagent\n"
+    "disable: true\n"
+    "---\n\n"
+)
+
+
+def _strip_existing_frontmatter(body: str) -> str:
+    """If body starts with a YAML frontmatter block (``---\\n...---\\n``), strip it.
+
+    Defensive: today's only partial has no frontmatter, but if a future partial
+    starts shipping its own frontmatter we don't want to emit two `---` blocks
+    back-to-back (which would parse as malformed YAML and confuse opencode).
+    Returns the body verbatim if no frontmatter is detected.
+    """
+    if not body.startswith("---\n"):
+        return body
+    # Find the closing fence on its own line.
+    end = body.find("\n---\n", 4)
+    if end == -1:
+        # Malformed / unterminated — return as-is and let the model see it.
+        return body
+    return body[end + len("\n---\n") :].lstrip("\n")
+
+
+def _build_partial_wrapper(partial_file: Path) -> str:
+    """Render the wrapper file content for a partial.
+
+    Format: PER-238 stopgap frontmatter + the partial body verbatim (with any
+    existing frontmatter stripped to avoid double-fences).
+    """
+    body = partial_file.read_text(encoding="utf-8")
+    return _PARTIAL_WRAPPER_FRONTMATTER + _strip_existing_frontmatter(body)
+
+
 def _wire_partial(
     project_root: Path,
     partial_file: Path,
     rel: Path,
     tool: str,
 ) -> Path:
-    """Create a symlink for a partial file under .<tool>/agents/<rel>.
+    """Wire a partial file into ``.<tool>/agents/<rel>`` as a wrapped regular file.
 
-    Idempotent: if the symlink already points at the same target, it is left
-    unchanged.  A stale symlink pointing at a different target is replaced.
-    The parent directory is created if it does not exist.
+    PER-238 stopgap: instead of a raw symlink (which opencode auto-discovers as
+    a full subagent), we write a regular file whose content is
+    ``disable: true`` frontmatter followed by the partial body inlined verbatim.
+    Empirically (opencode 1.14.31), ``disable: true`` removes the file from
+    both ``opencode agent list`` and the LLM's Task-tool agent listing while
+    keeping the body resolvable when other agents follow a relative markdown
+    link to it.
+
+    Idempotent: if the destination is already a regular file with identical
+    wrapped content, it is left untouched (preserves mtime — relied upon by
+    ``test_partials_idempotent``). A stale symlink (pre-PER-238 layout) or a
+    drifted wrapper file is replaced. The parent directory is created if it
+    does not exist.
 
     Args:
         project_root: Project root directory.
-        partial_file: Path to the partial artifact file (the symlink target).
-        rel: Relative path under agents/ (e.g. _partials/deep-review-checklist.md).
-        tool: "claudecode" or "opencode".
+        partial_file: Path to the partial artifact file in the warehouse —
+            its body is inlined into the wrapper at wire time.
+        rel: Relative path under agents/ (e.g.
+            ``_partials/deep-review-checklist.md``).
+        tool: ``"claudecode"`` or ``"opencode"``.
 
     Returns:
-        Path to the created (or existing) symlink.
+        Path to the wrapper file.
+
+    Raises:
+        RegularFileConflictError: If the destination is a regular file that
+            does NOT match the expected wrapper content (i.e. user-owned).
     """
     tool_dir = ".claude" if tool == "claudecode" else ".opencode"
     dest = project_root / tool_dir / "agents" / rel
     dest.parent.mkdir(parents=True, exist_ok=True)
 
+    expected = _build_partial_wrapper(partial_file)
+
     if dest.is_symlink():
-        try:
-            if dest.resolve(strict=False) == partial_file.resolve(strict=False):
-                return dest
-        except OSError:
-            pass
+        # Pre-PER-238 layout: a raw symlink. Always replace with a wrapper
+        # regardless of what it pointed at — the symlink itself is the bug.
         dest.unlink()
     elif dest.exists():
+        # Regular file already there. If it matches the wrapper we'd write,
+        # leave it alone (idempotent). Otherwise it's user-owned content.
+        try:
+            current = dest.read_text(encoding="utf-8")
+        except OSError:
+            current = None
+        if current == expected:
+            return dest
         raise RegularFileConflictError(
             conflicts=[
                 AgentWireConflict(
@@ -505,8 +579,12 @@ def _wire_partial(
             ],
         )
 
-    dest.symlink_to(partial_file)
-    logger.debug("Wired partial to {}/agents/: {}", tool_dir, rel)
+    dest.write_text(expected, encoding="utf-8")
+    logger.debug(
+        "Wired partial wrapper to {}/agents/: {} (PER-238 stopgap)",
+        tool_dir,
+        rel,
+    )
     return dest
 
 
@@ -596,29 +674,33 @@ def wire_agents_atomically(
                     )
                 )
 
-    # Also check partial destinations (PER-164)
+    # Also check partial destinations (PER-164/PER-238). Unlike top-level
+    # agent destinations, a regular file at a partial path is **expected**
+    # post-PER-238 — it's the wrapper we wrote on the previous wire. Flag a
+    # conflict only if the existing file's content does NOT match the wrapper
+    # we'd emit. Otherwise it's idempotent re-wire and we leave it alone.
     for partial_file in partial_files:
         rel = partial_file.relative_to(artifacts_agents_dir)
-        if "claudecode" in detected_tools:
-            cc_dest = project_root / ".claude" / "agents" / rel
-            if cc_dest.is_file() and not cc_dest.is_symlink():
-                pre_conflicts.append(
-                    AgentWireConflict(
-                        dest=cc_dest,
-                        agent_name=str(rel),
-                        tool="claudecode",
-                    )
+        expected_wrapper = _build_partial_wrapper(partial_file)
+        for tool, tool_dir in (("claudecode", ".claude"), ("opencode", ".opencode")):
+            if tool not in detected_tools:
+                continue
+            dest = project_root / tool_dir / "agents" / rel
+            if not (dest.is_file() and not dest.is_symlink()):
+                continue
+            try:
+                current = dest.read_text(encoding="utf-8")
+            except OSError:
+                current = None
+            if current == expected_wrapper:
+                continue  # idempotent: our own previously-written wrapper
+            pre_conflicts.append(
+                AgentWireConflict(
+                    dest=dest,
+                    agent_name=str(rel),
+                    tool=tool,
                 )
-        if "opencode" in detected_tools:
-            oc_dest = project_root / ".opencode" / "agents" / rel
-            if oc_dest.is_file() and not oc_dest.is_symlink():
-                pre_conflicts.append(
-                    AgentWireConflict(
-                        dest=oc_dest,
-                        agent_name=str(rel),
-                        tool="opencode",
-                    )
-                )
+            )
 
     if pre_conflicts:
         raise RegularFileConflictError(conflicts=pre_conflicts)

--- a/libs/beacon/src/beacon/domains/setup/wiring.py
+++ b/libs/beacon/src/beacon/domains/setup/wiring.py
@@ -618,6 +618,37 @@ def _wire_partial(
     return dest
 
 
+def _snapshot_partial_path(p: Path) -> tuple[str, Path | str | None]:
+    """Snapshot a partial destination's pre-wire state.
+
+    Like ``snapshot_agent_path`` but distinguishes Beacon-owned wrapper files
+    (``wrapper_file`` kind, content captured for rollback) from user-owned
+    regular files. Without this distinction the rollback closure in
+    ``wire_agents_atomically`` cannot restore a refreshed wrapper after a
+    later wire step fails — addressed in PER-238 PR #157 round-2 review.
+
+    Returns:
+        ("symlink", current_target)  — pre-PER-238 raw symlink, target captured.
+        ("wrapper_file", content)    — Beacon-owned wrapper, full content captured.
+        ("regular_file", None)       — user-owned regular file (never modified).
+        ("missing", None)            — nothing there yet.
+    """
+    if p.is_symlink():
+        return ("symlink", p.readlink())
+    if p.is_file():
+        if _is_beacon_owned_partial_wrapper(p):
+            try:
+                return ("wrapper_file", p.read_text(encoding="utf-8"))
+            except OSError:
+                # Fall through and treat as user-owned defensively. The
+                # in-flight wire helpers will refuse to mutate it anyway.
+                return ("regular_file", None)
+        return ("regular_file", None)
+    if p.exists():
+        return ("regular_file", None)
+    return ("missing", None)
+
+
 def wire_agents_atomically(
     project_root: Path,
     agent_artifact_files: list[Path],
@@ -732,36 +763,45 @@ def wire_agents_atomically(
     if pre_conflicts:
         raise RegularFileConflictError(conflicts=pre_conflicts)
 
-    snapshots: list[tuple[Path, str, Path | None]] = []
+    snapshots: list[tuple[Path, str, Path | str | None]] = []
 
     def _rollback() -> None:
-        for path, kind, prior_target in reversed(snapshots):
+        for path, kind, prior in reversed(snapshots):
             try:
                 if kind == "missing":
                     if path.is_symlink() or path.exists():
                         path.unlink()
                 elif kind == "symlink":
+                    assert isinstance(prior, Path)
                     if path.is_symlink():
-                        if path.readlink() != prior_target:
+                        if path.readlink() != prior:
                             path.unlink()
-                            path.symlink_to(prior_target)
+                            path.symlink_to(prior)
                     else:
                         if path.exists():
                             path.unlink()
                         path.parent.mkdir(parents=True, exist_ok=True)
-                        path.symlink_to(prior_target)
+                        path.symlink_to(prior)
+                elif kind == "wrapper_file":
+                    # PER-238 round-2: a refreshed wrapper must be restored
+                    # to its pre-wire content if a later wire step fails.
+                    assert isinstance(prior, str)
+                    if path.is_symlink():
+                        path.unlink()
+                    path.parent.mkdir(parents=True, exist_ok=True)
+                    path.write_text(prior, encoding="utf-8")
                 # "regular_file" snapshots imply wire never succeeded for
-                # that path (the wire helpers refuse to overwrite regular
-                # files), so no restore is needed.
+                # that path (the wire helpers refuse to overwrite user-owned
+                # regular files), so no restore is needed.
             except OSError as e:
                 logger.warning(
                     "wire_agents_atomically: rollback step failed for "
-                    "{} (kind={}, prior_target={}): {}. "
+                    "{} (kind={}, prior={}): {}. "
                     "Continuing with remaining snapshots; "
                     "post-failure state may be partially restored.",
                     path,
                     kind,
-                    prior_target,
+                    prior,
                     e,
                 )
 
@@ -777,16 +817,17 @@ def wire_agents_atomically(
                 snapshots.append((oc_dest, *snapshot_agent_path(oc_dest)))
                 wire_agent_opencode(project_root, artifact_file)
 
-        # Wire partials into each detected tool (PER-164)
+        # Wire partials into each detected tool (PER-164/PER-238).
+        # Use _snapshot_partial_path so refreshed wrappers can be rolled back.
         for partial_file in partial_files:
             rel = partial_file.relative_to(artifacts_agents_dir)
             if "claudecode" in detected_tools:
                 cc_dest = project_root / ".claude" / "agents" / rel
-                snapshots.append((cc_dest, *snapshot_agent_path(cc_dest)))
+                snapshots.append((cc_dest, *_snapshot_partial_path(cc_dest)))
                 _wire_partial(project_root, partial_file, rel, "claudecode")
             if "opencode" in detected_tools:
                 oc_dest = project_root / ".opencode" / "agents" / rel
-                snapshots.append((oc_dest, *snapshot_agent_path(oc_dest)))
+                snapshots.append((oc_dest, *_snapshot_partial_path(oc_dest)))
                 _wire_partial(project_root, partial_file, rel, "opencode")
     except Exception:
         _rollback()

--- a/libs/beacon/tests/integration/test_agent_sync_lifecycle.py
+++ b/libs/beacon/tests/integration/test_agent_sync_lifecycle.py
@@ -1024,15 +1024,25 @@ def test_sync_with_agent_partials(project_dir: Path, warehouse: Path, monkeypatc
         f"Artifact partial symlink is broken: {artifact_partial}"
     )
 
-    # Partial must be wired into .claude/agents/_partials/
+    # Partial must be wired into .claude/agents/_partials/ as a wrapper
+    # (PER-238: regular file with `disable: true` frontmatter, not a raw
+    # symlink — so opencode/Claude Code don't expose it as a callable agent).
     claude_partial = (
         project_dir / ".claude" / "agents" / "_partials" / "deep-review-checklist.md"
     )
-    assert claude_partial.is_symlink(), (
-        f"Expected .claude partial symlink at {claude_partial}"
+    assert claude_partial.is_file() and not claude_partial.is_symlink(), (
+        f"Expected .claude partial wrapper file at {claude_partial}"
     )
-    assert claude_partial.exists(), (
-        f".claude partial symlink is broken: {claude_partial}"
+    wrapper_content = claude_partial.read_text()
+    assert wrapper_content.startswith("---\n"), (
+        f"Wrapper at {claude_partial} missing frontmatter fence"
+    )
+    assert "disable: true" in wrapper_content.split("\n---\n", 1)[0], (
+        f"Wrapper at {claude_partial} missing disable: true"
+    )
+    # Original partial body must be inlined for relative-link resolution.
+    assert "Deep Review Checklist" in wrapper_content, (
+        f"Wrapper at {claude_partial} missing original partial body"
     )
 
     # Partial must NOT be discoverable as an adoptable agent.

--- a/libs/beacon/tests/unit/test_wire_agents.py
+++ b/libs/beacon/tests/unit/test_wire_agents.py
@@ -1123,3 +1123,78 @@ class TestWirePartialPER238Wrapper:
 
         # User file untouched.
         assert user_file.read_text() == "hand-written user content"
+
+    def test_wrapper_refreshes_when_warehouse_body_changes(self, tmp_path):
+        """Regression for opencode-review Medium finding on PR #157:
+
+        A wrapper written by a previous sync must be **refreshed in place**
+        when the warehouse partial body changes — not flagged as a user
+        conflict. Beacon-owned wrappers are recognised by the exact
+        frontmatter prefix; only the body below is allowed to drift.
+        """
+        project = tmp_path / "proj"
+        project.mkdir()
+        artifact = _make_artifact(tmp_path / "warehouse", "spec-planner.md")
+        partial = _make_partial(
+            project / ".agentic-beacon" / "artifacts",
+            "deep-review-checklist.md",
+            content="# checklist\n\nv1 body\n",
+        )
+
+        # First sync: wrapper holds v1 body.
+        wire_agents_atomically(project, [artifact], {"claudecode"})
+        cc_wrap = (
+            project / ".claude" / "agents" / "_partials" / "deep-review-checklist.md"
+        )
+        assert "v1 body" in cc_wrap.read_text()
+
+        # Warehouse partial body edited.
+        partial.write_text("# checklist\n\nv2 body\n")
+
+        # Re-sync must succeed and refresh the wrapper to v2 — NOT raise
+        # RegularFileConflictError.
+        wire_agents_atomically(project, [artifact], {"claudecode"})
+
+        refreshed = cc_wrap.read_text()
+        assert "v2 body" in refreshed, (
+            f"Wrapper did not refresh after warehouse partial edit:\n{refreshed}"
+        )
+        assert "v1 body" not in refreshed, (
+            f"Stale v1 body still present in wrapper:\n{refreshed}"
+        )
+        # Frontmatter still intact.
+        assert refreshed.startswith("---\n")
+        assert "disable: true" in refreshed.split("\n---\n", 1)[0]
+
+    def test_wrapper_with_drifted_body_not_user_conflict_in_preflight(self, tmp_path):
+        """Companion to the refresh test, exercising the **pre-flight** path.
+
+        When two partials are wired and only the second triggers a refresh,
+        the pre-flight scan must NOT short-circuit with a conflict on the
+        first partial just because its body has drifted. Bug from PR #157
+        opencode-review: the preflight compared full-file equality instead
+        of recognising Beacon-owned wrappers by frontmatter.
+        """
+        project = tmp_path / "proj"
+        project.mkdir()
+        artifact = _make_artifact(tmp_path / "warehouse", "spec-planner.md")
+        first = _make_partial(
+            project / ".agentic-beacon" / "artifacts", "first.md", "v1\n"
+        )
+        _make_partial(
+            project / ".agentic-beacon" / "artifacts", "second.md", "second body\n"
+        )
+        wire_agents_atomically(project, [artifact], {"claudecode"})
+
+        # Drift the first partial's warehouse body without touching the
+        # wrapper on disk.
+        first.write_text("v2\n")
+
+        # Pre-flight must accept the existing first wrapper as Beacon-owned
+        # despite the body drift, AND wire the second partial successfully.
+        wire_agents_atomically(project, [artifact], {"claudecode"})
+
+        cc_first = project / ".claude" / "agents" / "_partials" / "first.md"
+        cc_second = project / ".claude" / "agents" / "_partials" / "second.md"
+        assert "v2" in cc_first.read_text()
+        assert "second body" in cc_second.read_text()

--- a/libs/beacon/tests/unit/test_wire_agents.py
+++ b/libs/beacon/tests/unit/test_wire_agents.py
@@ -830,13 +830,20 @@ def _make_partial(base: Path, rel: str, content: str = "partial") -> Path:
 
 class TestWireAgentsAtomicallyPartials:
     def test_partials_wired_to_both_tools(self, tmp_path):
-        """Partials under artifacts/agents/_partials/ get symlinked into both tools (PER-164)."""
+        """Partials under artifacts/agents/_partials/ get wrapped+wired into both tools.
+
+        PER-164 introduced the wiring; PER-238 changed the wire output from a
+        raw symlink to a regular file with `disable: true` frontmatter so
+        opencode doesn't surface the partial as a callable subagent. Both the
+        frontmatter and the original partial body must be present.
+        """
         project = tmp_path / "proj"
         project.mkdir()
         artifact = _make_artifact(tmp_path / "warehouse", "spec-planner.md")
         partial = _make_partial(
             project / ".agentic-beacon" / "artifacts",
             "deep-review-checklist.md",
+            content="# Deep-review checklist\n\nbody line one\n",
         )
 
         wire_agents_atomically(project, [artifact], {"claudecode", "opencode"})
@@ -847,17 +854,30 @@ class TestWireAgentsAtomicallyPartials:
         oc_partial = (
             project / ".opencode" / "agents" / "_partials" / "deep-review-checklist.md"
         )
-        assert cc_partial.is_symlink(), (
-            f"Expected .claude partial symlink at {cc_partial}"
+        # PER-238: wrappers are regular files, NOT symlinks.
+        assert cc_partial.is_file() and not cc_partial.is_symlink(), (
+            f"Expected regular-file wrapper at {cc_partial}, not a symlink"
         )
-        assert cc_partial.readlink() == partial
-        assert oc_partial.is_symlink(), (
-            f"Expected .opencode partial symlink at {oc_partial}"
+        assert oc_partial.is_file() and not oc_partial.is_symlink(), (
+            f"Expected regular-file wrapper at {oc_partial}, not a symlink"
         )
-        assert oc_partial.readlink() == partial
+        for wrapped in (cc_partial, oc_partial):
+            content = wrapped.read_text()
+            assert content.startswith("---\n"), (
+                f"Wrapper at {wrapped} missing frontmatter fence"
+            )
+            assert "disable: true" in content, (
+                f"Wrapper at {wrapped} missing disable: true"
+            )
+            # Original body must be inlined verbatim below the frontmatter.
+            assert "body line one" in content, (
+                f"Wrapper at {wrapped} missing original partial body"
+            )
+        # Original warehouse partial must be untouched.
+        assert partial.read_text() == "# Deep-review checklist\n\nbody line one\n"
 
     def test_partials_idempotent(self, tmp_path):
-        """Re-running wire_agents_atomically does not duplicate partial symlinks (PER-164)."""
+        """Re-running wire_agents_atomically does not rewrite unchanged partial wrappers (PER-164/PER-238)."""
         project = tmp_path / "proj"
         project.mkdir()
         artifact = _make_artifact(tmp_path / "warehouse", "spec-planner.md")
@@ -883,6 +903,7 @@ class TestWireAgentsAtomicallyPartials:
         nested = _make_partial(
             project / ".agentic-beacon" / "artifacts",
             "sub/dir/nested.md",
+            content="# nested\n\ninner body\n",
         )
 
         wire_agents_atomically(project, [artifact], {"claudecode"})
@@ -890,8 +911,13 @@ class TestWireAgentsAtomicallyPartials:
         cc_nested = (
             project / ".claude" / "agents" / "_partials" / "sub" / "dir" / "nested.md"
         )
-        assert cc_nested.is_symlink()
-        assert cc_nested.readlink() == nested
+        # PER-238: regular-file wrapper, not symlink.
+        assert cc_nested.is_file() and not cc_nested.is_symlink()
+        content = cc_nested.read_text()
+        assert "disable: true" in content
+        assert "inner body" in content
+        # Source warehouse partial unchanged.
+        assert nested.read_text() == "# nested\n\ninner body\n"
 
     def test_no_partials_dir_is_noop(self, tmp_path):
         """When no _partials/ directory exists, wire_agents_atomically still works."""
@@ -979,3 +1005,121 @@ class TestWireAgentsAtomicallyPartials:
         assert not (project / ".claude" / "agents" / "agent-a.md").exists()
         assert not (project / ".claude" / "agents" / "_partials").exists()
         assert blocker.read_text() == "user content"
+
+
+# ---------------------------------------------------------------------------
+# PER-238: partial wrappers carry disable: true frontmatter and idempotently
+# replace pre-PER-238 raw symlinks.
+# ---------------------------------------------------------------------------
+
+
+class TestWirePartialPER238Wrapper:
+    def test_wrapper_carries_disable_true_frontmatter(self, tmp_path):
+        """Empirical PER-238 contract: the wrapper file must declare
+        `disable: true` and `mode: subagent` so opencode (and Claude Code)
+        skip the partial during agent autodiscovery.
+        """
+        project = tmp_path / "proj"
+        project.mkdir()
+        artifact = _make_artifact(tmp_path / "warehouse", "spec-planner.md")
+        _make_partial(
+            project / ".agentic-beacon" / "artifacts",
+            "deep-review-checklist.md",
+            content="# Deep-review checklist\n\nbody\n",
+        )
+
+        wire_agents_atomically(project, [artifact], {"claudecode"})
+
+        cc_wrap = (
+            project / ".claude" / "agents" / "_partials" / "deep-review-checklist.md"
+        )
+        content = cc_wrap.read_text()
+        # Frontmatter fence is the very first thing in the file — opencode
+        # parses YAML only at the head.
+        assert content.startswith("---\n")
+        # Extract the frontmatter block (everything between the first two ---).
+        head, _, body = content[4:].partition("\n---\n")
+        assert "mode: subagent" in head, f"frontmatter missing mode:\n{head}"
+        assert "disable: true" in head, f"frontmatter missing disable:\n{head}"
+        # Body is preserved verbatim after the frontmatter.
+        assert body.endswith("# Deep-review checklist\n\nbody\n"), body
+
+    def test_wrapper_replaces_pre_per238_symlink(self, tmp_path):
+        """Migration: an existing raw symlink (pre-PER-238 layout) must be
+        replaced by a wrapper file on the next wire pass — without raising.
+        """
+        project = tmp_path / "proj"
+        project.mkdir()
+        artifact = _make_artifact(tmp_path / "warehouse", "spec-planner.md")
+        partial = _make_partial(
+            project / ".agentic-beacon" / "artifacts",
+            "deep-review-checklist.md",
+            content="# checklist\n\nbody\n",
+        )
+
+        # Simulate the pre-PER-238 state: a raw symlink to the partial.
+        cc_dir = project / ".claude" / "agents" / "_partials"
+        cc_dir.mkdir(parents=True, exist_ok=True)
+        legacy = cc_dir / "deep-review-checklist.md"
+        legacy.symlink_to(partial)
+        assert legacy.is_symlink()
+
+        wire_agents_atomically(project, [artifact], {"claudecode"})
+
+        # Now a regular-file wrapper, not a symlink.
+        assert legacy.is_file() and not legacy.is_symlink()
+        assert "disable: true" in legacy.read_text()
+
+    def test_wrapper_strips_existing_partial_frontmatter(self, tmp_path):
+        """Defensive: if a partial ships with its own YAML frontmatter, the
+        wrapper must NOT emit two ``---`` blocks back-to-back (which would
+        confuse opencode's frontmatter parser). The partial's frontmatter is
+        stripped; only the body is inlined under our wrapper frontmatter.
+        """
+        project = tmp_path / "proj"
+        project.mkdir()
+        artifact = _make_artifact(tmp_path / "warehouse", "spec-planner.md")
+        _make_partial(
+            project / ".agentic-beacon" / "artifacts",
+            "with-fm.md",
+            content="---\nfoo: bar\n---\n\nactual body\n",
+        )
+
+        wire_agents_atomically(project, [artifact], {"claudecode"})
+
+        cc_wrap = project / ".claude" / "agents" / "_partials" / "with-fm.md"
+        content = cc_wrap.read_text()
+        # Exactly one frontmatter block at the head.
+        assert content.count("\n---\n") == 1, (
+            f"Expected exactly one frontmatter block, got:\n{content}"
+        )
+        # The partial's original frontmatter values are gone.
+        assert "foo: bar" not in content
+        # The body survives.
+        assert content.endswith("actual body\n")
+
+    def test_wrapper_conflicts_with_unrelated_user_file(self, tmp_path):
+        """If a user-authored regular file already sits at the wrapper path
+        and its content does NOT match the wrapper we'd write, the wire must
+        raise RegularFileConflictError — same protection as for top-level
+        agent destinations.
+        """
+        project = tmp_path / "proj"
+        project.mkdir()
+        artifact = _make_artifact(tmp_path / "warehouse", "spec-planner.md")
+        _make_partial(
+            project / ".agentic-beacon" / "artifacts",
+            "deep-review-checklist.md",
+            content="# checklist\n\nbody\n",
+        )
+
+        cc_dir = project / ".claude" / "agents" / "_partials"
+        cc_dir.mkdir(parents=True, exist_ok=True)
+        user_file = cc_dir / "deep-review-checklist.md"
+        user_file.write_text("hand-written user content")
+
+        with pytest.raises(RegularFileConflictError):
+            wire_agents_atomically(project, [artifact], {"claudecode"})
+
+        # User file untouched.
+        assert user_file.read_text() == "hand-written user content"

--- a/libs/beacon/tests/unit/test_wire_agents.py
+++ b/libs/beacon/tests/unit/test_wire_agents.py
@@ -1198,3 +1198,61 @@ class TestWirePartialPER238Wrapper:
         cc_second = project / ".claude" / "agents" / "_partials" / "second.md"
         assert "v2" in cc_first.read_text()
         assert "second body" in cc_second.read_text()
+
+    def test_refreshed_wrapper_rolled_back_when_later_wire_fails(
+        self, tmp_path, monkeypatch
+    ):
+        """Regression for opencode-review round-2 Medium finding on PR #157:
+
+        When ``_wire_partial`` refreshes an existing Beacon-owned wrapper
+        in-place (because the warehouse partial body drifted), the refreshed
+        content must be rolled back to its pre-wire state if a later wire
+        step fails. Before the fix, ``snapshot_agent_path`` recorded
+        ``regular_file`` for the existing wrapper and the rollback closure
+        treated that snapshot as a no-op, leaving the partial-applied refresh
+        on disk after a failure.
+        """
+        from beacon.domains.setup import wiring as wiring_mod
+
+        project = tmp_path / "proj"
+        project.mkdir()
+        artifact = _make_artifact(tmp_path / "warehouse", "spec-planner.md")
+        first = _make_partial(
+            project / ".agentic-beacon" / "artifacts", "first.md", "v1\n"
+        )
+        _make_partial(
+            project / ".agentic-beacon" / "artifacts", "second.md", "second body\n"
+        )
+
+        # Initial sync — both wrappers written.
+        wire_agents_atomically(project, [artifact], {"claudecode"})
+        cc_first = project / ".claude" / "agents" / "_partials" / "first.md"
+        v1_content = cc_first.read_text()
+        assert "v1" in v1_content
+
+        # Drift the first partial body, then arrange for the SECOND wire to
+        # fail. The first wire will refresh the wrapper from v1 → v2 and
+        # rollback must put v1 back.
+        first.write_text("v2\n")
+        real_wire_partial = wiring_mod._wire_partial
+        calls = {"n": 0}
+
+        def flaky_wire_partial(*args, **kwargs):
+            calls["n"] += 1
+            if calls["n"] == 2:
+                raise BeaconSyncError("simulated mid-wire failure")
+            return real_wire_partial(*args, **kwargs)
+
+        monkeypatch.setattr(wiring_mod, "_wire_partial", flaky_wire_partial)
+
+        with pytest.raises(BeaconSyncError, match="simulated mid-wire failure"):
+            wire_agents_atomically(project, [artifact], {"claudecode"})
+
+        # The refreshed wrapper must be restored to the pre-wire (v1) state.
+        restored = cc_first.read_text()
+        assert restored == v1_content, (
+            "Refreshed wrapper not rolled back; expected pre-wire content "
+            f"but got:\n{restored}"
+        )
+        # Sanity: the flaky wrapper was actually invoked twice.
+        assert calls["n"] == 2


### PR DESCRIPTION
## Summary

- **Stopgap fix for [PER-238](https://linear.app/shadowsong-personal/issue/PER-238/opencode-exposes-agents-partials-and-agentsreadmemd-as-callable):** opencode (and likely Claude Code) was surfacing `_partials/deep-review-checklist` as a callable subagent because PER-164 wires partials into `.<tool>/agents/_partials/*.md` and opencode's agent discovery is recursive without filtering.
- **Approach:** rewrite `_wire_partial` to emit a regular file with `disable: true` frontmatter instead of a raw symlink. Partial body is inlined verbatim below the frontmatter so agents that reference the partial via a relative markdown link still see the full content.
- **Empirically verified** (opencode `1.14.31`): `disable: true` removes the agent from both `opencode agent list` and the LLM-facing Task-tool agent listing. `hidden: true` was tested first and rejected — it only hides from TUI `@`-autocomplete.

## Why a stopgap, not the final fix?

The architecturally clean fix is Option C in PER-238: stop co-distributing partials entirely and rewrite the supervisor agents to reference them via canonical project-relative paths under `.agentic-beacon/artifacts/...`. That depends on [PER-206](https://linear.app/shadowsong-personal/issue/PER-206/resolve-and-gate-artifact-reference-paths-so-markdown-links-survive) (canonical link form + lint + integration tests), which is multi-day work. Today's `_partials/deep-review-checklist` leak shows up in **every opencode session** in this repo, so a half-day stopgap is worth it.

Sequencing:

1. **This PR** — disable-frontmatter wrappers (PER-238 stopgap).
2. PER-206 — establish canonical link form, add lint, integration test for cross-artifact resolution.
3. PER-238 final — delete `_wire_partial`, rewrite supervisor links to canonical form, drop the wrapper machinery.

## Code changes

`libs/beacon/src/beacon/domains/setup/wiring.py` (+103 / −51):

- New `_PARTIAL_WRAPPER_FRONTMATTER` constant — the frontmatter block (`description`, `mode: subagent`, `disable: true`) with explanatory PER-238 comment.
- New `_strip_existing_frontmatter(body)` helper — defensive: if a future partial ships its own YAML frontmatter, strip it so the wrapper doesn't emit two `---` blocks back-to-back.
- New `_build_partial_wrapper(partial_file)` helper — composes wrapper frontmatter + (cleaned) partial body.
- Rewrote `_wire_partial`: writes a regular-file wrapper instead of `dest.symlink_to(partial_file)`. Idempotent — if the existing file matches the wrapper we'd write, leave it alone (preserves mtime). Auto-migrates pre-PER-238 raw symlinks.
- Updated the pre-flight scan in `wire_agents_atomically` to recognise our own wrappers as non-conflicts (only flags regular-file conflicts when content differs from the wrapper we'd write — i.e. user-authored content).

## Tests

`libs/beacon/tests/unit/test_wire_agents.py` (+148 / −16):

- Updated 3 existing partial tests for the regular-file wrapper shape (`test_partials_wired_to_both_tools`, `test_partials_idempotent`, `test_partials_preserve_subdirectory_structure`).
- Added `TestWirePartialPER238Wrapper` with 4 new tests:
  - `test_wrapper_carries_disable_true_frontmatter` — wrapper starts with `---`, contains `mode: subagent` and `disable: true`, body inlined verbatim.
  - `test_wrapper_replaces_pre_per238_symlink` — migration: legacy raw symlink replaced by wrapper without raising.
  - `test_wrapper_strips_existing_partial_frontmatter` — defensive: partials shipping their own frontmatter don't produce double-fenced output.
  - `test_wrapper_conflicts_with_unrelated_user_file` — user-authored regular file at the wrapper path still raises `RegularFileConflictError`.

`libs/beacon/tests/integration/test_agent_sync_lifecycle.py` (+16 / −4):

- Updated `test_sync_with_agent_partials` symlink assertions to wrapper-file assertions.

**Test results:** 1457 passed, 15 skipped, 0 failed (`BEACON_OFFLINE=1 pytest`).

## Empirical end-to-end verification

On `agentic-beacon` itself, after the fix:

1. Restored a legacy raw symlink at `.claude/agents/_partials/deep-review-checklist.md` to test migration.
2. Ran `abc sync --skip-git-check` → both `.{claude,opencode}/agents/_partials/deep-review-checklist.md` are now regular files (4442 bytes; matches frontmatter + body).
3. `opencode agent list` no longer lists `_partials/deep-review-checklist`. Only the three real beacon agents remain.
4. **LLM probe** — `opencode run --model openai/gpt-5.4-mini "List ONLY the names of subagents you can invoke via the Task tool…"` returns:

   ```
   - diligent-supervisor
   - explore
   - general
   - implementation-supervisor
   - spec-planner
   - tmp-frontmatter-probe   ← unrelated stale global agent
   ```

   `_partials/deep-review-checklist` is gone from the model's view.

## Out of scope (intentionally)

- **`agents/README.md` distribution.** Originally cited in the ticket; on inspection, Beacon already filters `README.md` out at every enumeration site (`distributor.py:361,376`; `orchestrator.py:260`; `lint.py:315`). The `README` agent observed in the LLM listing came from orphaned `~/.config/opencode/agents/README.md` and `~/.claude/agents/README.md`, not anything Beacon wires today. Cleaned up locally; no Beacon code change needed.
- **Rewriting supervisor agent links.** The current `[checklist](_partials/deep-review-checklist.md)` relative link still resolves — to the wrapper, which has the body inlined. The link rewrite to canonical form happens in the PER-238 final fix once PER-206 lands.

## Linear

PER-238 — see ticket body and comment thread for the full design rationale, the `hidden:` vs `disable:` empirical test, and the working-order plan.