### PR TITLE
feat: canonical artifact-link convention with lint integrity, autofix, and partials restructure

### DIFF
--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,9 @@
+# Gitignored-but-locally-useful paths copied into delegate worktrees by
+# delegate-to-oc / delegate-to-cc (delegate_ticket.sh).
+#
+# These are abc-sync-distributed harness artifacts (symlinks/files under the
+# tool dirs) that are gitignored, so a fresh `git worktree` does not carry them.
+# Delegates need the project-local skills — notably openspec-apply-change, which
+# the --openspec fast-path requires — to resolve inside the worktree.
+.opencode/skills/
+.claude/skills/

--- a/libs/beacon/src/beacon/cli/warehouse.py
+++ b/libs/beacon/src/beacon/cli/warehouse.py
@@ -594,6 +594,10 @@ def _print_lint_report(report: LintReport, _console: Console | None = None) -> N
     from rich.markup import escape
 
     c = _console if _console is not None else console
+    if report.rewritten_links or report.files_touched or "--fix" in " ".join(sys.argv):
+        c.print(
+            f"[cyan]Rewrote {report.rewritten_links} link(s) across {report.files_touched} file(s).[/cyan]"
+        )
     if not report:
         c.print("[green]✓ Lint passed.[/green]")
         return
@@ -627,7 +631,12 @@ def _print_lint_report(report: LintReport, _console: Console | None = None) -> N
     required=False,
     default=None,
 )
-def warehouse_lint(*, warehouse_path: Path | None) -> None:
+@click.option(
+    "--fix",
+    is_flag=True,
+    help="Rewrite fixable cross-artifact links in place before linting.",
+)
+def warehouse_lint(*, warehouse_path: Path | None, fix: bool) -> None:
     """Validate a warehouse directory end-to-end.
 
     Runs every Beacon-owned artifact validation rule against the warehouse at
@@ -643,8 +652,9 @@ def warehouse_lint(*, warehouse_path: Path | None) -> None:
     Examples:
         abc warehouse lint
         abc warehouse lint /path/to/warehouse
+        abc warehouse lint --fix /path/to/warehouse
     """
     target = warehouse_path or Path.cwd()
-    report = lint_warehouse(target)
+    report = lint_warehouse(target, fix=fix)
     _print_lint_report(report)
     sys.exit(1 if report.findings else 0)

--- a/libs/beacon/src/beacon/cli/warehouse.py
+++ b/libs/beacon/src/beacon/cli/warehouse.py
@@ -594,7 +594,7 @@ def _print_lint_report(report: LintReport, _console: Console | None = None) -> N
     from rich.markup import escape
 
     c = _console if _console is not None else console
-    if report.rewritten_links or report.files_touched or "--fix" in " ".join(sys.argv):
+    if report.fix_requested or report.rewritten_links or report.files_touched:
         c.print(
             f"[cyan]Rewrote {report.rewritten_links} link(s) across {report.files_touched} file(s).[/cyan]"
         )

--- a/libs/beacon/src/beacon/core/scanner/scanner.py
+++ b/libs/beacon/src/beacon/core/scanner/scanner.py
@@ -173,7 +173,14 @@ def extract_markdown_headings(path: Path) -> list[str]:
         if match is None:
             continue
 
-        slug = slugify_heading(match.group(2))
+        heading_text = match.group(2)
+        # Strip optional ATX "closing hash" suffix (e.g. ``## Setup ##``).
+        # CommonMark/GFM allow a trailing ``\s+#+\s*$`` after the heading
+        # body; without stripping it, ``## Setup ##`` slugifies to
+        # ``setup-`` instead of ``setup`` and breaks anchor resolution.
+        heading_text = re.sub(r"\s+#+\s*$", "", heading_text)
+
+        slug = slugify_heading(heading_text)
         duplicate_count = seen_counts.get(slug, 0)
         seen_counts[slug] = duplicate_count + 1
         if duplicate_count:
@@ -191,14 +198,28 @@ def is_absolute_url(target: str) -> bool:
 def resolve_canonical_link(
     link_target: str, warehouse_root: Path
 ) -> tuple[Path, str | None] | None:
-    """Resolve a canonical artifact link to a warehouse path and optional anchor."""
+    """Resolve a canonical artifact link to a warehouse path and optional anchor.
+
+    Returns ``None`` for non-canonical input AND for canonical-shaped input
+    whose path component escapes ``warehouse_root`` via ``..`` traversal —
+    e.g. ``.agentic-beacon/artifacts/../../outside.md`` is rejected.
+    Treating a path-traversal payload as canonical would let an attacker
+    smuggle a warehouse-escape link past the canonical-vs-relative
+    classifier; the classifier reroutes such links to
+    ``LINK_WAREHOUSE_ESCAPE`` instead.
+    """
     if not link_target.startswith(CANONICAL_PREFIX):
         return None
 
     path_part, separator, anchor = link_target.partition("#")
     warehouse_relative = path_part.removeprefix(CANONICAL_PREFIX)
+    target_path = (warehouse_root / warehouse_relative).resolve(strict=False)
+    try:
+        target_path.relative_to(warehouse_root.resolve())
+    except ValueError:
+        return None
     resolved_anchor = unquote(anchor) if separator else None
-    return warehouse_root / warehouse_relative, resolved_anchor
+    return target_path, resolved_anchor
 
 
 def classify_link(link_target: str, source_file: Path, warehouse_root: Path) -> str:
@@ -206,6 +227,13 @@ def classify_link(link_target: str, source_file: Path, warehouse_root: Path) -> 
     if is_absolute_url(link_target):
         return LINK_ABSOLUTE_URL
     if link_target.startswith(CANONICAL_PREFIX):
+        # Reject canonical-shaped input that escapes the warehouse via
+        # ``..`` traversal — e.g. ``.agentic-beacon/artifacts/../../x.md``.
+        # A naive prefix-strip would treat this as a valid canonical
+        # reference; reroute it to the warehouse-escape category so the
+        # lint emits a finding instead of silently passing.
+        if resolve_canonical_link(link_target, warehouse_root) is None:
+            return LINK_WAREHOUSE_ESCAPE
         return LINK_CANONICAL
 
     path_part = link_target.split("#", 1)[0]
@@ -229,14 +257,28 @@ def classify_link(link_target: str, source_file: Path, warehouse_root: Path) -> 
 
 
 def to_canonical(link_target: str, source_file: Path, warehouse_root: Path) -> str:
-    """Convert a relative cross-artifact link into canonical artifact form."""
+    """Convert a relative cross-artifact link into canonical artifact form.
+
+    Special-cases the legacy ``agents/_partials/...`` location: any
+    relative reference that resolves there is canonicalised to the
+    Phase-4 ``agent-partials/...`` top-level location instead. After the
+    warehouse migration moves partials out of ``agents/_partials/`` and
+    Beacon's distribution glob retargets to ``agent-partials/**``, a link
+    rewritten to ``.agentic-beacon/artifacts/agents/_partials/x.md``
+    would pass lint shape-wise but never resolve in a synced project
+    because sync no longer mirrors that path. Rewriting straight to the
+    new location keeps ``--fix`` safe during and after the migration.
+    """
     if link_target.startswith(CANONICAL_PREFIX):
         return link_target
 
     path_part, separator, anchor = link_target.partition("#")
     resolved = (source_file.parent / path_part).resolve()
     warehouse_relative = resolved.relative_to(warehouse_root.resolve())
-    canonical = f"{CANONICAL_PREFIX}{warehouse_relative.as_posix()}"
+    rel_posix = warehouse_relative.as_posix()
+    if rel_posix.startswith("agents/_partials/"):
+        rel_posix = "agent-partials/" + rel_posix[len("agents/_partials/") :]
+    canonical = f"{CANONICAL_PREFIX}{rel_posix}"
     if separator:
         return f"{canonical}#{anchor}"
     return canonical

--- a/libs/beacon/src/beacon/core/scanner/scanner.py
+++ b/libs/beacon/src/beacon/core/scanner/scanner.py
@@ -14,6 +14,13 @@ from loguru import logger
 
 from beacon.core.manifest.beacon import BeaconManifest
 
+CANONICAL_PREFIX = ".agentic-beacon/artifacts/"
+LINK_ABSOLUTE_URL = "absolute-url"
+LINK_CANONICAL = "canonical"
+LINK_OWN_SKILL_FOLDER = "own-skill-folder"
+LINK_CROSS_ARTIFACT_RELATIVE = "cross-artifact-relative"
+LINK_WAREHOUSE_ESCAPE = "warehouse-escape"
+
 
 @dataclass(frozen=True)
 class LinkRef:
@@ -122,9 +129,130 @@ def normalize_link_target(target: str) -> str:
     return target
 
 
+def slugify_heading(heading: str) -> str:
+    """Convert a markdown heading to GitHub-compatible anchor text."""
+    heading = heading.replace("`", "").strip().lower()
+
+    filtered_chars: list[str] = []
+    for char in heading:
+        if char.isalnum() or char in {" ", "-"}:
+            filtered_chars.append(char)
+
+    return "".join(filtered_chars).replace(" ", "-")
+
+
+def extract_markdown_headings(path: Path) -> list[str]:
+    """Extract ATX heading slugs from a markdown file in document order."""
+    try:
+        content = path.read_text(encoding="utf-8")
+    except OSError:
+        return []
+
+    in_code_fence = False
+    fence_char = None
+    seen_counts: dict[str, int] = {}
+    headings: list[str] = []
+
+    for line in content.splitlines():
+        stripped = line.lstrip()
+
+        if not in_code_fence and (
+            stripped.startswith("```") or stripped.startswith("~~~")
+        ):
+            in_code_fence = True
+            fence_char = stripped[:3]
+            continue
+        if in_code_fence and fence_char is not None and stripped.startswith(fence_char):
+            in_code_fence = False
+            fence_char = None
+            continue
+        if in_code_fence:
+            continue
+
+        match = re.match(r"^\s{0,3}(#{1,6})\s+(.*?)\s*$", line)
+        if match is None:
+            continue
+
+        slug = slugify_heading(match.group(2))
+        duplicate_count = seen_counts.get(slug, 0)
+        seen_counts[slug] = duplicate_count + 1
+        if duplicate_count:
+            slug = f"{slug}-{duplicate_count}"
+        headings.append(slug)
+
+    return headings
+
+
 def is_absolute_url(target: str) -> bool:
     """Return True if target is an absolute URL (has a scheme)."""
     return "://" in target or target.startswith("mailto:") or target.startswith("ftp:")
+
+
+def resolve_canonical_link(
+    link_target: str, warehouse_root: Path
+) -> tuple[Path, str | None] | None:
+    """Resolve a canonical artifact link to a warehouse path and optional anchor."""
+    if not link_target.startswith(CANONICAL_PREFIX):
+        return None
+
+    path_part, separator, anchor = link_target.partition("#")
+    warehouse_relative = path_part.removeprefix(CANONICAL_PREFIX)
+    resolved_anchor = unquote(anchor) if separator else None
+    return warehouse_root / warehouse_relative, resolved_anchor
+
+
+def classify_link(link_target: str, source_file: Path, warehouse_root: Path) -> str:
+    """Classify a markdown link target for canonical artifact linting."""
+    if is_absolute_url(link_target):
+        return LINK_ABSOLUTE_URL
+    if link_target.startswith(CANONICAL_PREFIX):
+        return LINK_CANONICAL
+
+    path_part = link_target.split("#", 1)[0]
+    resolved = (source_file.parent / path_part).resolve()
+    warehouse_root = warehouse_root.resolve()
+
+    try:
+        resolved.relative_to(warehouse_root)
+    except ValueError:
+        return LINK_WAREHOUSE_ESCAPE
+
+    skill_dir = _skill_dir_for_source(source_file, warehouse_root)
+    if skill_dir is not None:
+        try:
+            resolved.relative_to(skill_dir)
+            return LINK_OWN_SKILL_FOLDER
+        except ValueError:
+            pass
+
+    return LINK_CROSS_ARTIFACT_RELATIVE
+
+
+def to_canonical(link_target: str, source_file: Path, warehouse_root: Path) -> str:
+    """Convert a relative cross-artifact link into canonical artifact form."""
+    if link_target.startswith(CANONICAL_PREFIX):
+        return link_target
+
+    path_part, separator, anchor = link_target.partition("#")
+    resolved = (source_file.parent / path_part).resolve()
+    warehouse_relative = resolved.relative_to(warehouse_root.resolve())
+    canonical = f"{CANONICAL_PREFIX}{warehouse_relative.as_posix()}"
+    if separator:
+        return f"{canonical}#{anchor}"
+    return canonical
+
+
+def _skill_dir_for_source(source_file: Path, warehouse_root: Path) -> Path | None:
+    """Return the owning skill directory when the source lives under skills/<name>/."""
+    try:
+        relative = source_file.resolve().relative_to(warehouse_root.resolve())
+    except ValueError:
+        return None
+
+    parts = relative.parts
+    if len(parts) >= 3 and parts[0] == "skills":
+        return warehouse_root.resolve() / parts[0] / parts[1]
+    return None
 
 
 @dataclass(frozen=True)

--- a/libs/beacon/src/beacon/data/skills/contribute-warehouse/SKILL.md
+++ b/libs/beacon/src/beacon/data/skills/contribute-warehouse/SKILL.md
@@ -84,6 +84,7 @@ Warehouse lint failed. Resolve the following issues before contributing:
 <lint output>
 
 Suggested recovery:
+  - Run `abc warehouse lint --fix "$WAREHOUSE_ROOT"` for fixable malformed cross-artifact-relative links; it rewrites them to canonical form, preserves anchors, is idempotent, and is safe to run again. It does NOT fix warehouse-escape or missing-target findings — those stay manual.
   - Fix the failing files and re-run /contribute-warehouse
   - Or move the failing edits to a separate branch and re-run on a clean tree
   - As a last resort, you (the user) may discard the changes with
@@ -337,7 +338,7 @@ Contribution summary:
 ## Checklist for Agent
 
 - [ ] Run `resolve_warehouse.py` — STOP if exits non-zero
-- [ ] Run `abc warehouse lint <warehouse>` — STOP and surface errors if non-zero
+- [ ] Run `abc warehouse lint <warehouse>` — STOP and surface errors if non-zero; suggest `--fix` for fixable categories
 - [ ] Run `summarize_changes.py` — STOP if no dirty warehouse paths
 - [ ] Triage dirty files with the user (include / leave-for-later)
 - [ ] Dedup scan for `knowledge/` files — flag overlaps before proceeding

--- a/libs/beacon/src/beacon/domains/distribution/delta.py
+++ b/libs/beacon/src/beacon/domains/distribution/delta.py
@@ -414,9 +414,9 @@ class DeltaComparator:
                         summary.results.append(result)
 
             # Also iterate agents/ from warehouse when agents_paths is configured.
-            # Partials are co-distributed alongside agents (PER-164), so they
-            # are intentionally NOT skipped here — delta must surface missing
-            # or stale partial symlinks just like it does for agent files.
+            # Partials moved to top-level agent-partials/ in Phase 4, so this
+            # block now covers agent files only. Drift for mirrored
+            # agent-partials/ is surfaced through artifacts/ comparison.
             if self.agents_paths:
                 agents_dir = self.warehouse_path / "agents"
                 if agents_dir.is_dir():

--- a/libs/beacon/src/beacon/domains/distribution/distributor.py
+++ b/libs/beacon/src/beacon/domains/distribution/distributor.py
@@ -10,16 +10,16 @@ from beacon.core.file_filter import ARTIFACT_IGNORE_PATTERNS
 
 
 def is_partial_path(rel: Path | str) -> bool:
-    """Return True if the path is under an ``agents/_partials/`` directory.
+    """Return True if the path is a canonical or legacy agent partial.
 
-    Matches the warehouse convention for shared agent partials
-    (e.g. ``agents/_partials/deep-review-checklist.md``). The filter is
-    intentionally scoped to ``_partials/`` specifically — the same string
-    drives co-distribution in ``run_sync`` (``agents/_partials/**/*``), so
-    broadening the filter without broadening co-distribution would hide
-    files from agent listings while silently failing to ship them.
+    Accepts the canonical top-level ``agent-partials/`` location and the
+    legacy ``agents/_partials/`` / ``_partials/`` forms so agent discovery and
+    stale-prune paths can recognize pre-migration warehouses safely.
     """
     parts = Path(rel).parts
+
+    if parts and parts[0] == "agent-partials":
+        return True
 
     # Accept both warehouse-relative ('agents/_partials/...') and
     # agents-dir-relative ('_partials/...') input. Find the first occurrence

--- a/libs/beacon/src/beacon/domains/distribution/orchestrator.py
+++ b/libs/beacon/src/beacon/domains/distribution/orchestrator.py
@@ -360,9 +360,9 @@ def run_sync(
     for agent_entry in beacon_settings.artifacts.agents:
         artifact_paths.append(agent_entry)
 
-    # Co-distribute agent partials alongside declared agents (PER-164).
+    # Co-distribute agent partials alongside declared agents.
     if beacon_settings.artifacts.agents:
-        partial_matches = sync_engine.expand_glob("agents/_partials/**/*")
+        partial_matches = sync_engine.expand_glob("agent-partials/**/*")
         for partial_path in partial_matches:
             if (warehouse_path / partial_path).is_file():
                 artifact_paths.append(partial_path)

--- a/libs/beacon/src/beacon/domains/setup/wiring.py
+++ b/libs/beacon/src/beacon/domains/setup/wiring.py
@@ -490,11 +490,60 @@ def _is_beacon_owned_partial_wrapper(dest: Path) -> bool:
         return False
 
 
+def _is_beacon_owned_partial_symlink(path: Path, project_root: Path) -> bool:
+    """Return True if ``path`` is a symlink Beacon previously created.
+
+    Beacon-owned partial symlinks (pre-PER-238 layout) always pointed at a
+    location inside the project's ``.agentic-beacon/artifacts/`` mirror.
+    A symlink whose target resolves anywhere else is treated as
+    user-owned: a contributor may have legitimately hand-symlinked their
+    own partial into the tool dir, and sync must not silently delete it.
+
+    Returns False on any read error (defensively treat as user-owned).
+    """
+    try:
+        target = path.readlink()
+    except OSError:
+        return False
+
+    # Resolve the symlink's target relative to the symlink's parent dir
+    # so a relative target (the common Beacon shape) is judged correctly.
+    if target.is_absolute():
+        resolved = target
+    else:
+        resolved = (path.parent / target).resolve(strict=False)
+
+    artifacts_root = (project_root / ".agentic-beacon" / "artifacts").resolve()
+    try:
+        resolved.relative_to(artifacts_root)
+    except ValueError:
+        return False
+    return True
+
+
 def _prune_stale_tool_dir_partials(
     project_root: Path,
     detected_tools: Iterable[str],
 ) -> list[Path]:
-    """Prune Beacon-owned partials from legacy and transitional tool dirs."""
+    """Prune Beacon-owned partials from legacy and transitional tool dirs.
+
+    For each candidate path under ``.<tool>/agents/_partials/`` and
+    ``.<tool>/agents/agent-partials/``:
+
+    - Symlink whose target resolves inside ``.agentic-beacon/artifacts/``
+      → Beacon-owned (legacy PER-164/PER-238 layout); unlink.
+    - Symlink whose target resolves elsewhere → user-owned; preserve with a
+      warning. Sync must not silently delete a contributor's own symlinked
+      partial.
+    - Regular file matching the legacy wrapper-frontmatter prefix (via
+      ``_is_beacon_owned_partial_wrapper``) → Beacon-owned; unlink.
+    - Any other regular file → user-owned; preserve with a warning.
+
+    The ownership-aware policy mirrors the conflict-detection used by
+    ``wire_agents_atomically`` for top-level agent paths and addresses the
+    PR #159 round-2 review finding that symlinks were being deleted
+    unconditionally.
+    """
     pruned: list[Path] = []
     tool_roots = {
         "claudecode": project_root / ".claude" / "agents",
@@ -511,8 +560,14 @@ def _prune_stale_tool_dir_partials(
                 continue
             for path in sorted(partial_root.rglob("*"), reverse=True):
                 if path.is_symlink():
-                    path.unlink()
-                    pruned.append(path)
+                    if _is_beacon_owned_partial_symlink(path, project_root):
+                        path.unlink()
+                        pruned.append(path)
+                    else:
+                        logger.warning(
+                            "Preserving user-owned partial symlink {} during sync prune.",
+                            path,
+                        )
                 elif path.is_file():
                     if _is_beacon_owned_partial_wrapper(path):
                         path.unlink()

--- a/libs/beacon/src/beacon/domains/setup/wiring.py
+++ b/libs/beacon/src/beacon/domains/setup/wiring.py
@@ -462,22 +462,10 @@ def wire_agent_opencode(project_root: Path, artifact_file: Path) -> Path:
     return dest
 
 
-# PER-238 stopgap: partials co-distributed under .{tool}/agents/_partials/
-# get auto-discovered by opencode (and likely Claude Code) as full subagents,
-# polluting `@`-autocomplete and the LLM's Task-tool agent listing. Wrapping
-# each partial in a `disable: true` frontmatter block at wire time hides the
-# file from both empirically (verified against opencode 1.14.31 — see PER-238
-# comment thread for the test matrix). The partial body is inlined verbatim
-# below the frontmatter so agents that reference the partial via a relative
-# markdown link (e.g. `[checklist](_partials/deep-review-checklist.md)`) still
-# see the full content when they follow the link.
-#
-# Long-term fix (Option C in PER-238) is to stop co-distributing partials
-# entirely once PER-206's canonical-link form lands.
-_PARTIAL_WRAPPER_FRONTMATTER = (
+_LEGACY_PARTIAL_WRAPPER_FRONTMATTER = (
     "---\n"
     "description: >-\n"
-    "  Internal fragment referenced by other agents — not a real agent.\n"
+    "  Internal fragment referenced by other agents \u2014 not a real agent.\n"
     "  Disabled at wire time by Beacon (PER-238).\n"
     "mode: subagent\n"
     "disable: true\n"
@@ -485,168 +473,66 @@ _PARTIAL_WRAPPER_FRONTMATTER = (
 )
 
 
-def _strip_existing_frontmatter(body: str) -> str:
-    """If body starts with a YAML frontmatter block (``---\\n...---\\n``), strip it.
-
-    Defensive: today's only partial has no frontmatter, but if a future partial
-    starts shipping its own frontmatter we don't want to emit two `---` blocks
-    back-to-back (which would parse as malformed YAML and confuse opencode).
-    Returns the body verbatim if no frontmatter is detected.
-    """
-    if not body.startswith("---\n"):
-        return body
-    # Find the closing fence on its own line.
-    end = body.find("\n---\n", 4)
-    if end == -1:
-        # Malformed / unterminated — return as-is and let the model see it.
-        return body
-    return body[end + len("\n---\n") :].lstrip("\n")
-
-
-def _build_partial_wrapper(partial_file: Path) -> str:
-    """Render the wrapper file content for a partial.
-
-    Format: PER-238 stopgap frontmatter + the partial body verbatim (with any
-    existing frontmatter stripped to avoid double-fences).
-    """
-    body = partial_file.read_text(encoding="utf-8")
-    return _PARTIAL_WRAPPER_FRONTMATTER + _strip_existing_frontmatter(body)
-
-
 def _is_beacon_owned_partial_wrapper(dest: Path) -> bool:
     """Return True if ``dest`` is a regular file Beacon previously wrote as a
     partial wrapper.
 
-    We detect Beacon-owned wrappers by the **exact** frontmatter prefix
-    (``_PARTIAL_WRAPPER_FRONTMATTER``). The body below that prefix may
-    legitimately drift between syncs whenever the warehouse partial body is
-    edited, so refreshing such a file is safe and expected. Any other
-    regular file at the destination — including a hand-edited wrapper whose
-    frontmatter someone changed — is treated as user-owned.
+    We detect Beacon-owned wrappers by the exact legacy frontmatter prefix.
+    Any other regular file at the destination is treated as user-owned.
 
     Returns False on any read error (treat as user-owned, defensively).
     """
     try:
-        return dest.read_text(encoding="utf-8").startswith(_PARTIAL_WRAPPER_FRONTMATTER)
+        return dest.read_text(encoding="utf-8").startswith(
+            _LEGACY_PARTIAL_WRAPPER_FRONTMATTER
+        )
     except OSError:
         return False
 
 
-def _wire_partial(
+def _prune_stale_tool_dir_partials(
     project_root: Path,
-    partial_file: Path,
-    rel: Path,
-    tool: str,
-) -> Path:
-    """Wire a partial file into ``.<tool>/agents/<rel>`` as a wrapped regular file.
+    detected_tools: Iterable[str],
+) -> list[Path]:
+    """Prune Beacon-owned partials from legacy and transitional tool dirs."""
+    pruned: list[Path] = []
+    tool_roots = {
+        "claudecode": project_root / ".claude" / "agents",
+        "opencode": project_root / ".opencode" / "agents",
+    }
 
-    PER-238 stopgap: instead of a raw symlink (which opencode auto-discovers as
-    a full subagent), we write a regular file whose content is
-    ``disable: true`` frontmatter followed by the partial body inlined verbatim.
-    Empirically (opencode 1.14.31), ``disable: true`` removes the file from
-    both ``opencode agent list`` and the LLM's Task-tool agent listing while
-    keeping the body resolvable when other agents follow a relative markdown
-    link to it.
-
-    Idempotent: if the destination is already a regular file with identical
-    wrapped content, it is left untouched (preserves mtime — relied upon by
-    ``test_partials_idempotent``). A stale symlink (pre-PER-238 layout) or a
-    drifted wrapper file is replaced. The parent directory is created if it
-    does not exist.
-
-    Args:
-        project_root: Project root directory.
-        partial_file: Path to the partial artifact file in the warehouse —
-            its body is inlined into the wrapper at wire time.
-        rel: Relative path under agents/ (e.g.
-            ``_partials/deep-review-checklist.md``).
-        tool: ``"claudecode"`` or ``"opencode"``.
-
-    Returns:
-        Path to the wrapper file.
-
-    Raises:
-        RegularFileConflictError: If the destination is a regular file that
-            does NOT match the expected wrapper content (i.e. user-owned).
-    """
-    tool_dir = ".claude" if tool == "claudecode" else ".opencode"
-    dest = project_root / tool_dir / "agents" / rel
-    dest.parent.mkdir(parents=True, exist_ok=True)
-
-    expected = _build_partial_wrapper(partial_file)
-
-    if dest.is_symlink():
-        # Pre-PER-238 layout: a raw symlink. Always replace with a wrapper
-        # regardless of what it pointed at — the symlink itself is the bug.
-        dest.unlink()
-    elif dest.exists():
-        # Regular file at the destination. Two cases:
-        #   1. It's a Beacon-owned wrapper from a previous sync (recognised
-        #      by the exact wrapper frontmatter prefix). The body may have
-        #      drifted because the warehouse partial body was edited — that
-        #      is expected and we should refresh in place. If the content
-        #      already matches what we'd write, leave it alone to preserve
-        #      mtime (idempotent re-wire).
-        #   2. It's user-authored content that happens to sit at the same
-        #      path. Refuse to overwrite.
-        try:
-            current = dest.read_text(encoding="utf-8")
-        except OSError:
-            current = None
-        if current == expected:
-            return dest
-        if current is not None and current.startswith(_PARTIAL_WRAPPER_FRONTMATTER):
-            # Stale Beacon-owned wrapper — refresh below.
-            pass
-        else:
-            raise RegularFileConflictError(
-                conflicts=[
-                    AgentWireConflict(
-                        dest=dest,
-                        agent_name=str(rel),
-                        tool=tool,
-                    ),
-                ],
-            )
-
-    dest.write_text(expected, encoding="utf-8")
-    logger.debug(
-        "Wired partial wrapper to {}/agents/: {} (PER-238 stopgap)",
-        tool_dir,
-        rel,
-    )
-    return dest
-
-
-def _snapshot_partial_path(p: Path) -> tuple[str, Path | str | None]:
-    """Snapshot a partial destination's pre-wire state.
-
-    Like ``snapshot_agent_path`` but distinguishes Beacon-owned wrapper files
-    (``wrapper_file`` kind, content captured for rollback) from user-owned
-    regular files. Without this distinction the rollback closure in
-    ``wire_agents_atomically`` cannot restore a refreshed wrapper after a
-    later wire step fails — addressed in PER-238 PR #157 round-2 review.
-
-    Returns:
-        ("symlink", current_target)  — pre-PER-238 raw symlink, target captured.
-        ("wrapper_file", content)    — Beacon-owned wrapper, full content captured.
-        ("regular_file", None)       — user-owned regular file (never modified).
-        ("missing", None)            — nothing there yet.
-    """
-    if p.is_symlink():
-        return ("symlink", p.readlink())
-    if p.is_file():
-        if _is_beacon_owned_partial_wrapper(p):
+    for tool in detected_tools:
+        agents_root = tool_roots.get(tool)
+        if agents_root is None:
+            continue
+        for rel_dir in (Path("_partials"), Path("agent-partials")):
+            partial_root = agents_root / rel_dir
+            if not partial_root.exists():
+                continue
+            for path in sorted(partial_root.rglob("*"), reverse=True):
+                if path.is_symlink():
+                    path.unlink()
+                    pruned.append(path)
+                elif path.is_file():
+                    if _is_beacon_owned_partial_wrapper(path):
+                        path.unlink()
+                        pruned.append(path)
+                    else:
+                        logger.warning(
+                            "Preserving user-owned partial path {} during sync prune.",
+                            path,
+                        )
+            for directory in sorted(partial_root.rglob("*"), reverse=True):
+                if directory.is_dir():
+                    try:
+                        directory.rmdir()
+                    except OSError:
+                        pass
             try:
-                return ("wrapper_file", p.read_text(encoding="utf-8"))
+                partial_root.rmdir()
             except OSError:
-                # Fall through and treat as user-owned defensively. The
-                # in-flight wire helpers will refuse to mutate it anyway.
-                return ("regular_file", None)
-        return ("regular_file", None)
-    if p.exists():
-        return ("regular_file", None)
-    return ("missing", None)
+                pass
+    return pruned
 
 
 def wire_agents_atomically(
@@ -660,10 +546,6 @@ def wire_agents_atomically(
     pre-wire state, then calls the tool-specific wire_agent_* helper. If any
     wire raises, restores ALL previously-wired destinations to their pre-wire
     state and re-raises the original exception.
-
-    When partial files exist under .agentic-beacon/artifacts/agents/_partials/,
-    they are also wired into each detected tool's .<tool>/agents/_partials/
-    directory (PER-164).
 
     Args:
         project_root: Root of the project (where .claude/ / .opencode/ live).
@@ -696,14 +578,7 @@ def wire_agents_atomically(
         operates at a tighter atomic boundary (single session commit) where
         any partial restore is itself a correctness concern worth raising.
     """
-    # Collect partial files from .agentic-beacon/artifacts/agents/_partials/
-    artifacts_agents_dir = project_root / ".agentic-beacon" / "artifacts" / "agents"
-    partial_files: list[Path] = []
-    partials_dir = artifacts_agents_dir / "_partials"
-    if partials_dir.is_dir():
-        for p in sorted(partials_dir.rglob("*")):
-            if p.is_file():
-                partial_files.append(p)
+    _prune_stale_tool_dir_partials(project_root, detected_tools)
 
     # Pre-flight: collect ALL regular-file conflicts before touching anything.
     # Aborts with a structured error so the caller can present every blocked
@@ -734,31 +609,6 @@ def wire_agents_atomically(
                         tool="opencode",
                     )
                 )
-
-    # Also check partial destinations (PER-164/PER-238). Unlike top-level
-    # agent destinations, a regular file at a partial path is **expected**
-    # post-PER-238 — it's a Beacon-owned wrapper from a previous sync. We
-    # recognise wrappers by the exact frontmatter prefix; a stale wrapper
-    # whose body drifted (because the warehouse partial body was edited)
-    # is **not** a conflict and will be refreshed in `_wire_partial`. Only
-    # flag genuinely user-authored regular files.
-    for partial_file in partial_files:
-        rel = partial_file.relative_to(artifacts_agents_dir)
-        for tool, tool_dir in (("claudecode", ".claude"), ("opencode", ".opencode")):
-            if tool not in detected_tools:
-                continue
-            dest = project_root / tool_dir / "agents" / rel
-            if not (dest.is_file() and not dest.is_symlink()):
-                continue
-            if _is_beacon_owned_partial_wrapper(dest):
-                continue  # Beacon-owned wrapper — idempotent or refresh.
-            pre_conflicts.append(
-                AgentWireConflict(
-                    dest=dest,
-                    agent_name=str(rel),
-                    tool=tool,
-                )
-            )
 
     if pre_conflicts:
         raise RegularFileConflictError(conflicts=pre_conflicts)
@@ -817,18 +667,6 @@ def wire_agents_atomically(
                 snapshots.append((oc_dest, *snapshot_agent_path(oc_dest)))
                 wire_agent_opencode(project_root, artifact_file)
 
-        # Wire partials into each detected tool (PER-164/PER-238).
-        # Use _snapshot_partial_path so refreshed wrappers can be rolled back.
-        for partial_file in partial_files:
-            rel = partial_file.relative_to(artifacts_agents_dir)
-            if "claudecode" in detected_tools:
-                cc_dest = project_root / ".claude" / "agents" / rel
-                snapshots.append((cc_dest, *_snapshot_partial_path(cc_dest)))
-                _wire_partial(project_root, partial_file, rel, "claudecode")
-            if "opencode" in detected_tools:
-                oc_dest = project_root / ".opencode" / "agents" / rel
-                snapshots.append((oc_dest, *_snapshot_partial_path(oc_dest)))
-                _wire_partial(project_root, partial_file, rel, "opencode")
     except Exception:
         _rollback()
         raise

--- a/libs/beacon/src/beacon/domains/setup/wiring.py
+++ b/libs/beacon/src/beacon/domains/setup/wiring.py
@@ -578,6 +578,16 @@ def wire_agents_atomically(
         operates at a tighter atomic boundary (single session commit) where
         any partial restore is itself a correctness concern worth raising.
     """
+    # Stale-partial prune runs FIRST, intentionally outside the rollback
+    # snapshot. Rationale: prune deletes ONLY Beacon-owned wrappers (gated by
+    # _is_beacon_owned_partial_wrapper's exact-prefix check) and stale
+    # symlinks; user-authored regular files at partial paths are preserved
+    # with a warning. The prune is therefore (a) non-destructive of user
+    # content and (b) idempotent — the next sync re-runs the same prune as a
+    # no-op. Including it in the rollback transaction would force re-creating
+    # Beacon-owned wrappers we just deleted intentionally; on a wire failure,
+    # the next successful sync converges to the same end state. Reviewed in
+    # PR #159 (gate-artifact-reference-paths phase 4).
     _prune_stale_tool_dir_partials(project_root, detected_tools)
 
     # Pre-flight: collect ALL regular-file conflicts before touching anything.

--- a/libs/beacon/src/beacon/domains/warehouse/lint.py
+++ b/libs/beacon/src/beacon/domains/warehouse/lint.py
@@ -51,6 +51,7 @@ class LintReport:
     findings: tuple[LintFinding, ...]
     rewritten_links: int = 0
     files_touched: int = 0
+    fix_requested: bool = False
 
     def __bool__(self) -> bool:
         return bool(self.findings)
@@ -77,6 +78,7 @@ def lint_warehouse(warehouse_path: Path, *, fix: bool = False) -> LintReport:
         findings=tuple(sorted_findings),
         rewritten_links=rewritten_links,
         files_touched=files_touched,
+        fix_requested=fix,
     )
 
 

--- a/libs/beacon/src/beacon/domains/warehouse/lint.py
+++ b/libs/beacon/src/beacon/domains/warehouse/lint.py
@@ -119,6 +119,20 @@ def _iter_artifact_markdown_files(warehouse_path: Path) -> list[tuple[Path, str]
                     (file_path, file_path.relative_to(warehouse_path).as_posix())
                 )
 
+    # agent-partials/ is a first-class artifact family in the Phase 4 layout
+    # — partial bodies (e.g. agent-partials/deep-review-checklist.md) are
+    # mirrored into projects and may themselves contain canonical links
+    # back to other artifacts. Scan them under the same rules so a malformed
+    # cross-artifact link inside a shared partial does not slip past lint
+    # and get distributed to every project that pulls the partial.
+    agent_partials_dir = warehouse_path / "agent-partials"
+    if agent_partials_dir.exists() and agent_partials_dir.is_dir():
+        for file_path in sorted(agent_partials_dir.rglob("*.md")):
+            if file_path.is_file():
+                files_to_scan.append(
+                    (file_path, file_path.relative_to(warehouse_path).as_posix())
+                )
+
     return files_to_scan
 
 
@@ -474,11 +488,17 @@ def _fix_artifact_links(warehouse_path: Path) -> tuple[int, int]:
 
             changed = True
             rewritten_links += 1
-            return full_text.replace(
-                match.group(2),
-                to_canonical(target, current_file_path, warehouse_path),
-                1,
-            )
+            # Rebuild the link from regex spans so we only ever rewrite the
+            # target (group 2), never the label (group 1). A naive
+            # ``full_text.replace(group(2), ..., 1)`` corrupts links of the
+            # form ``[../../contexts/a.md](../../contexts/a.md)`` — `replace`
+            # finds the label text first and rewrites it instead of the
+            # destination. Using span slicing relative to the match keeps the
+            # label byte-for-byte and only replaces the parenthesised target.
+            target_start = match.start(2) - match.start(0)
+            target_end = match.end(2) - match.start(0)
+            new_target = to_canonical(target, current_file_path, warehouse_path)
+            return full_text[:target_start] + new_target + full_text[target_end:]
 
         out_lines: list[str] = []
         in_code_fence = False

--- a/libs/beacon/src/beacon/domains/warehouse/lint.py
+++ b/libs/beacon/src/beacon/domains/warehouse/lint.py
@@ -436,8 +436,16 @@ def _lint_artifact_links(warehouse_path: Path) -> list[LintFinding]:
     return sorted(findings, key=lambda f: (f.artifact_path, f.message))
 
 
+_INLINE_LINK_RE = re.compile(r"(?<!\\)(?<!!)\[([^\]]*)\]\(([^)]+)\)")
+
+
 def _fix_artifact_links(warehouse_path: Path) -> tuple[int, int]:
-    """Rewrite fixable cross-artifact links in place and report counts."""
+    """Rewrite fixable cross-artifact links in place and report counts.
+
+    Mirrors ``extract_markdown_links`` exactly so ``--fix`` only ever touches
+    links that the lint would actually flag: links inside fenced code blocks
+    (``` / ~~~) and inline code spans (backticks) are left untouched.
+    """
     rewritten_links = 0
     files_touched = 0
 
@@ -470,16 +478,44 @@ def _fix_artifact_links(warehouse_path: Path) -> tuple[int, int]:
                 1,
             )
 
-        updated = re.sub(
-            r"(?<!\\)(?<!!)\[([^\]]*)\]\(([^)]+)\)", replace_link, original
-        )
+        out_lines: list[str] = []
+        in_code_fence = False
+        fence_char: str | None = None
+        for line in original.splitlines(keepends=True):
+            stripped = line.lstrip()
+
+            # Toggle fenced code block state on ``` or ~~~ at line start.
+            if not in_code_fence and (
+                stripped.startswith("```") or stripped.startswith("~~~")
+            ):
+                in_code_fence = True
+                fence_char = stripped[:3]
+                out_lines.append(line)
+                continue
+            if (
+                in_code_fence
+                and fence_char is not None
+                and stripped.startswith(fence_char)
+            ):
+                in_code_fence = False
+                fence_char = None
+                out_lines.append(line)
+                continue
+            if in_code_fence:
+                out_lines.append(line)
+                continue
+
+            # Outside fences: rewrite only the segments outside inline code
+            # spans (odd-indexed backtick splits are inside inline code).
+            parts = line.split("`")
+            for i, part in enumerate(parts):
+                if i % 2 == 0:
+                    parts[i] = _INLINE_LINK_RE.sub(replace_link, part)
+            out_lines.append("`".join(parts))
+
+        updated = "".join(out_lines)
         if changed and updated != original:
             file_path.write_text(updated, encoding="utf-8")
             files_touched += 1
 
     return rewritten_links, files_touched
-
-
-def _lint_knowledge_links(warehouse_path: Path) -> list[LintFinding]:
-    """Backward-compat shim to preserve direct test imports during the change."""
-    return _lint_artifact_links(warehouse_path)

--- a/libs/beacon/src/beacon/domains/warehouse/lint.py
+++ b/libs/beacon/src/beacon/domains/warehouse/lint.py
@@ -6,6 +6,7 @@ directory end-to-end by composing existing path-agnostic primitives.
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -20,11 +21,17 @@ from beacon.core.dependencies.manifest import (
     validate_declared_skills,
 )
 from beacon.core.scanner.scanner import (
-    classify_knowledge_ref,
+    LINK_ABSOLUTE_URL,
+    LINK_CANONICAL,
+    LINK_CROSS_ARTIFACT_RELATIVE,
+    LINK_OWN_SKILL_FOLDER,
+    LINK_WAREHOUSE_ESCAPE,
+    classify_link,
+    extract_markdown_headings,
     extract_markdown_links,
-    is_absolute_url,
-    normalize_link_target,
-    resolve_link,
+    resolve_canonical_link,
+    slugify_heading,
+    to_canonical,
 )
 from beacon.domains.warehouse.validator import WarehouseValidator
 
@@ -42,25 +49,20 @@ class LintReport:
     """Aggregated lint report for a warehouse directory."""
 
     findings: tuple[LintFinding, ...]
+    rewritten_links: int = 0
+    files_touched: int = 0
 
     def __bool__(self) -> bool:
         return bool(self.findings)
 
 
-def lint_warehouse(warehouse_path: Path) -> LintReport:
-    """Validate a warehouse directory end-to-end.
-
-    Calls every rule helper, concatenates findings in fixed order, and
-    returns a LintReport. Rule helpers never raise — any exception from a
-    primitive is caught and converted to a LintFinding.
-
-    Args:
-        warehouse_path: Path to the warehouse directory.
-
-    Returns:
-        LintReport with all findings across all rules.
-    """
+def lint_warehouse(warehouse_path: Path, *, fix: bool = False) -> LintReport:
+    """Validate a warehouse directory end-to-end."""
     resolved = Path(warehouse_path).expanduser().resolve()
+    rewritten_links = 0
+    files_touched = 0
+    if fix:
+        rewritten_links, files_touched = _fix_artifact_links(resolved)
 
     findings: list[LintFinding] = []
     findings.extend(_lint_structure(resolved))
@@ -68,11 +70,54 @@ def lint_warehouse(warehouse_path: Path) -> LintReport:
     findings.extend(_lint_skill_requires(resolved))
     findings.extend(_lint_agent_manifest(resolved))
     findings.extend(_lint_agent_frontmatter(resolved))
-    findings.extend(_lint_knowledge_links(resolved))
+    findings.extend(_lint_artifact_links(resolved))
 
-    # Sort by (artifact_path, message) for stable cross-platform ordering
     sorted_findings = sorted(findings, key=lambda f: (f.artifact_path, f.message))
-    return LintReport(findings=tuple(sorted_findings))
+    return LintReport(
+        findings=tuple(sorted_findings),
+        rewritten_links=rewritten_links,
+        files_touched=files_touched,
+    )
+
+
+def _iter_artifact_markdown_files(warehouse_path: Path) -> list[tuple[Path, str]]:
+    """Return every markdown artifact path covered by the artifact-link lint."""
+    files_to_scan: list[tuple[Path, str]] = []
+
+    contexts_dir = warehouse_path / "contexts"
+    if contexts_dir.exists() and contexts_dir.is_dir():
+        for file_path in sorted(contexts_dir.iterdir()):
+            if file_path.is_file() and file_path.suffix == ".md":
+                files_to_scan.append((file_path, f"contexts/{file_path.name}"))
+
+    skills_dir = warehouse_path / "skills"
+    if skills_dir.exists() and skills_dir.is_dir():
+        for skill_dir in sorted(skills_dir.iterdir()):
+            if not skill_dir.is_dir():
+                continue
+            skill_file = skill_dir / "SKILL.md"
+            if skill_file.exists():
+                files_to_scan.append((skill_file, f"skills/{skill_dir.name}/SKILL.md"))
+
+    agents_dir = warehouse_path / "agents"
+    if agents_dir.exists() and agents_dir.is_dir():
+        for file_path in sorted(agents_dir.iterdir()):
+            if (
+                file_path.is_file()
+                and file_path.suffix == ".md"
+                and file_path.name != "README.md"
+            ):
+                files_to_scan.append((file_path, f"agents/{file_path.name}"))
+
+    knowledge_dir = warehouse_path / "knowledge"
+    if knowledge_dir.exists() and knowledge_dir.is_dir():
+        for file_path in sorted(knowledge_dir.rglob("*.md")):
+            if file_path.is_file():
+                files_to_scan.append(
+                    (file_path, file_path.relative_to(warehouse_path).as_posix())
+                )
+
+    return files_to_scan
 
 
 # ---------------------------------------------------------------------------
@@ -81,14 +126,7 @@ def lint_warehouse(warehouse_path: Path) -> LintReport:
 
 
 def _lint_structure(warehouse_path: Path) -> list[LintFinding]:
-    """Validate warehouse directory structure via WarehouseValidator.
-
-    Passes validate_manifest=False so WarehouseValidator runs only its
-    structural checks. The agent-manifest validators are invoked separately
-    by _lint_agent_manifest with per-defect, per-artifact-path findings —
-    running them here too would emit one combined <warehouse>-scoped finding
-    plus N per-defect findings for the same underlying issues.
-    """
+    """Validate warehouse directory structure via WarehouseValidator."""
     validator = WarehouseValidator()
     result = validator.validate(warehouse_path, validate_manifest=False)
     if result.valid:
@@ -128,7 +166,6 @@ def _lint_skill_frontmatter(warehouse_path: Path) -> list[LintFinding]:
             )
             continue
 
-        # Validate against SkillFrontmatter schema
         try:
             SkillFrontmatter(**result.data)
         except ValidationError as exc:
@@ -161,15 +198,12 @@ def _lint_skill_requires(warehouse_path: Path) -> list[LintFinding]:
 
         relative_path = f"skills/{skill_dir.name}/SKILL.md"
         result = parse_frontmatter(skill_file)
-
-        # Skip skills whose frontmatter is invalid — rule 2 handles those
         if not result.success:
             continue
 
         try:
             fm = SkillFrontmatter(**result.data)
         except ValidationError:
-            # Invalid schema — rule 2 already handles this
             continue
 
         for ctx_name in fm.requires.contexts:
@@ -179,8 +213,7 @@ def _lint_skill_requires(warehouse_path: Path) -> list[LintFinding]:
                     LintFinding(
                         artifact_path=relative_path,
                         message=(
-                            f"requires context '{ctx_name}' but "
-                            f"contexts/{ctx_name}.md does not exist"
+                            f"requires context '{ctx_name}' but contexts/{ctx_name}.md does not exist"
                         ),
                     )
                 )
@@ -194,31 +227,12 @@ def _lint_skill_requires(warehouse_path: Path) -> list[LintFinding]:
 
 
 def _extract_path_from_manifest_error(message: str) -> str:
-    """Try to extract an agent path from a manifest error message.
-
-    Recognised patterns (each returns an `agents/<name>.md`-shaped path so
-    findings get scoped to the agent file the message implicates):
-
-    - Explicit relative path: ``agents/<name>.md`` anywhere in the message.
-      Used by ``validate_agents_directory`` /
-      ``validate_agent_frontmatter_clean``.
-    - Agent name in quotes: ``Agent '<name>'`` (single or double).
-      Used by ``validate_declared_skills`` whose error format is
-      ``"Agent 'foo' declares skill 'bar' but ..."``.
-
-    Falls back to ``agents/agents.yaml`` only when neither pattern matches —
-    i.e. when the error is genuinely manifest-file-level (e.g. parse error)
-    or the format changed and this extractor no longer recognises it.
-    """
-    import re
-
-    # Pattern 1: explicit agents/<name>.md mention
+    """Try to extract an agent path from a manifest error message."""
     match = re.search(r"agents/([^/\s]+\.md)", message)
     if match:
         return f"agents/{match.group(1)}"
 
-    # Pattern 2: Agent '<name>' or Agent "<name>" — used by validate_declared_skills.
-    match = re.search(r"""Agent\s+['"]([^'"]+)['"]""", message)
+    match = re.search(r"""Agent\s+['\"]([^'\"]+)['\"]""", message)
     if match:
         return f"agents/{match.group(1)}.md"
 
@@ -226,36 +240,18 @@ def _extract_path_from_manifest_error(message: str) -> str:
 
 
 def _lint_agent_manifest(warehouse_path: Path) -> list[LintFinding]:
-    """Validate agent manifest and run downstream manifest validators.
-
-    Each validator is run independently in its own try/except so a failure in
-    one does not suppress findings from the others. Notably,
-    validate_agent_frontmatter_clean does NOT need a parsed manifest — it only
-    inspects agents/*.md frontmatter — so it must still run even when
-    load_agent_manifest fails.
-    """
+    """Validate agent manifest and run downstream manifest validators."""
     findings = []
-
-    # Track manifest parse outcome separately so we can short-circuit only the
-    # validators that actually need a parsed manifest (agents_directory +
-    # declared_skills), without suppressing frontmatter_clean.
     manifest = None
     manifest_parsed = False
     try:
         manifest = load_agent_manifest(warehouse_path)
         manifest_parsed = True
     except AgentManifestError as exc:
-        # load_agent_manifest formats failures as "<error>\nSee <migration-url>
-        # for ..." — the newline is a continuation, NOT a per-defect separator.
-        # Splitting it would inflate the finding count (one defect becomes N
-        # findings). Preserve the full message as a single finding. This
-        # differs from the validate_* helpers below where '\n' DOES separate
-        # per-defect lines and the split-and-fan-out treatment is correct.
         findings.append(
             LintFinding(artifact_path="agents/agents.yaml", message=str(exc).strip())
         )
 
-    # validate_agents_directory needs a parsed manifest — skip on parse failure.
     if manifest_parsed:
         try:
             validate_agents_directory(warehouse_path, manifest)
@@ -263,25 +259,26 @@ def _lint_agent_manifest(warehouse_path: Path) -> list[LintFinding]:
             for line in str(exc).split("\n"):
                 line = line.strip()
                 if line:
-                    artifact_path = _extract_path_from_manifest_error(line)
                     findings.append(
-                        LintFinding(artifact_path=artifact_path, message=line)
+                        LintFinding(
+                            artifact_path=_extract_path_from_manifest_error(line),
+                            message=line,
+                        )
                     )
 
-    # validate_agent_frontmatter_clean does NOT need a parsed manifest —
-    # always run it, even when load_agent_manifest failed. Otherwise an
-    # unparseable agents.yaml would mask agents with legacy `requires:` keys
-    # in their frontmatter.
     try:
         validate_agent_frontmatter_clean(warehouse_path)
     except AgentManifestError as exc:
         for line in str(exc).split("\n"):
             line = line.strip()
             if line:
-                artifact_path = _extract_path_from_manifest_error(line)
-                findings.append(LintFinding(artifact_path=artifact_path, message=line))
+                findings.append(
+                    LintFinding(
+                        artifact_path=_extract_path_from_manifest_error(line),
+                        message=line,
+                    )
+                )
 
-    # validate_declared_skills needs a parsed (non-None) manifest.
     if manifest_parsed and manifest is not None:
         try:
             validate_declared_skills(warehouse_path, manifest)
@@ -289,9 +286,11 @@ def _lint_agent_manifest(warehouse_path: Path) -> list[LintFinding]:
             for line in str(exc).split("\n"):
                 line = line.strip()
                 if line:
-                    artifact_path = _extract_path_from_manifest_error(line)
                     findings.append(
-                        LintFinding(artifact_path=artifact_path, message=line)
+                        LintFinding(
+                            artifact_path=_extract_path_from_manifest_error(line),
+                            message=line,
+                        )
                     )
 
     return findings
@@ -319,13 +318,11 @@ def _lint_agent_frontmatter(warehouse_path: Path) -> list[LintFinding]:
         result = parse_frontmatter(agent_file)
 
         if not result.success:
-            # When frontmatter is wholly absent/malformed, emit ONE finding only
             findings.append(
                 LintFinding(artifact_path=relative_path, message=result.message)
             )
             continue
 
-        # Check for required keys
         data = result.data or {}
         for key in ("name", "description"):
             if key not in data:
@@ -340,34 +337,15 @@ def _lint_agent_frontmatter(warehouse_path: Path) -> list[LintFinding]:
 
 
 # ---------------------------------------------------------------------------
-# Rule 6: Knowledge link integrity
+# Rule 6: Artifact link integrity
 # ---------------------------------------------------------------------------
 
 
-def _lint_knowledge_links(warehouse_path: Path) -> list[LintFinding]:
-    """Promote broken knowledge links to errors (without modifying scan_file_for_knowledge)."""
-    files_to_scan: list[tuple[Path, str]] = []
+def _lint_artifact_links(warehouse_path: Path) -> list[LintFinding]:
+    """Validate cross-artifact link integrity without changing sync behavior."""
+    findings: list[LintFinding] = []
 
-    # Scan contexts/*.md
-    contexts_dir = warehouse_path / "contexts"
-    if contexts_dir.exists() and contexts_dir.is_dir():
-        for f in sorted(contexts_dir.iterdir()):
-            if f.is_file() and f.suffix == ".md":
-                files_to_scan.append((f, f"contexts/{f.name}"))
-
-    # Scan skills/*/SKILL.md
-    skills_dir = warehouse_path / "skills"
-    if skills_dir.exists() and skills_dir.is_dir():
-        for skill_dir in sorted(skills_dir.iterdir()):
-            if skill_dir.is_dir():
-                skill_file = skill_dir / "SKILL.md"
-                if skill_file.exists():
-                    files_to_scan.append(
-                        (skill_file, f"skills/{skill_dir.name}/SKILL.md")
-                    )
-
-    findings = []
-    for file_path, relative_path in files_to_scan:
+    for file_path, relative_path in _iter_artifact_markdown_files(warehouse_path):
         try:
             content = file_path.read_text(encoding="utf-8")
         except OSError:
@@ -379,28 +357,129 @@ def _lint_knowledge_links(warehouse_path: Path) -> list[LintFinding]:
             )
             continue
 
-        links = extract_markdown_links(content)
-        for link in links:
-            raw_target = link.target
-            normalized = normalize_link_target(raw_target)
-            if not normalized or is_absolute_url(normalized):
+        own_headings = extract_markdown_headings(file_path)
+        for link in extract_markdown_links(content):
+            raw_target = link.target.strip()
+            if not raw_target:
                 continue
 
-            resolved = resolve_link(file_path, normalized, warehouse_path)
-            if resolved is None:
-                continue
-
-            resolved_abs = warehouse_path / resolved.warehouse_relative
-            if classify_knowledge_ref(resolved_abs, warehouse_path):
-                if not resolved_abs.exists():
+            if raw_target.startswith("#"):
+                anchor = slugify_heading(raw_target[1:])
+                if anchor not in own_headings:
                     findings.append(
                         LintFinding(
                             artifact_path=relative_path,
                             message=(
-                                f"broken knowledge link: {raw_target} → "
-                                f"{resolved.warehouse_relative} (file not found)"
+                                f"unresolved anchor: {raw_target} does not match any heading in {relative_path}"
                             ),
                         )
                     )
+                continue
 
-    return findings
+            category = classify_link(raw_target, file_path, warehouse_path)
+            if category in {LINK_ABSOLUTE_URL, LINK_OWN_SKILL_FOLDER}:
+                continue
+
+            if category == LINK_CROSS_ARTIFACT_RELATIVE:
+                findings.append(
+                    LintFinding(
+                        artifact_path=relative_path,
+                        message=(
+                            f"malformed cross-artifact link: {raw_target} must use canonical form "
+                            f"{to_canonical(raw_target, file_path, warehouse_path)}"
+                        ),
+                    )
+                )
+                continue
+
+            if category == LINK_WAREHOUSE_ESCAPE:
+                findings.append(
+                    LintFinding(
+                        artifact_path=relative_path,
+                        message=f"warehouse-escape link: {raw_target} resolves outside the warehouse root",
+                    )
+                )
+                continue
+
+            if category != LINK_CANONICAL:
+                continue
+
+            resolved = resolve_canonical_link(raw_target, warehouse_path)
+            if resolved is None:
+                continue
+            target_path, anchor = resolved
+
+            if not target_path.exists():
+                findings.append(
+                    LintFinding(
+                        artifact_path=relative_path,
+                        message=(
+                            f"missing canonical target: {raw_target} → {target_path.relative_to(warehouse_path).as_posix()}"
+                        ),
+                    )
+                )
+                continue
+
+            if anchor is not None and anchor not in extract_markdown_headings(
+                target_path
+            ):
+                findings.append(
+                    LintFinding(
+                        artifact_path=relative_path,
+                        message=(
+                            f"unresolved anchor: {raw_target} does not match any heading in "
+                            f"{target_path.relative_to(warehouse_path).as_posix()}"
+                        ),
+                    )
+                )
+
+    return sorted(findings, key=lambda f: (f.artifact_path, f.message))
+
+
+def _fix_artifact_links(warehouse_path: Path) -> tuple[int, int]:
+    """Rewrite fixable cross-artifact links in place and report counts."""
+    rewritten_links = 0
+    files_touched = 0
+
+    for file_path, _relative_path in _iter_artifact_markdown_files(warehouse_path):
+        try:
+            original = file_path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+
+        changed = False
+
+        def replace_link(
+            match: re.Match[str], current_file_path: Path = file_path
+        ) -> str:
+            nonlocal rewritten_links, changed
+
+            full_text = match.group(0)
+            target = match.group(2).strip()
+            if (
+                classify_link(target, current_file_path, warehouse_path)
+                != LINK_CROSS_ARTIFACT_RELATIVE
+            ):
+                return full_text
+
+            changed = True
+            rewritten_links += 1
+            return full_text.replace(
+                match.group(2),
+                to_canonical(target, current_file_path, warehouse_path),
+                1,
+            )
+
+        updated = re.sub(
+            r"(?<!\\)(?<!!)\[([^\]]*)\]\(([^)]+)\)", replace_link, original
+        )
+        if changed and updated != original:
+            file_path.write_text(updated, encoding="utf-8")
+            files_touched += 1
+
+    return rewritten_links, files_touched
+
+
+def _lint_knowledge_links(warehouse_path: Path) -> list[LintFinding]:
+    """Backward-compat shim to preserve direct test imports during the change."""
+    return _lint_artifact_links(warehouse_path)

--- a/libs/beacon/tests/integration/domains/warehouse/test_lint_cli.py
+++ b/libs/beacon/tests/integration/domains/warehouse/test_lint_cli.py
@@ -47,7 +47,10 @@ def _build_defective_warehouse(root: Path) -> tuple[Path, dict]:
 
     Defects:
       - skills/no-fm/SKILL.md: no frontmatter
-      - contexts/ctx-with-broken-link.md: broken knowledge link
+      - contexts/ctx-with-broken-link.md: cross-artifact-relative link
+        to a missing knowledge target (post-Phase-2 lint classifies the
+        link form as malformed regardless of target existence; pre-Phase-2
+        this fixture verified the broken-knowledge-link rule)
       - agents/no-name.md: missing `name` key in frontmatter (registered in agents.yaml)
 
     Returns:
@@ -79,7 +82,7 @@ def _build_defective_warehouse(root: Path) -> tuple[Path, dict]:
 
     expected = {
         "skills/no-fm/SKILL.md": ["YAML frontmatter"],
-        "contexts/ctx-with-broken-link.md": ["broken knowledge link"],
+        "contexts/ctx-with-broken-link.md": ["malformed cross-artifact link"],
         "agents/no-name.md": ["`name`"],
     }
     return wh, expected

--- a/libs/beacon/tests/integration/test_agent_sync_lifecycle.py
+++ b/libs/beacon/tests/integration/test_agent_sync_lifecycle.py
@@ -968,24 +968,23 @@ def test_readme_filtered_from_warehouse_agent_catalog(
 
 
 # ---------------------------------------------------------------------------
-# PER-164: agent partials co-distribution
+# Agent partials co-distribution
 # ---------------------------------------------------------------------------
 
 
 def test_sync_with_agent_partials(project_dir: Path, warehouse: Path, monkeypatch):
-    """Warehouse with agents/_partials/ — partials are synced and wired but NOT adoptable.
+    """Warehouse with agent-partials/ mirrors partials but does not wire them.
 
-    Covers PER-164 Layer A (filter partials from agent listings) and
-    Layer B (co-distribute partials alongside declared agents).
+    Covers partial mirror distribution and non-adoptability after Phase 4.
     """
     # Plant a partial file and an agent that references it.
-    (warehouse / "agents" / "_partials").mkdir()
-    (warehouse / "agents" / "_partials" / "deep-review-checklist.md").write_text(
+    (warehouse / "agent-partials").mkdir()
+    (warehouse / "agent-partials" / "deep-review-checklist.md").write_text(
         "## Deep Review Checklist\n- [ ] Item 1\n"
     )
     (warehouse / "agents" / "implementation-supervisor.md").write_text(
         "---\nname: implementation-supervisor\n---\n"
-        "[`_partials/deep-review-checklist.md`](_partials/deep-review-checklist.md)\n"
+        "[`.agentic-beacon/artifacts/agent-partials/deep-review-checklist.md`](.agentic-beacon/artifacts/agent-partials/deep-review-checklist.md)\n"
     )
     manifest_path = warehouse / "agents" / "agents.yaml"
     manifest = yaml.safe_load(manifest_path.read_text()) or {}
@@ -1008,13 +1007,12 @@ def test_sync_with_agent_partials(project_dir: Path, warehouse: Path, monkeypatc
     r = runner.invoke(main, ["sync", "--skip-git-check"])
     assert r.exit_code == 0, f"sync failed: {r.output}"
 
-    # Partial must appear under .agentic-beacon/artifacts/agents/_partials/
+    # Partial must appear under .agentic-beacon/artifacts/agent-partials/
     artifact_partial = (
         project_dir
         / ".agentic-beacon"
         / "artifacts"
-        / "agents"
-        / "_partials"
+        / "agent-partials"
         / "deep-review-checklist.md"
     )
     assert artifact_partial.is_symlink(), (
@@ -1024,26 +1022,15 @@ def test_sync_with_agent_partials(project_dir: Path, warehouse: Path, monkeypatc
         f"Artifact partial symlink is broken: {artifact_partial}"
     )
 
-    # Partial must be wired into .claude/agents/_partials/ as a wrapper
-    # (PER-238: regular file with `disable: true` frontmatter, not a raw
-    # symlink — so opencode/Claude Code don't expose it as a callable agent).
+    # Partial must not be wired into tool agent directories.
     claude_partial = (
         project_dir / ".claude" / "agents" / "_partials" / "deep-review-checklist.md"
     )
-    assert claude_partial.is_file() and not claude_partial.is_symlink(), (
-        f"Expected .claude partial wrapper file at {claude_partial}"
+    opencode_partial = (
+        project_dir / ".opencode" / "agents" / "_partials" / "deep-review-checklist.md"
     )
-    wrapper_content = claude_partial.read_text()
-    assert wrapper_content.startswith("---\n"), (
-        f"Wrapper at {claude_partial} missing frontmatter fence"
-    )
-    assert "disable: true" in wrapper_content.split("\n---\n", 1)[0], (
-        f"Wrapper at {claude_partial} missing disable: true"
-    )
-    # Original partial body must be inlined for relative-link resolution.
-    assert "Deep Review Checklist" in wrapper_content, (
-        f"Wrapper at {claude_partial} missing original partial body"
-    )
+    assert not claude_partial.exists()
+    assert not opencode_partial.exists()
 
     # Partial must NOT be discoverable as an adoptable agent.
     from beacon.domains.distribution.distributor import WarehouseDistributor

--- a/libs/beacon/tests/integration/test_link_resolution.py
+++ b/libs/beacon/tests/integration/test_link_resolution.py
@@ -1,0 +1,427 @@
+"""Phase 6 - synthetic-distribution canonical-link resolution integration test.
+
+Builds a hermetic synthetic warehouse with all four canonical-link categories
+(plus an own-folder skill asset and an agent->partial canonical link), wires up
+a tmp project via real `abc warehouse connect` + `abc sync`, then walks every
+distributed artifact and asserts every canonical link resolves from the project
+root. A negative-fixture warehouse plants malformed/missing-target links and
+asserts `abc warehouse lint` catches them and `--fix` clears the fixable one.
+"""
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+from beacon.cli.main import main
+from beacon.core.scanner.scanner import (
+    LINK_CANONICAL,
+    LINK_CROSS_ARTIFACT_RELATIVE,
+    LINK_OWN_SKILL_FOLDER,
+    LINK_WAREHOUSE_ESCAPE,
+    classify_link,
+    extract_markdown_headings,
+    extract_markdown_links,
+)
+from click.testing import CliRunner
+
+pytestmark = pytest.mark.integration
+
+
+def _git_env() -> dict[str, str]:
+    return {
+        **os.environ,
+        "GIT_AUTHOR_NAME": "Test",
+        "GIT_AUTHOR_EMAIL": "t@t.local",
+        "GIT_COMMITTER_NAME": "Test",
+        "GIT_COMMITTER_EMAIL": "t@t.local",
+    }
+
+
+def _git_init_commit(path: Path, message: str = "init") -> None:
+    env = _git_env()
+    subprocess.run(["git", "init"], cwd=path, env=env, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "add", "."], cwd=path, env=env, check=True, capture_output=True
+    )
+    subprocess.run(
+        ["git", "commit", "-m", message],
+        cwd=path,
+        env=env,
+        check=True,
+        capture_output=True,
+    )
+
+
+def _init_warehouse(tmp_path: Path, name: str) -> Path:
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "warehouse",
+            "init",
+            name,
+            "--path",
+            str(tmp_path),
+            "--org",
+            "Test Org",
+            "--languages",
+            "python",
+            "--no-interactive",
+            "--no-git",
+        ],
+    )
+    assert result.exit_code == 0, f"warehouse init failed:\n{result.output}"
+    return tmp_path / name
+
+
+def _write_agents_manifest(warehouse: Path) -> None:
+    (warehouse / "agents" / "agents.yaml").write_text(
+        yaml.safe_dump({"test-supervisor": {"skills": []}}, sort_keys=True)
+    )
+
+
+def _populate_positive_warehouse(warehouse: Path) -> None:
+    (warehouse / "contexts" / "team-context.md").write_text(
+        "# Team Context\n\n"
+        "## Section A\n\n"
+        "See [skill](.agentic-beacon/artifacts/skills/code-review/SKILL.md).\n"
+    )
+
+    skill_dir = warehouse / "skills" / "code-review"
+    (skill_dir / "references").mkdir(parents=True, exist_ok=True)
+    (skill_dir / "references" / "api.md").write_text("# API Notes\n")
+    (skill_dir / "SKILL.md").write_text(
+        "---\n"
+        "name: code-review\n"
+        "description: Review code changes.\n"
+        "requires:\n"
+        "  contexts: []\n"
+        "---\n\n"
+        "# Code Review\n\n"
+        "Read [ctx](.agentic-beacon/artifacts/contexts/team-context.md#section-a).\n"
+        "Read [api](references/api.md).\n"
+    )
+
+    (warehouse / "agent-partials").mkdir(exist_ok=True)
+    (warehouse / "agent-partials" / "deep-review-checklist.md").write_text(
+        "# Deep Review Checklist\n\n- [ ] Confirm artifacts resolve.\n"
+    )
+    (warehouse / "agents" / "test-supervisor.md").write_text(
+        "---\n"
+        "name: test-supervisor\n"
+        "description: Supervises integration checks.\n"
+        "---\n\n"
+        "# Test Supervisor\n\n"
+        "Use [checklist](.agentic-beacon/artifacts/agent-partials/deep-review-checklist.md).\n"
+    )
+
+    # Knowledge files exist in the warehouse to support the warehouse-side
+    # canonical-link walk (TC2: context→knowledge canonical, TC4:
+    # knowledge→knowledge canonical) and to keep `abc warehouse lint` happy
+    # when validating the synthetic fixture. They are NOT pulled into the
+    # downstream project because:
+    #   1. beacon.yaml in this test does not declare any knowledge dir
+    #      (ArtifactsConfig has no `knowledge` field).
+    #   2. The auto-pull pathway in core/scanner/scanner.scan_file_for_knowledge
+    #      recognises legacy directory-relative `knowledge/...` links only,
+    #      not the new canonical form `.agentic-beacon/artifacts/knowledge/...`.
+    #      Filed as a follow-up: extending auto-pull to canonical links lives
+    #      outside this change's scope (per spec: scan_file_for_knowledge is
+    #      explicitly NOT modified — sync stays warning-only). See repo issue
+    #      tracker for the dedicated ticket.
+    # The project-side canonical-link walk therefore covers
+    # skill→context, agent→partial, skill own-folder, and context→skill;
+    # the warehouse-side walk additionally covers knowledge→knowledge.
+    (warehouse / "knowledge" / "python").mkdir(parents=True, exist_ok=True)
+    (warehouse / "knowledge" / "python" / "standards.md").write_text(
+        "# Python Standards\n\n"
+        "## Section A\n\n"
+        "See [style](.agentic-beacon/artifacts/knowledge/python/style-guide.md).\n"
+    )
+    (warehouse / "knowledge" / "python" / "style-guide.md").write_text(
+        "# Style Guide\n\n## Usage\n\nKeep examples short.\n"
+    )
+
+    _write_agents_manifest(warehouse)
+
+
+def _write_negative_warehouse(warehouse: Path, *, include_missing_target: bool) -> None:
+    _populate_positive_warehouse(warehouse)
+
+    skill_path = warehouse / "skills" / "code-review" / "SKILL.md"
+    skill_path.write_text(
+        "---\n"
+        "name: code-review\n"
+        "description: Review code changes.\n"
+        "requires:\n"
+        "  contexts: []\n"
+        "---\n\n"
+        "# Code Review\n\n"
+        "Read [ctx](../../contexts/team-context.md).\n"
+        "Read [api](references/api.md).\n"
+    )
+
+    if include_missing_target:
+        (warehouse / "contexts" / "team-context.md").write_text(
+            "# Team Context\n\n"
+            "See [gone](.agentic-beacon/artifacts/knowledge/python/missing.md).\n"
+        )
+
+
+@pytest.fixture
+def synthetic_warehouse(tmp_path: Path) -> Path:
+    warehouse = _init_warehouse(tmp_path, "synthetic-warehouse")
+    _populate_positive_warehouse(warehouse)
+    _git_init_commit(warehouse)
+    return warehouse
+
+
+@pytest.fixture
+def negative_fixture_warehouse(tmp_path: Path) -> Path:
+    warehouse = _init_warehouse(tmp_path, "negative-warehouse")
+    _write_negative_warehouse(warehouse, include_missing_target=True)
+    _git_init_commit(warehouse)
+    return warehouse
+
+
+@pytest.fixture
+def fixable_only_warehouse(tmp_path: Path) -> Path:
+    warehouse = _init_warehouse(tmp_path, "fixable-only-warehouse")
+    _write_negative_warehouse(warehouse, include_missing_target=False)
+    _git_init_commit(warehouse)
+    return warehouse
+
+
+@pytest.fixture
+def synced_project(
+    tmp_path: Path, synthetic_warehouse: Path, monkeypatch
+) -> tuple[Path, Path]:
+    runner = CliRunner()
+    project_dir = tmp_path / "proj"
+    project_dir.mkdir()
+    (project_dir / ".claude").mkdir()
+    (project_dir / ".opencode").mkdir()
+
+    monkeypatch.chdir(project_dir)
+    connect = runner.invoke(
+        main,
+        ["warehouse", "connect", "--path", str(synthetic_warehouse)],
+    )
+    assert connect.exit_code == 0, f"connect failed:\n{connect.output}"
+
+    setup = runner.invoke(main, ["setup"])
+    assert setup.exit_code == 0, f"setup failed:\n{setup.output}"
+
+    (project_dir / ".agentic-beacon" / "beacon.yaml").write_text(
+        "artifacts:\n"
+        "  contexts:\n"
+        "    - contexts/team-context.md\n"
+        "  skills:\n"
+        "    - skills/code-review/\n"
+        "  agents:\n"
+        "    - agents/test-supervisor.md\n"
+    )
+
+    sync = runner.invoke(main, ["sync", "--skip-git-check"])
+    assert sync.exit_code == 0, f"sync failed:\n{sync.output}"
+
+    return project_dir, synthetic_warehouse
+
+
+def _assert_links_resolve(
+    project_dir: Path, warehouse: Path, source_file: Path
+) -> None:
+    for link in extract_markdown_links(source_file.read_text(encoding="utf-8")):
+        category = classify_link(
+            link.target, source_file=source_file, warehouse_root=warehouse
+        )
+        assert category not in {
+            LINK_CROSS_ARTIFACT_RELATIVE,
+            LINK_WAREHOUSE_ESCAPE,
+        }, f"unexpected non-canonical link {link.target!r} in {source_file}"
+
+        if category == LINK_CANONICAL:
+            target_path = project_dir / link.target.split("#", 1)[0]
+            assert target_path.exists(), (
+                f"missing canonical target for {link.target} from {source_file}"
+            )
+            if "#" in link.target:
+                headings = extract_markdown_headings(target_path)
+                anchor = link.target.split("#", 1)[1]
+                assert anchor in headings
+
+        if category == LINK_OWN_SKILL_FOLDER:
+            assert (source_file.parent / link.target).exists()
+
+
+def test_sync_materializes_declared_artifacts_and_agent_partial_mirror(
+    synced_project: tuple[Path, Path],
+):
+    project_dir, warehouse = synced_project
+
+    expected_paths = [
+        project_dir / ".agentic-beacon" / "artifacts" / "contexts" / "team-context.md",
+        project_dir
+        / ".agentic-beacon"
+        / "artifacts"
+        / "skills"
+        / "code-review"
+        / "SKILL.md",
+        project_dir / ".agentic-beacon" / "artifacts" / "agents" / "test-supervisor.md",
+        project_dir
+        / ".agentic-beacon"
+        / "artifacts"
+        / "agent-partials"
+        / "deep-review-checklist.md",
+        project_dir / ".claude" / "agents" / "test-supervisor.md",
+        project_dir / ".opencode" / "agents" / "test-supervisor.md",
+    ]
+
+    for path in expected_paths:
+        assert path.is_symlink(), f"expected symlink at {path}"
+        assert path.resolve().is_file(), f"expected resolved file for {path}"
+        assert str(path.resolve()).startswith(str(warehouse.resolve()))
+
+    assert not (project_dir / ".claude" / "agents" / "_partials").exists()
+    assert not (project_dir / ".opencode" / "agents" / "_partials").exists()
+
+
+def test_artifact_mirror_files_only_use_resolving_link_categories(
+    synced_project: tuple[Path, Path],
+):
+    project_dir, warehouse = synced_project
+    for source_file in (project_dir / ".agentic-beacon" / "artifacts").rglob("*.md"):
+        _assert_links_resolve(project_dir, warehouse, source_file)
+
+
+def test_claude_agent_links_resolve_from_project_root(
+    synced_project: tuple[Path, Path],
+):
+    project_dir, warehouse = synced_project
+    for source_file in (project_dir / ".claude" / "agents").rglob("*.md"):
+        _assert_links_resolve(project_dir, warehouse, source_file)
+
+
+def test_opencode_agent_links_resolve_from_project_root(
+    synced_project: tuple[Path, Path],
+):
+    project_dir, warehouse = synced_project
+    for source_file in (project_dir / ".opencode" / "agents").rglob("*.md"):
+        _assert_links_resolve(project_dir, warehouse, source_file)
+
+
+def test_knowledge_anchor_resolves_in_distributed_target(
+    synced_project: tuple[Path, Path],
+):
+    """TC5: anchor on a canonical link matches a heading slug in the target.
+
+    Knowledge files aren't materialised under .agentic-beacon/artifacts/ in
+    this fixture (auto-pull doesn't recognise canonical-form links — see
+    follow-up note in _populate_positive_warehouse). Verify the anchor
+    resolution rule against the warehouse-side knowledge file instead;
+    that's the source the symlink would resolve to once auto-pull is
+    extended to canonical links.
+    """
+    _project_dir, warehouse = synced_project
+    target = warehouse / "knowledge" / "python" / "standards.md"
+    assert "section-a" in extract_markdown_headings(target)
+
+
+def test_warehouse_side_canonical_links_in_knowledge_resolve(
+    synthetic_warehouse: Path,
+):
+    """TC2 + TC4: walk warehouse-side knowledge files; every canonical link
+    points at an existing warehouse file.
+
+    Mirrors the project-side resolution walk but rooted at the warehouse —
+    needed to exercise context→knowledge and knowledge→knowledge canonical
+    links because knowledge is not pulled into the project under the current
+    spec (see follow-up note in _populate_positive_warehouse).
+    """
+    for source_file in (synthetic_warehouse / "knowledge").rglob("*.md"):
+        for link in extract_markdown_links(source_file.read_text(encoding="utf-8")):
+            category = classify_link(
+                link.target,
+                source_file=source_file,
+                warehouse_root=synthetic_warehouse,
+            )
+            assert category in {LINK_CANONICAL, LINK_OWN_SKILL_FOLDER}, (
+                f"unexpected non-canonical link {link.target!r} in {source_file}"
+            )
+            if category == LINK_CANONICAL:
+                # canonical resolution rule: strip prefix → warehouse-relative
+                rel = link.target.split("#", 1)[0].removeprefix(
+                    ".agentic-beacon/artifacts/"
+                )
+                assert (synthetic_warehouse / rel).exists(), (
+                    f"missing canonical target for {link.target} from {source_file}"
+                )
+
+
+def test_skill_own_folder_reference_resolves_inside_skill_directory(
+    synced_project: tuple[Path, Path],
+):
+    project_dir, warehouse = synced_project
+    skill_file = (
+        project_dir
+        / ".agentic-beacon"
+        / "artifacts"
+        / "skills"
+        / "code-review"
+        / "SKILL.md"
+    )
+    links = extract_markdown_links(skill_file.read_text(encoding="utf-8"))
+    api_link = next(link for link in links if link.target == "references/api.md")
+    assert (
+        classify_link(api_link.target, source_file=skill_file, warehouse_root=warehouse)
+        == LINK_OWN_SKILL_FOLDER
+    )
+    assert (skill_file.parent / api_link.target).exists()
+
+
+def test_negative_lint_reports_malformed_and_missing_target_findings(
+    negative_fixture_warehouse: Path,
+):
+    runner = CliRunner()
+    result = runner.invoke(main, ["warehouse", "lint", str(negative_fixture_warehouse)])
+
+    assert result.exit_code == 1
+    assert "skills/code-review/SKILL.md" in result.output
+    assert "malformed cross-artifact link" in result.output
+    assert "contexts/team-context.md" in result.output
+    assert "missing canonical target" in result.output
+
+
+def test_negative_lint_fix_rewrites_fixable_link_and_leaves_missing_target(
+    negative_fixture_warehouse: Path,
+):
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        ["warehouse", "lint", str(negative_fixture_warehouse), "--fix"],
+    )
+
+    assert result.exit_code == 1
+    assert "missing canonical target" in result.output
+    assert "malformed cross-artifact link" not in result.output
+
+    skill_content = (
+        negative_fixture_warehouse / "skills" / "code-review" / "SKILL.md"
+    ).read_text(encoding="utf-8")
+    assert "[ctx](.agentic-beacon/artifacts/contexts/team-context.md)" in skill_content
+
+
+def test_fixable_only_warehouse_passes_after_lint_fix(fixable_only_warehouse: Path):
+    runner = CliRunner()
+    fix_result = runner.invoke(
+        main,
+        ["warehouse", "lint", str(fixable_only_warehouse), "--fix"],
+    )
+    assert fix_result.exit_code == 0, fix_result.output
+
+    relint_result = runner.invoke(
+        main, ["warehouse", "lint", str(fixable_only_warehouse)]
+    )
+    assert relint_result.exit_code == 0, relint_result.output

--- a/libs/beacon/tests/unit/domains/warehouse/test_lint.py
+++ b/libs/beacon/tests/unit/domains/warehouse/test_lint.py
@@ -76,6 +76,44 @@ def _add_valid_context(wh: Path, name: str, content: str | None = None) -> Path:
     return ctx_file
 
 
+def _add_valid_knowledge(
+    wh: Path, relative_path: str, content: str | None = None
+) -> Path:
+    """Add a knowledge markdown file at the given warehouse-relative path."""
+    knowledge_file = wh / "knowledge" / relative_path
+    knowledge_file.parent.mkdir(parents=True, exist_ok=True)
+    knowledge_file.write_text(content or f"# {knowledge_file.stem}\n")
+    return knowledge_file
+
+
+def _artifact_families_fixture(root: Path) -> Path:
+    """Build a warehouse with one malformed link in each artifact family."""
+    wh = _build_clean_warehouse(root)
+    (wh / "knowledge").mkdir(exist_ok=True)
+    _add_valid_context(wh, "shared")
+    _add_valid_knowledge(wh, "notes/topic.md")
+
+    (wh / "contexts" / "alpha.md").write_text("[skill](../skills/foo/SKILL.md)\n")
+
+    skill_dir = wh / "skills" / "foo"
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\nrequires:\n  contexts: []\n---\n[ctx](../../contexts/shared.md)\n"
+    )
+
+    _add_valid_agent(wh, "assistant")
+    (wh / "agents" / "assistant.md").write_text(
+        "---\nname: assistant\ndescription: Test agent\n---\n"
+        "[ctx](../contexts/shared.md)\n"
+    )
+
+    (wh / "knowledge" / "notes" / "topic.md").write_text(
+        "[ctx](../../contexts/shared.md)\n"
+    )
+
+    return wh
+
+
 # ---------------------------------------------------------------------------
 # Phase 2: Data model
 # ---------------------------------------------------------------------------
@@ -676,98 +714,206 @@ class TestLintAgentFrontmatter:
 
 
 # ---------------------------------------------------------------------------
-# Phase 8: Knowledge link integrity rule
+# Phase 8: Artifact link integrity rule
 # ---------------------------------------------------------------------------
 
 
-class TestLintKnowledgeLinks:
-    """Tests for _lint_knowledge_links."""
+class TestLintArtifactLinks:
+    """Tests for _lint_artifact_links and the phase-2 lint contract."""
 
     def _call(self, path):
-        from beacon.domains.warehouse.lint import _lint_knowledge_links
+        from beacon.domains.warehouse.lint import _lint_artifact_links
 
-        return _lint_knowledge_links(path)
+        return _lint_artifact_links(path)
 
-    def test_valid_knowledge_link_no_finding(self, tmp_path):
-        """TC1/TC7: context with valid knowledge link → no finding."""
+    def test_artifact_links_scans_all_four_families(self, tmp_path):
+        """Task 2.1: contexts, skills, agents, and knowledge are all scanned."""
+        wh = _artifact_families_fixture(tmp_path)
+        findings = self._call(wh)
+
+        assert [f.artifact_path for f in findings] == [
+            "agents/assistant.md",
+            "contexts/alpha.md",
+            "knowledge/notes/topic.md",
+            "skills/foo/SKILL.md",
+        ]
+
+    def test_artifact_links_findings_are_sorted_stably(self, tmp_path):
+        """Task 2.1: findings are deterministic by artifact_path and message."""
+        wh = _artifact_families_fixture(tmp_path)
+        findings = self._call(wh)
+        ordered = [(f.artifact_path, f.message) for f in findings]
+        assert ordered == sorted(ordered)
+
+    def test_cross_artifact_relative_link_reports_malformed_error(self, tmp_path):
+        """TC1: cross-artifact relative link → malformed-link error scoped to source."""
         wh = _build_clean_warehouse(tmp_path)
-        (wh / "knowledge").mkdir()
-        (wh / "knowledge" / "foo").mkdir()
-        (wh / "knowledge" / "foo" / "bar.md").write_text("# Bar\n")
-        ctx = wh / "contexts" / "ctx.md"
-        ctx.write_text("[X](../knowledge/foo/bar.md)\n")
-        result = self._call(wh)
-        assert result == []
-
-    def test_broken_context_knowledge_link_produces_finding(self, tmp_path):
-        """TC2/8.3: context with broken knowledge link → 1 finding."""
-        wh = _build_clean_warehouse(tmp_path)
-        (wh / "knowledge").mkdir()
-        ctx = wh / "contexts" / "foo.md"
-        ctx.write_text("[X](../knowledge/foo/bar.md)\n")
-        result = self._call(wh)
-        assert len(result) == 1
-        assert result[0].artifact_path == "contexts/foo.md"
-
-    def test_broken_skill_knowledge_link_produces_finding(self, tmp_path):
-        """TC4/8.4: skill with broken knowledge link → 1 finding scoped to skill."""
-        wh = _build_clean_warehouse(tmp_path)
-        skill_dir = wh / "skills" / "foo"
-        skill_dir.mkdir()
-        (skill_dir / "SKILL.md").write_text(
-            "---\nrequires:\n  contexts: []\n---\n[X](../../knowledge/foo/bar.md)\n"
+        _add_valid_context(wh, "bar")
+        _add_valid_skill(wh, "foo", contexts=[])
+        skill_file = wh / "skills" / "foo" / "SKILL.md"
+        skill_file.write_text(
+            "---\nrequires:\n  contexts: []\n---\n[ctx](../../contexts/bar.md)\n"
         )
-        result = self._call(wh)
-        assert len(result) == 1
-        assert result[0].artifact_path == "skills/foo/SKILL.md"
 
-    def test_absolute_url_no_finding(self, tmp_path):
-        """TC5/8.5: context with absolute URL → no finding."""
+        findings = self._call(wh)
+
+        assert len(findings) == 1
+        assert findings[0].artifact_path == "skills/foo/SKILL.md"
+        assert "malformed cross-artifact link" in findings[0].message
+        assert ".agentic-beacon/artifacts/contexts/bar.md" in findings[0].message
+        assert lint_warehouse(wh).findings == tuple(findings)
+
+    def test_canonical_missing_target_reports_missing_target_error(self, tmp_path):
+        """TC2: canonical link to a missing target → missing-target error."""
+        wh = _build_clean_warehouse(tmp_path)
+        (wh / "knowledge").mkdir()
+        ctx = wh / "contexts" / "foo.md"
+        ctx.write_text("[X](.agentic-beacon/artifacts/knowledge/foo/bar.md)\n")
+
+        findings = self._call(wh)
+
+        assert len(findings) == 1
+        assert findings[0].artifact_path == "contexts/foo.md"
+        assert "missing canonical target" in findings[0].message
+        assert "knowledge/foo/bar.md" in findings[0].message
+
+    def test_canonical_bad_anchor_reports_unresolved_anchor_error(self, tmp_path):
+        """TC3: canonical link with bad anchor → unresolved-anchor error."""
+        wh = _build_clean_warehouse(tmp_path)
+        _add_valid_context(wh, "bar", "# Existing Heading\n")
+        _add_valid_skill(wh, "foo", contexts=[])
+        skill_file = wh / "skills" / "foo" / "SKILL.md"
+        skill_file.write_text(
+            "---\nrequires:\n  contexts: []\n---\n"
+            "[X](.agentic-beacon/artifacts/contexts/bar.md#no-such-heading)\n"
+        )
+
+        findings = self._call(wh)
+
+        assert len(findings) == 1
+        assert findings[0].artifact_path == "skills/foo/SKILL.md"
+        assert "unresolved anchor" in findings[0].message
+        assert "no-such-heading" in findings[0].message
+
+    def test_warehouse_escape_reports_escape_error(self, tmp_path):
+        """TC4: relative link escaping warehouse → warehouse-escape error."""
+        wh = _build_clean_warehouse(tmp_path)
+        _add_valid_skill(wh, "foo", contexts=[])
+        skill_file = wh / "skills" / "foo" / "SKILL.md"
+        skill_file.write_text(
+            "---\nrequires:\n  contexts: []\n---\n"
+            "[X](../../../apps/backtest/docs/schema.md)\n"
+        )
+
+        findings = self._call(wh)
+
+        assert len(findings) == 1
+        assert findings[0].artifact_path == "skills/foo/SKILL.md"
+        assert "warehouse-escape link" in findings[0].message
+
+    def test_own_folder_skill_link_is_allowed(self, tmp_path):
+        """TC5: own-folder skill asset link → no finding."""
+        wh = _build_clean_warehouse(tmp_path)
+        _add_valid_skill(wh, "foo", contexts=[])
+        ref_dir = wh / "skills" / "foo" / "references"
+        ref_dir.mkdir(parents=True)
+        (ref_dir / "api.md").write_text("# API\n")
+        (wh / "skills" / "foo" / "SKILL.md").write_text(
+            "---\nrequires:\n  contexts: []\n---\n[api](references/api.md)\n"
+        )
+
+        assert self._call(wh) == []
+
+    def test_absolute_url_is_allowed(self, tmp_path):
+        """TC6: absolute URL → no finding."""
         wh = _build_clean_warehouse(tmp_path)
         ctx = wh / "contexts" / "foo.md"
-        ctx.write_text("[X](https://example.com)\n")
-        result = self._call(wh)
-        assert result == []
+        ctx.write_text("[X](https://example.com/docs)\n")
 
-    def test_non_knowledge_link_no_finding(self, tmp_path):
-        """TC6/8.6: context with non-knowledge link → no finding."""
+        assert self._call(wh) == []
+
+    def test_valid_canonical_link_with_valid_anchor_is_allowed(self, tmp_path):
+        """TC7: valid canonical link with valid anchor → no finding."""
+        wh = _build_clean_warehouse(tmp_path)
+        _add_valid_context(wh, "bar", "# Multi Repo\n")
+        _add_valid_skill(wh, "foo", contexts=[])
+        (wh / "skills" / "foo" / "SKILL.md").write_text(
+            "---\nrequires:\n  contexts: []\n---\n"
+            "[ctx](.agentic-beacon/artifacts/contexts/bar.md#multi-repo)\n"
+        )
+
+        assert self._call(wh) == []
+
+    def test_same_file_anchor_existing_heading_is_allowed(self, tmp_path):
+        """TC1: bare anchor resolves against the linking file's own headings."""
         wh = _build_clean_warehouse(tmp_path)
         ctx = wh / "contexts" / "foo.md"
-        ctx.write_text("[X](./other.md)\n")
-        result = self._call(wh)
-        assert result == []
+        ctx.write_text("# Existing Heading\n\n[Jump](#existing-heading)\n")
 
-    def test_two_broken_links_produce_two_findings(self, tmp_path):
-        """TC3: context with two broken knowledge links → 2 findings."""
+        assert self._call(wh) == []
+
+    def test_same_file_anchor_missing_heading_reports_error(self, tmp_path):
+        """TC2: missing same-file anchor → unresolved-anchor error."""
         wh = _build_clean_warehouse(tmp_path)
         ctx = wh / "contexts" / "foo.md"
-        ctx.write_text("[X](../knowledge/a.md)\n[Y](../knowledge/b.md)\n")
-        result = self._call(wh)
-        assert len(result) == 2
+        ctx.write_text("# Existing Heading\n\n[Jump](#missing-heading)\n")
 
-    def test_finding_message_names_broken_target(self, tmp_path):
-        """TC8.2: finding message contains raw link, resolved path, and file not found."""
+        findings = self._call(wh)
+
+        assert len(findings) == 1
+        assert findings[0].artifact_path == "contexts/foo.md"
+        assert "unresolved anchor" in findings[0].message
+        assert "missing-heading" in findings[0].message
+
+    def test_same_file_anchor_duplicate_slug_resolves_second_heading(self, tmp_path):
+        """TC3: #setup-1 resolves to the second duplicate heading."""
         wh = _build_clean_warehouse(tmp_path)
         ctx = wh / "contexts" / "foo.md"
-        ctx.write_text("[X](../knowledge/foo/bar.md)\n")
-        result = self._call(wh)
-        assert len(result) == 1
-        msg = result[0].message
-        assert "../knowledge/foo/bar.md" in msg
-        assert "knowledge/foo/bar.md" in msg
-        assert "file not found" in msg
+        ctx.write_text("## Setup\n\n## Setup\n\n[Jump](#setup-1)\n")
+
+        assert self._call(wh) == []
 
     def test_scan_file_for_knowledge_unchanged(self, tmp_path):
-        """TC8.7: regression — scan_file_for_knowledge returns a set and does not raise."""
+        """Task 2.4: sync-side scanner stays warning-only and unchanged."""
         from beacon.core.scanner.scanner import scan_file_for_knowledge
 
         wh = _build_clean_warehouse(tmp_path)
+        (wh / "knowledge").mkdir()
         ctx = wh / "contexts" / "foo.md"
         ctx.write_text("[X](../knowledge/foo/bar.md)\n")
+
         result = scan_file_for_knowledge(ctx, wh)
+
         assert isinstance(result, set)
-        # Broken target is still in the returned set
         assert "knowledge/foo/bar.md" in result
+
+    def test_clean_warehouse_has_no_artifact_link_findings(self, tmp_path):
+        """Task 2.5: clean warehouse exits with no artifact-link findings."""
+        wh = _build_clean_warehouse(tmp_path)
+        (wh / "knowledge").mkdir(exist_ok=True)
+        _add_valid_context(wh, "bar", "# Multi Repo\n")
+        _add_valid_knowledge(wh, "notes/topic.md", "# Topic\n")
+        _add_valid_skill(wh, "foo", contexts=[])
+        ref_dir = wh / "skills" / "foo" / "references"
+        ref_dir.mkdir(parents=True)
+        (ref_dir / "api.md").write_text("# API\n")
+        (wh / "skills" / "foo" / "SKILL.md").write_text(
+            "---\nrequires:\n  contexts: []\n---\n"
+            "[ctx](.agentic-beacon/artifacts/contexts/bar.md#multi-repo)\n"
+            "[api](references/api.md)\n"
+        )
+        _add_valid_agent(wh, "assistant")
+        (wh / "agents" / "assistant.md").write_text(
+            "---\nname: assistant\ndescription: Test agent\n---\n"
+            "[topic](.agentic-beacon/artifacts/knowledge/notes/topic.md)\n"
+        )
+        (wh / "knowledge" / "notes" / "topic.md").write_text(
+            "# Topic\n\n[ctx](.agentic-beacon/artifacts/contexts/bar.md)\n"
+        )
+
+        report = lint_warehouse(wh)
+
+        assert report.findings == ()
 
 
 # ---------------------------------------------------------------------------

--- a/libs/beacon/tests/unit/domains/warehouse/test_lint_fix.py
+++ b/libs/beacon/tests/unit/domains/warehouse/test_lint_fix.py
@@ -1,0 +1,226 @@
+"""Unit tests for artifact-link autofix in beacon.domains.warehouse.lint."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from beacon.domains.warehouse.lint import lint_warehouse
+from click.testing import CliRunner
+
+
+def _build_clean_warehouse(root: Path) -> Path:
+    wh = root / "warehouse"
+    wh.mkdir()
+    (wh / "agents").mkdir()
+    (wh / "contexts").mkdir()
+    (wh / "skills").mkdir()
+    (wh / "docs").mkdir()
+    (wh / "knowledge").mkdir()
+    (wh / "README.md").write_text("# Warehouse\n")
+    (wh / "agents" / "README.md").write_text("# Agents\n")
+    (wh / "contexts" / "README.md").write_text("# Contexts\n")
+    (wh / "skills" / "README.md").write_text("# Skills\n")
+    return wh
+
+
+def _add_valid_skill(wh: Path, name: str) -> Path:
+    skill_dir = wh / "skills" / name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    skill_file = skill_dir / "SKILL.md"
+    skill_file.write_text("---\nrequires:\n  contexts: []\n---\n# Skill\n")
+    return skill_file
+
+
+def _run_cli(args: list[str]):
+    from beacon.cli.main import main
+
+    return CliRunner().invoke(
+        main, ["warehouse", "lint"] + args, catch_exceptions=False
+    )
+
+
+class TestLintFix:
+    def test_fix_rewrites_cross_artifact_relative_link(self, tmp_path):
+        """TC1: fix rewrites a cross-artifact relative link and preserves anchor."""
+        wh = _build_clean_warehouse(tmp_path)
+        (wh / "contexts" / "bar.md").write_text("# Multi Repo\n")
+        skill_file = _add_valid_skill(wh, "foo")
+        skill_file.write_text(
+            "---\nrequires:\n  contexts: []\n---\n"
+            "[ctx](../../contexts/bar.md#multi-repo)\n"
+        )
+
+        report = lint_warehouse(wh, fix=True)
+
+        assert report.rewritten_links == 1
+        assert report.files_touched == 1
+        assert report.findings == ()
+        assert (
+            skill_file.read_text() == "---\nrequires:\n  contexts: []\n---\n"
+            "[ctx](.agentic-beacon/artifacts/contexts/bar.md#multi-repo)\n"
+        )
+
+    def test_fix_leaves_own_folder_link_unchanged(self, tmp_path):
+        """TC2: own-folder skill link stays byte-identical."""
+        wh = _build_clean_warehouse(tmp_path)
+        skill_file = _add_valid_skill(wh, "foo")
+        ref_dir = wh / "skills" / "foo" / "references"
+        ref_dir.mkdir(parents=True)
+        (ref_dir / "api.md").write_text("# API\n")
+        original = "---\nrequires:\n  contexts: []\n---\n[api](references/api.md)\n"
+        skill_file.write_text(original)
+
+        report = lint_warehouse(wh, fix=True)
+
+        assert report.rewritten_links == 0
+        assert report.files_touched == 0
+        assert skill_file.read_text() == original
+
+    def test_fix_leaves_absolute_url_unchanged(self, tmp_path):
+        """TC3: absolute URL stays untouched."""
+        wh = _build_clean_warehouse(tmp_path)
+        ctx = wh / "contexts" / "foo.md"
+        original = "[site](https://example.com/docs)\n"
+        ctx.write_text(original)
+
+        report = lint_warehouse(wh, fix=True)
+
+        assert report.rewritten_links == 0
+        assert report.files_touched == 0
+        assert ctx.read_text() == original
+
+    def test_fix_leaves_canonical_link_unchanged(self, tmp_path):
+        """TC4: already-canonical link stays untouched."""
+        wh = _build_clean_warehouse(tmp_path)
+        (wh / "contexts" / "bar.md").write_text("# Bar\n")
+        ctx = wh / "contexts" / "foo.md"
+        original = "[bar](.agentic-beacon/artifacts/contexts/bar.md)\n"
+        ctx.write_text(original)
+
+        report = lint_warehouse(wh, fix=True)
+
+        assert report.rewritten_links == 0
+        assert report.files_touched == 0
+        assert ctx.read_text() == original
+
+    def test_fix_leaves_warehouse_escape_link_unchanged(self, tmp_path):
+        """TC5: warehouse-escape link is not rewritten and remains an error."""
+        wh = _build_clean_warehouse(tmp_path)
+        skill_file = _add_valid_skill(wh, "foo")
+        original = (
+            "---\nrequires:\n  contexts: []\n---\n"
+            "[escape](../../../apps/backtest/docs/schema.md)\n"
+        )
+        skill_file.write_text(original)
+
+        report = lint_warehouse(wh, fix=True)
+
+        assert report.rewritten_links == 0
+        assert report.files_touched == 0
+        assert len(report.findings) == 1
+        assert "warehouse-escape link" in report.findings[0].message
+        assert skill_file.read_text() == original
+
+    def test_fix_rewrites_multiple_links_on_one_line(self, tmp_path):
+        """TC6: multiple fixable links on one line each rewrite independently."""
+        wh = _build_clean_warehouse(tmp_path)
+        (wh / "contexts" / "bar.md").write_text("# Bar\n")
+        (wh / "knowledge" / "topic.md").write_text("# Topic\n")
+        ctx = wh / "contexts" / "foo.md"
+        ctx.write_text(
+            "See [bar](../contexts/bar.md) and [topic](../knowledge/topic.md#topic).\n"
+        )
+
+        report = lint_warehouse(wh, fix=True)
+
+        assert report.rewritten_links == 2
+        assert report.files_touched == 1
+        assert (
+            ctx.read_text()
+            == "See [bar](.agentic-beacon/artifacts/contexts/bar.md) and "
+            "[topic](.agentic-beacon/artifacts/knowledge/topic.md#topic).\n"
+        )
+
+    def test_fix_is_idempotent_on_second_run(self, tmp_path):
+        """TC1: second --fix run is a byte-identical no-op."""
+        wh = _build_clean_warehouse(tmp_path)
+        (wh / "contexts" / "bar.md").write_text("# Bar\n")
+        skill_file = _add_valid_skill(wh, "foo")
+        skill_file.write_text(
+            "---\nrequires:\n  contexts: []\n---\n[ctx](../../contexts/bar.md)\n"
+        )
+
+        first = lint_warehouse(wh, fix=True)
+        after_first = skill_file.read_text()
+        second = lint_warehouse(wh, fix=True)
+
+        assert first.rewritten_links == 1
+        assert second.rewritten_links == 0
+        assert second.files_touched == 0
+        assert skill_file.read_text() == after_first
+
+    def test_lint_without_fix_is_read_only(self, tmp_path):
+        """TC3: lint without --fix reports errors and does not modify files."""
+        wh = _build_clean_warehouse(tmp_path)
+        (wh / "contexts" / "bar.md").write_text("# Bar\n")
+        skill_file = _add_valid_skill(wh, "foo")
+        original = "---\nrequires:\n  contexts: []\n---\n[ctx](../../contexts/bar.md)\n"
+        skill_file.write_text(original)
+
+        report = lint_warehouse(wh)
+
+        assert report.rewritten_links == 0
+        assert report.files_touched == 0
+        assert len(report.findings) == 1
+        assert "malformed cross-artifact link" in report.findings[0].message
+        assert skill_file.read_text() == original
+
+    def test_fix_on_clean_warehouse_is_no_op(self, tmp_path):
+        """TC4: --fix on already-clean warehouse makes no edits and exits cleanly."""
+        wh = _build_clean_warehouse(tmp_path)
+        (wh / "contexts" / "bar.md").write_text("# Bar\n")
+        ctx = wh / "contexts" / "foo.md"
+        ctx.write_text("[bar](.agentic-beacon/artifacts/contexts/bar.md)\n")
+
+        report = lint_warehouse(wh, fix=True)
+
+        assert report.rewritten_links == 0
+        assert report.files_touched == 0
+        assert report.findings == ()
+
+    def test_cli_help_includes_fix_flag(self):
+        """Task 3.1: warehouse lint help exposes the --fix flag."""
+        result = _run_cli(["--help"])
+        assert result.exit_code == 0
+        assert "--fix" in result.output
+
+    def test_cli_fix_reports_counts_and_exits_zero_when_clean_after_fix(self, tmp_path):
+        """Task 3.3: --fix prints rewrite counts and exits 0 when no errors remain."""
+        wh = _build_clean_warehouse(tmp_path)
+        (wh / "contexts" / "bar.md").write_text("# Bar\n")
+        skill_file = _add_valid_skill(wh, "foo")
+        skill_file.write_text(
+            "---\nrequires:\n  contexts: []\n---\n[ctx](../../contexts/bar.md)\n"
+        )
+
+        result = _run_cli(["--fix", str(wh)])
+
+        assert result.exit_code == 0
+        assert "Rewrote 1 link(s) across 1 file(s)." in result.output
+        assert "Lint passed" in result.output
+
+    def test_cli_fix_leaves_escape_error_and_exits_one(self, tmp_path):
+        """Task 3.3: remaining warehouse-escape errors still print and exit 1."""
+        wh = _build_clean_warehouse(tmp_path)
+        skill_file = _add_valid_skill(wh, "foo")
+        skill_file.write_text(
+            "---\nrequires:\n  contexts: []\n---\n[escape](../../../apps/backtest/docs/schema.md)\n"
+        )
+
+        report = lint_warehouse(wh, fix=True)
+        result = _run_cli(["--fix", str(wh)])
+
+        assert result.exit_code == 1
+        assert report.rewritten_links == 0
+        assert report.files_touched == 0
+        assert "warehouse-escape link" in result.output

--- a/libs/beacon/tests/unit/domains/warehouse/test_lint_fix.py
+++ b/libs/beacon/tests/unit/domains/warehouse/test_lint_fix.py
@@ -224,3 +224,76 @@ class TestLintFix:
         assert report.rewritten_links == 0
         assert report.files_touched == 0
         assert "warehouse-escape link" in result.output
+
+    def test_fix_does_not_rewrite_label_when_label_matches_target(self, tmp_path):
+        """Regression: rewrite must touch the link target only, never the label.
+
+        A naive ``full_text.replace(group(2), ..., 1)`` finds the first
+        occurrence anywhere inside ``[label](target)``, so for
+        ``[../../contexts/bar.md](../../contexts/bar.md)`` it rewrites the
+        label and leaves the target malformed. PR #159 round-2 review
+        (medium severity) — fix uses span-based slicing.
+        """
+        wh = _build_clean_warehouse(tmp_path)
+        (wh / "contexts" / "bar.md").write_text("# Bar\n")
+        skill_file = _add_valid_skill(wh, "foo")
+        skill_file.write_text(
+            "---\nrequires:\n  contexts: []\n---\n"
+            "[../../contexts/bar.md](../../contexts/bar.md)\n"
+        )
+
+        report = lint_warehouse(wh, fix=True)
+
+        assert report.rewritten_links == 1
+        assert report.files_touched == 1
+        # Label is byte-preserved; only the target is rewritten to canonical.
+        assert (
+            skill_file.read_text() == "---\nrequires:\n  contexts: []\n---\n"
+            "[../../contexts/bar.md](.agentic-beacon/artifacts/contexts/bar.md)\n"
+        )
+        # Re-lint must be clean — the rewritten link classifies as canonical.
+        relint = lint_warehouse(wh)
+        assert relint.findings == ()
+
+    def test_lint_scans_agent_partials_directory(self, tmp_path):
+        """``agent-partials/**/*.md`` must be covered by the artifact-link rule.
+
+        Phase 4 made ``agent-partials/`` a first-class artifact family
+        mirrored into projects. A malformed cross-artifact link inside a
+        shared partial would otherwise pass lint and ship to every
+        downstream project. PR #159 round-2 review (medium severity).
+        """
+        wh = _build_clean_warehouse(tmp_path)
+        (wh / "contexts" / "bar.md").write_text("# Bar\n")
+        partials_dir = wh / "agent-partials"
+        partials_dir.mkdir()
+        (partials_dir / "shared-checklist.md").write_text(
+            "# Shared Checklist\n\n[ctx](../contexts/bar.md)\n"
+        )
+
+        report = lint_warehouse(wh)
+
+        relevant = [f for f in report.findings if "agent-partials" in f.artifact_path]
+        assert len(relevant) == 1, (
+            f"expected one finding scoped to agent-partials/, got {report.findings}"
+        )
+        assert relevant[0].artifact_path == "agent-partials/shared-checklist.md"
+        assert "malformed cross-artifact link" in relevant[0].message
+
+    def test_fix_rewrites_links_inside_agent_partials(self, tmp_path):
+        """``--fix`` must rewrite cross-artifact links inside agent-partials/."""
+        wh = _build_clean_warehouse(tmp_path)
+        (wh / "contexts" / "bar.md").write_text("# Bar\n")
+        partials_dir = wh / "agent-partials"
+        partials_dir.mkdir()
+        partial_file = partials_dir / "shared-checklist.md"
+        partial_file.write_text("# Shared Checklist\n\n[ctx](../contexts/bar.md)\n")
+
+        report = lint_warehouse(wh, fix=True)
+
+        assert report.rewritten_links == 1
+        assert report.files_touched == 1
+        assert (
+            partial_file.read_text()
+            == "# Shared Checklist\n\n[ctx](.agentic-beacon/artifacts/contexts/bar.md)\n"
+        )

--- a/libs/beacon/tests/unit/test_scanner_classify.py
+++ b/libs/beacon/tests/unit/test_scanner_classify.py
@@ -66,3 +66,18 @@ def test_classify_link_context_relative_is_not_own_folder(tmp_path: Path) -> Non
         classify_link("references/api.md", source, tmp_path)
         == "cross-artifact-relative"
     )
+
+
+def test_classify_link_canonical_with_traversal_escape_is_warehouse_escape(
+    tmp_path: Path,
+) -> None:
+    """A canonical-shaped link that .. -escapes the warehouse classifies as
+    warehouse-escape, not canonical. PR #159 round-3 review (HIGH severity).
+    """
+    source = tmp_path / "contexts" / "foo.md"
+    source.parent.mkdir(parents=True, exist_ok=True)
+
+    assert (
+        classify_link(".agentic-beacon/artifacts/../../outside.md", source, tmp_path)
+        == "warehouse-escape"
+    )

--- a/libs/beacon/tests/unit/test_scanner_classify.py
+++ b/libs/beacon/tests/unit/test_scanner_classify.py
@@ -1,0 +1,68 @@
+from pathlib import Path
+
+from beacon.core.scanner.scanner import classify_link
+
+
+def test_classify_link_absolute_urls(tmp_path: Path) -> None:
+    source = tmp_path / "contexts" / "foo.md"
+
+    assert classify_link("https://x.com", source, tmp_path) == "absolute-url"
+    assert classify_link("mailto:a@b.com", source, tmp_path) == "absolute-url"
+
+
+def test_classify_link_canonical(tmp_path: Path) -> None:
+    source = tmp_path / "contexts" / "foo.md"
+
+    assert (
+        classify_link(".agentic-beacon/artifacts/contexts/a.md", source, tmp_path)
+        == "canonical"
+    )
+
+
+def test_classify_link_own_skill_folder(tmp_path: Path) -> None:
+    source = tmp_path / "skills" / "foo" / "SKILL.md"
+    (tmp_path / "skills" / "foo" / "references").mkdir(parents=True)
+    (tmp_path / "skills" / "foo" / "references" / "api.md").write_text(
+        "# API\n", encoding="utf-8"
+    )
+
+    assert classify_link("references/api.md", source, tmp_path) == "own-skill-folder"
+
+
+def test_classify_link_cross_artifact_relative_from_skill(tmp_path: Path) -> None:
+    source = tmp_path / "skills" / "foo" / "SKILL.md"
+
+    assert (
+        classify_link("../../contexts/bar.md", source, tmp_path)
+        == "cross-artifact-relative"
+    )
+
+
+def test_classify_link_cross_artifact_relative_from_agent(tmp_path: Path) -> None:
+    source = tmp_path / "agents" / "sup.md"
+
+    assert (
+        classify_link("_partials/x.md", source, tmp_path) == "cross-artifact-relative"
+    )
+
+
+def test_classify_link_warehouse_escape(tmp_path: Path) -> None:
+    source = tmp_path / "skills" / "foo" / "SKILL.md"
+
+    assert (
+        classify_link("../../../apps/backtest/docs/schema.md", source, tmp_path)
+        == "warehouse-escape"
+    )
+
+
+def test_classify_link_context_relative_is_not_own_folder(tmp_path: Path) -> None:
+    source = tmp_path / "contexts" / "foo.md"
+    (tmp_path / "contexts" / "references").mkdir(parents=True)
+    (tmp_path / "contexts" / "references" / "api.md").write_text(
+        "# API\n", encoding="utf-8"
+    )
+
+    assert (
+        classify_link("references/api.md", source, tmp_path)
+        == "cross-artifact-relative"
+    )

--- a/libs/beacon/tests/unit/test_scanner_resolve.py
+++ b/libs/beacon/tests/unit/test_scanner_resolve.py
@@ -55,3 +55,28 @@ def test_resolve_canonical_link_decodes_url_encoded_anchor(tmp_path: Path) -> No
         warehouse_root / "contexts" / "cicd-flow.md",
         "\ufe0f-clickhouses3ingestor--dlt-ingestion-design",
     )
+
+
+def test_resolve_canonical_link_rejects_path_traversal_escape(tmp_path: Path) -> None:
+    """Canonical-shaped input that escapes the warehouse via .. is rejected.
+
+    PR #159 round-3 review (HIGH severity). Without the relative_to() guard
+    a payload like .agentic-beacon/artifacts/../../outside.md would be
+    accepted as canonical and joined to a path outside the warehouse,
+    silently widening the lint's allowed scope.
+    """
+    warehouse_root = tmp_path / "warehouse"
+    warehouse_root.mkdir()
+
+    assert (
+        resolve_canonical_link(
+            ".agentic-beacon/artifacts/../../outside.md", warehouse_root
+        )
+        is None
+    )
+    assert (
+        resolve_canonical_link(
+            ".agentic-beacon/artifacts/contexts/../../escape.md", warehouse_root
+        )
+        is None
+    )

--- a/libs/beacon/tests/unit/test_scanner_resolve.py
+++ b/libs/beacon/tests/unit/test_scanner_resolve.py
@@ -1,0 +1,57 @@
+from pathlib import Path
+
+from beacon.core.scanner.scanner import resolve_canonical_link
+
+
+def test_resolve_canonical_link_resolves_existing_target(tmp_path: Path) -> None:
+    warehouse_root = tmp_path
+    target = warehouse_root / "contexts" / "cicd-flow.md"
+    target.parent.mkdir()
+    target.write_text("# CI/CD\n", encoding="utf-8")
+
+    resolved = resolve_canonical_link(
+        ".agentic-beacon/artifacts/contexts/cicd-flow.md", warehouse_root
+    )
+
+    assert resolved == (target, None)
+
+
+def test_resolve_canonical_link_splits_anchor(tmp_path: Path) -> None:
+    warehouse_root = tmp_path
+
+    resolved = resolve_canonical_link(
+        ".agentic-beacon/artifacts/contexts/cicd-flow.md#section", warehouse_root
+    )
+
+    assert resolved == (warehouse_root / "contexts" / "cicd-flow.md", "section")
+
+
+def test_resolve_canonical_link_returns_missing_path_for_missing_target(
+    tmp_path: Path,
+) -> None:
+    warehouse_root = tmp_path
+
+    resolved = resolve_canonical_link(
+        ".agentic-beacon/artifacts/contexts/missing.md", warehouse_root
+    )
+
+    assert resolved == (warehouse_root / "contexts" / "missing.md", None)
+    assert not resolved[0].exists()
+
+
+def test_resolve_canonical_link_rejects_non_canonical_input(tmp_path: Path) -> None:
+    assert resolve_canonical_link("contexts/cicd-flow.md", tmp_path) is None
+
+
+def test_resolve_canonical_link_decodes_url_encoded_anchor(tmp_path: Path) -> None:
+    warehouse_root = tmp_path
+
+    resolved = resolve_canonical_link(
+        ".agentic-beacon/artifacts/contexts/cicd-flow.md#%EF%B8%8F-clickhouses3ingestor--dlt-ingestion-design",
+        warehouse_root,
+    )
+
+    assert resolved == (
+        warehouse_root / "contexts" / "cicd-flow.md",
+        "\ufe0f-clickhouses3ingestor--dlt-ingestion-design",
+    )

--- a/libs/beacon/tests/unit/test_scanner_slugify.py
+++ b/libs/beacon/tests/unit/test_scanner_slugify.py
@@ -1,0 +1,58 @@
+from pathlib import Path
+
+from beacon.core.scanner.scanner import extract_markdown_headings, slugify_heading
+
+
+def test_slugify_heading_matches_cases() -> None:
+    assert slugify_heading("Setup") == "setup"
+    assert (
+        slugify_heading("✨ ClickhouseS3Ingestor — DLT ingestion design")
+        == "-clickhouses3ingestor--dlt-ingestion-design"
+    )
+    assert (
+        slugify_heading("Multi-Repository Workspace - CRITICAL")
+        == "multi-repository-workspace---critical"
+    )
+    assert slugify_heading("  Setup  ") == "setup"
+    assert slugify_heading("Use `foo()`") == "use-foo"
+
+
+def test_extract_markdown_headings_deduplicates_in_document_order(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "doc.md"
+    path.write_text("## Setup\n\n## Setup\n", encoding="utf-8")
+
+    assert extract_markdown_headings(path) == ["setup", "setup-1"]
+
+
+def test_extract_markdown_headings_ignores_non_headings_and_fenced_blocks(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "doc.md"
+    path.write_text(
+        """plain text
+```md
+## Hidden heading
+```
+# Visible Heading
+not a heading
+~~~python
+## Also hidden
+~~~
+## Final Heading
+""",
+        encoding="utf-8",
+    )
+
+    assert extract_markdown_headings(path) == ["visible-heading", "final-heading"]
+
+
+def test_heading_dedup_counter_resets_per_file(tmp_path: Path) -> None:
+    first = tmp_path / "first.md"
+    second = tmp_path / "second.md"
+    first.write_text("## Setup\n## Setup\n", encoding="utf-8")
+    second.write_text("## Setup\n", encoding="utf-8")
+
+    assert extract_markdown_headings(first) == ["setup", "setup-1"]
+    assert extract_markdown_headings(second) == ["setup"]

--- a/libs/beacon/tests/unit/test_scanner_slugify.py
+++ b/libs/beacon/tests/unit/test_scanner_slugify.py
@@ -56,3 +56,18 @@ def test_heading_dedup_counter_resets_per_file(tmp_path: Path) -> None:
 
     assert extract_markdown_headings(first) == ["setup", "setup-1"]
     assert extract_markdown_headings(second) == ["setup"]
+
+
+def test_extract_headings_strips_atx_closing_hashes(tmp_path: Path) -> None:
+    """ATX headings with optional closing hashes (``## Setup ##``) slugify
+    to ``setup``, not ``setup-``.
+
+    PR #159 round-3 review (medium severity). Without the closing-hash
+    strip the captured heading text was ``Setup ##`` and slugified to
+    ``setup-`` because the # characters are filtered but the surrounding
+    space-then-hash sequence collapsed into a trailing hyphen.
+    """
+    path = tmp_path / "with-closing-hashes.md"
+    path.write_text("## Setup ##\n## Reference ###\n## Notes\n", encoding="utf-8")
+
+    assert extract_markdown_headings(path) == ["setup", "reference", "notes"]

--- a/libs/beacon/tests/unit/test_scanner_to_canonical.py
+++ b/libs/beacon/tests/unit/test_scanner_to_canonical.py
@@ -1,0 +1,52 @@
+from pathlib import Path
+
+from beacon.core.scanner.scanner import (
+    classify_link,
+    resolve_canonical_link,
+    to_canonical,
+)
+
+
+def test_to_canonical_rewrites_cross_artifact_relative_skill_link(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "skills" / "foo" / "SKILL.md"
+
+    assert (
+        to_canonical("../../contexts/bar.md", source, tmp_path)
+        == ".agentic-beacon/artifacts/contexts/bar.md"
+    )
+
+
+def test_to_canonical_preserves_anchor(tmp_path: Path) -> None:
+    source = tmp_path / "skills" / "foo" / "SKILL.md"
+
+    assert (
+        to_canonical("../../contexts/bar.md#multi-repo", source, tmp_path)
+        == ".agentic-beacon/artifacts/contexts/bar.md#multi-repo"
+    )
+
+
+def test_to_canonical_round_trips_agent_partial_link(tmp_path: Path) -> None:
+    warehouse_root = tmp_path
+    source = warehouse_root / "agents" / "sup.md"
+    rewritten = to_canonical(
+        "_partials/deep-review-checklist.md", source, warehouse_root
+    )
+
+    assert (
+        rewritten
+        == ".agentic-beacon/artifacts/agents/_partials/deep-review-checklist.md"
+    )
+    assert classify_link(rewritten, source, warehouse_root) == "canonical"
+    assert resolve_canonical_link(rewritten, warehouse_root) == (
+        warehouse_root / "agents" / "_partials" / "deep-review-checklist.md",
+        None,
+    )
+
+
+def test_to_canonical_is_idempotent_for_canonical_input(tmp_path: Path) -> None:
+    source = tmp_path / "skills" / "foo" / "SKILL.md"
+    link = ".agentic-beacon/artifacts/contexts/bar.md#multi-repo"
+
+    assert to_canonical(link, source, tmp_path) == link

--- a/libs/beacon/tests/unit/test_scanner_to_canonical.py
+++ b/libs/beacon/tests/unit/test_scanner_to_canonical.py
@@ -27,7 +27,19 @@ def test_to_canonical_preserves_anchor(tmp_path: Path) -> None:
     )
 
 
-def test_to_canonical_round_trips_agent_partial_link(tmp_path: Path) -> None:
+def test_to_canonical_rewrites_legacy_partials_to_top_level_agent_partials(
+    tmp_path: Path,
+) -> None:
+    """Legacy ``agents/_partials/`` references rewrite to ``agent-partials/``.
+
+    The Phase 4 layout moves partials out of ``agents/_partials/`` to a
+    top-level ``agent-partials/`` directory and the distribution glob only
+    mirrors the new location. ``to_canonical()`` therefore canonicalises
+    a legacy relative reference straight to the new location so a
+    rewritten link resolves in synced projects after the warehouse
+    migration. Tests both the agent-relative form (``_partials/...``)
+    and a same-tree absolute form (resolving to ``agents/_partials/...``).
+    """
     warehouse_root = tmp_path
     source = warehouse_root / "agents" / "sup.md"
     rewritten = to_canonical(
@@ -35,12 +47,15 @@ def test_to_canonical_round_trips_agent_partial_link(tmp_path: Path) -> None:
     )
 
     assert (
-        rewritten
-        == ".agentic-beacon/artifacts/agents/_partials/deep-review-checklist.md"
+        rewritten == ".agentic-beacon/artifacts/agent-partials/deep-review-checklist.md"
     )
     assert classify_link(rewritten, source, warehouse_root) == "canonical"
+    # Build the agent-partials/ tree so resolve_canonical_link can verify
+    # the rewritten target lives under the warehouse root.
+    (warehouse_root / "agent-partials").mkdir()
+    (warehouse_root / "agent-partials" / "deep-review-checklist.md").write_text("x\n")
     assert resolve_canonical_link(rewritten, warehouse_root) == (
-        warehouse_root / "agents" / "_partials" / "deep-review-checklist.md",
+        (warehouse_root / "agent-partials" / "deep-review-checklist.md").resolve(),
         None,
     )
 

--- a/libs/beacon/tests/unit/test_wire_agents.py
+++ b/libs/beacon/tests/unit/test_wire_agents.py
@@ -947,3 +947,68 @@ class TestWireAgentsAtomicallyPartials:
         assert not (project / ".claude" / "agents" / "agent-a.md").exists()
         assert not (project / ".claude" / "agents" / "_partials").exists()
         assert blocker.read_text() == "user content"
+
+    def test_user_owned_symlink_under_partials_dir_is_preserved(
+        self, tmp_path, loguru_caplog
+    ):
+        """Sync prune must not delete a symlink whose target lives outside the
+        Beacon-owned ``.agentic-beacon/artifacts/`` mirror.
+
+        Pre-PER-238 Beacon-owned symlinks always pointed into the artifacts
+        mirror; a contributor's hand-symlinked partial pointing somewhere else
+        (e.g. an external notes file) is user content and must survive sync.
+        Addresses PR #159 round-2 review (medium severity).
+        """
+        project = tmp_path / "proj"
+        project.mkdir()
+        artifact = _make_artifact(tmp_path / "warehouse", "spec-planner.md")
+        # Materialise an artifacts/ tree so the prune helper can resolve it.
+        _make_partial(
+            project / ".agentic-beacon" / "artifacts", "deep-review-checklist.md"
+        )
+
+        # User's own external file + symlink under the tool partials dir.
+        external = tmp_path / "external" / "my-notes.md"
+        external.parent.mkdir(parents=True, exist_ok=True)
+        external.write_text("# my notes\n")
+
+        user_symlink = project / ".opencode" / "agents" / "_partials" / "mine.md"
+        user_symlink.parent.mkdir(parents=True, exist_ok=True)
+        user_symlink.symlink_to(external)
+
+        wire_agents_atomically(project, [artifact], {"opencode"})
+
+        assert user_symlink.is_symlink(), (
+            "user-owned symlink must be preserved by sync prune"
+        )
+        assert user_symlink.resolve() == external.resolve()
+        warnings = [
+            r.getMessage() for r in loguru_caplog.records if r.levelname == "WARNING"
+        ]
+        assert any("Preserving user-owned partial symlink" in m for m in warnings), (
+            f"expected preservation warning; got warnings={warnings!r}"
+        )
+
+    def test_legacy_beacon_owned_symlink_under_partials_is_pruned(self, tmp_path):
+        """A symlink under ``.<tool>/agents/_partials/`` that points INTO the
+        ``.agentic-beacon/artifacts/`` mirror is the pre-PER-238 Beacon-owned
+        layout; sync MUST remove it during prune.
+        """
+        project = tmp_path / "proj"
+        project.mkdir()
+        artifact = _make_artifact(tmp_path / "warehouse", "spec-planner.md")
+        target = _make_partial(
+            project / ".agentic-beacon" / "artifacts", "legacy-checklist.md"
+        )
+
+        legacy_symlink = (
+            project / ".opencode" / "agents" / "_partials" / "legacy-checklist.md"
+        )
+        legacy_symlink.parent.mkdir(parents=True, exist_ok=True)
+        legacy_symlink.symlink_to(target)
+
+        wire_agents_atomically(project, [artifact], {"opencode"})
+
+        assert not legacy_symlink.exists(), (
+            "Beacon-owned legacy partial symlink must be pruned"
+        )

--- a/libs/beacon/tests/unit/test_wire_agents.py
+++ b/libs/beacon/tests/unit/test_wire_agents.py
@@ -816,27 +816,32 @@ def test_wire_agent_opencode_idempotent_with_relative_readlink(tmp_path):
 
 
 # ---------------------------------------------------------------------------
-# PER-164: partial wiring
+# Agent partial pruning / no-wiring
 # ---------------------------------------------------------------------------
 
 
+LEGACY_BEACON_PARTIAL_WRAPPER_PREFIX = (
+    "---\n"
+    "description: >-\n"
+    "  Internal fragment referenced by other agents \u2014 not a real agent.\n"
+    "  Disabled at wire time by Beacon (PER-238).\n"
+    "mode: subagent\n"
+    "disable: true\n"
+    "---\n\n"
+)
+
+
 def _make_partial(base: Path, rel: str, content: str = "partial") -> Path:
-    """Create a partial file under base/agents/_partials/ and return its Path."""
-    partial = base / "agents" / "_partials" / rel
+    """Create a partial file under base/agent-partials/ and return its Path."""
+    partial = base / "agent-partials" / rel
     partial.parent.mkdir(parents=True, exist_ok=True)
     partial.write_text(content)
     return partial
 
 
 class TestWireAgentsAtomicallyPartials:
-    def test_partials_wired_to_both_tools(self, tmp_path):
-        """Partials under artifacts/agents/_partials/ get wrapped+wired into both tools.
-
-        PER-164 introduced the wiring; PER-238 changed the wire output from a
-        raw symlink to a regular file with `disable: true` frontmatter so
-        opencode doesn't surface the partial as a callable subagent. Both the
-        frontmatter and the original partial body must be present.
-        """
+    def test_sync_with_declared_agent_does_not_wire_partials(self, tmp_path):
+        """Declared agents still sync, but partials stay out of tool dirs."""
         project = tmp_path / "proj"
         project.mkdir()
         artifact = _make_artifact(tmp_path / "warehouse", "spec-planner.md")
@@ -848,135 +853,78 @@ class TestWireAgentsAtomicallyPartials:
 
         wire_agents_atomically(project, [artifact], {"claudecode", "opencode"})
 
-        cc_partial = (
-            project / ".claude" / "agents" / "_partials" / "deep-review-checklist.md"
-        )
-        oc_partial = (
-            project / ".opencode" / "agents" / "_partials" / "deep-review-checklist.md"
-        )
-        # PER-238: wrappers are regular files, NOT symlinks.
-        assert cc_partial.is_file() and not cc_partial.is_symlink(), (
-            f"Expected regular-file wrapper at {cc_partial}, not a symlink"
-        )
-        assert oc_partial.is_file() and not oc_partial.is_symlink(), (
-            f"Expected regular-file wrapper at {oc_partial}, not a symlink"
-        )
-        for wrapped in (cc_partial, oc_partial):
-            content = wrapped.read_text()
-            assert content.startswith("---\n"), (
-                f"Wrapper at {wrapped} missing frontmatter fence"
-            )
-            assert "disable: true" in content, (
-                f"Wrapper at {wrapped} missing disable: true"
-            )
-            # Original body must be inlined verbatim below the frontmatter.
-            assert "body line one" in content, (
-                f"Wrapper at {wrapped} missing original partial body"
-            )
-        # Original warehouse partial must be untouched.
+        assert (project / ".claude" / "agents" / "spec-planner.md").is_symlink()
+        assert (project / ".opencode" / "agents" / "spec-planner.md").is_symlink()
+        assert not (project / ".claude" / "agents" / "_partials").exists()
+        assert not (project / ".opencode" / "agents" / "_partials").exists()
+        assert not (project / ".claude" / "agents" / "agent-partials").exists()
+        assert not (project / ".opencode" / "agents" / "agent-partials").exists()
         assert partial.read_text() == "# Deep-review checklist\n\nbody line one\n"
 
-    def test_partials_idempotent(self, tmp_path):
-        """Re-running wire_agents_atomically does not rewrite unchanged partial wrappers (PER-164/PER-238)."""
+    def test_pre_existing_beacon_wrapper_is_pruned(self, tmp_path):
+        """Beacon-owned legacy wrappers are removed and not recreated."""
         project = tmp_path / "proj"
         project.mkdir()
         artifact = _make_artifact(tmp_path / "warehouse", "spec-planner.md")
         _make_partial(
-            project / ".agentic-beacon" / "artifacts",
-            "deep-review-checklist.md",
+            project / ".agentic-beacon" / "artifacts", "deep-review-checklist.md"
         )
 
-        wire_agents_atomically(project, [artifact], {"claudecode"})
-        cc_partial = (
-            project / ".claude" / "agents" / "_partials" / "deep-review-checklist.md"
+        stale = (
+            project / ".opencode" / "agents" / "_partials" / "deep-review-checklist.md"
         )
-        mtime_before = cc_partial.lstat().st_mtime
+        stale.parent.mkdir(parents=True, exist_ok=True)
+        stale.write_text(LEGACY_BEACON_PARTIAL_WRAPPER_PREFIX + "body\n")
 
-        wire_agents_atomically(project, [artifact], {"claudecode"})
-        assert cc_partial.lstat().st_mtime == mtime_before
+        wire_agents_atomically(project, [artifact], {"opencode"})
 
-    def test_partials_preserve_subdirectory_structure(self, tmp_path):
-        """Nested partial files retain their subdirectory under _partials/ (PER-164)."""
-        project = tmp_path / "proj"
-        project.mkdir()
-        artifact = _make_artifact(tmp_path / "warehouse", "spec-planner.md")
-        nested = _make_partial(
-            project / ".agentic-beacon" / "artifacts",
-            "sub/dir/nested.md",
-            content="# nested\n\ninner body\n",
-        )
+        assert not stale.exists()
 
-        wire_agents_atomically(project, [artifact], {"claudecode"})
-
-        cc_nested = (
-            project / ".claude" / "agents" / "_partials" / "sub" / "dir" / "nested.md"
-        )
-        # PER-238: regular-file wrapper, not symlink.
-        assert cc_nested.is_file() and not cc_nested.is_symlink()
-        content = cc_nested.read_text()
-        assert "disable: true" in content
-        assert "inner body" in content
-        # Source warehouse partial unchanged.
-        assert nested.read_text() == "# nested\n\ninner body\n"
-
-    def test_no_partials_dir_is_noop(self, tmp_path):
-        """When no _partials/ directory exists, wire_agents_atomically still works."""
-        project = tmp_path / "proj"
-        project.mkdir()
-        artifact = _make_artifact(tmp_path / "warehouse", "spec-planner.md")
-
-        wire_agents_atomically(project, [artifact], {"claudecode"})
-
-        assert (project / ".claude" / "agents" / "spec-planner.md").is_symlink()
-        assert not (project / ".claude" / "agents" / "_partials").exists()
-
-    def test_partial_rolled_back_when_later_partial_wire_fails(
-        self, tmp_path, monkeypatch
+    def test_user_owned_file_at_partial_path_is_preserved(
+        self, tmp_path, loguru_caplog
     ):
-        """Real rollback exercise: monkeypatch _wire_partial to raise on the second
-        invocation. The first partial AND the previously-wired agent must be
-        rolled back. (PER-164; addresses opencode-review round-2 finding that
-        the pre-flight conflict path was being checked instead of the in-flight
-        rollback path.)
+        """User content at a partial path is preserved with a warning.
+
+        Uses the repo's ``loguru_caplog`` fixture (tests/conftest.py) to capture
+        loguru WARNINGs — plain ``capsys`` does not see them because loguru
+        writes to its own sinks, not ``sys.stderr``.
         """
+        project = tmp_path / "proj"
+        project.mkdir()
+        artifact = _make_artifact(tmp_path / "warehouse", "spec-planner.md")
+        _make_partial(
+            project / ".agentic-beacon" / "artifacts", "deep-review-checklist.md"
+        )
+
+        user_file = project / ".opencode" / "agents" / "_partials" / "mine.md"
+        user_file.parent.mkdir(parents=True, exist_ok=True)
+        user_file.write_text("hand-written user content")
+
+        wire_agents_atomically(project, [artifact], {"opencode"})
+
+        assert user_file.read_text() == "hand-written user content"
+        warnings = [
+            r.getMessage() for r in loguru_caplog.records if r.levelname == "WARNING"
+        ]
+        assert any("Preserving user-owned partial path" in m for m in warnings), (
+            f"expected preservation warning; got warnings={warnings!r}"
+        )
+
+    def test_no_partial_wrapper_builder(self):
+        """Wrapper builder helper was removed with the stopgap."""
         from beacon.domains.setup import wiring as wiring_mod
 
+        assert not hasattr(wiring_mod, "_build_partial_wrapper")
+
+    def test_no_agents_declared_is_still_a_noop(self, tmp_path):
+        """Without partial wiring, empty agent lists remain a no-op."""
         project = tmp_path / "proj"
         project.mkdir()
-        artifact = _make_artifact(tmp_path / "warehouse", "spec-planner.md")
-        _make_partial(project / ".agentic-beacon" / "artifacts", "first.md", "first")
-        _make_partial(project / ".agentic-beacon" / "artifacts", "second.md", "second")
 
-        # Wrap the real _wire_partial: succeed the first time, raise the second.
-        real_wire_partial = wiring_mod._wire_partial
-        calls = {"n": 0}
+        wire_agents_atomically(project, [], {"claudecode", "opencode"})
 
-        def flaky_wire_partial(*args, **kwargs):
-            calls["n"] += 1
-            if calls["n"] == 2:
-                raise BeaconSyncError("simulated mid-wire failure")
-            return real_wire_partial(*args, **kwargs)
-
-        monkeypatch.setattr(wiring_mod, "_wire_partial", flaky_wire_partial)
-
-        with pytest.raises(BeaconSyncError, match="simulated mid-wire failure"):
-            wire_agents_atomically(project, [artifact], {"claudecode"})
-
-        # Agent symlink must be rolled back …
-        dest_agent = project / ".claude" / "agents" / "spec-planner.md"
-        assert not dest_agent.is_symlink() and not dest_agent.exists()
-
-        # … the first partial (wired before the failure) must be rolled back …
-        first = project / ".claude" / "agents" / "_partials" / "first.md"
-        assert not first.is_symlink() and not first.exists()
-
-        # … and the second partial (whose wire raised) must not have been
-        # left behind either.
-        second = project / ".claude" / "agents" / "_partials" / "second.md"
-        assert not second.is_symlink() and not second.exists()
-
-        # Sanity: the flaky wrapper was actually invoked twice.
-        assert calls["n"] == 2
+        assert not (project / ".claude" / "agents" / "_partials").exists()
+        assert not (project / ".opencode" / "agents" / "_partials").exists()
 
     def test_preflight_blocks_when_regular_file_at_agent_dest(self, tmp_path):
         """Companion test for the pre-flight path the original (vacuous) rollback
@@ -988,11 +936,6 @@ class TestWireAgentsAtomicallyPartials:
 
         artifact_a = _make_artifact(tmp_path / "warehouse", "agent-a.md")
         artifact_b = _make_artifact(tmp_path / "warehouse", "agent-b.md")
-        _make_partial(
-            project / ".agentic-beacon" / "artifacts",
-            "deep-review-checklist.md",
-        )
-
         blocker = project / ".claude" / "agents" / "agent-b.md"
         blocker.parent.mkdir(parents=True, exist_ok=True)
         blocker.write_text("user content")
@@ -1000,259 +943,7 @@ class TestWireAgentsAtomicallyPartials:
         with pytest.raises(RegularFileConflictError):
             wire_agents_atomically(project, [artifact_a, artifact_b], {"claudecode"})
 
-        # Pre-flight aborted before any wire: agent-a is untouched, partial is untouched,
-        # blocker file is preserved.
+        # Pre-flight aborted before any wire and blocker file is preserved.
         assert not (project / ".claude" / "agents" / "agent-a.md").exists()
         assert not (project / ".claude" / "agents" / "_partials").exists()
         assert blocker.read_text() == "user content"
-
-
-# ---------------------------------------------------------------------------
-# PER-238: partial wrappers carry disable: true frontmatter and idempotently
-# replace pre-PER-238 raw symlinks.
-# ---------------------------------------------------------------------------
-
-
-class TestWirePartialPER238Wrapper:
-    def test_wrapper_carries_disable_true_frontmatter(self, tmp_path):
-        """Empirical PER-238 contract: the wrapper file must declare
-        `disable: true` and `mode: subagent` so opencode (and Claude Code)
-        skip the partial during agent autodiscovery.
-        """
-        project = tmp_path / "proj"
-        project.mkdir()
-        artifact = _make_artifact(tmp_path / "warehouse", "spec-planner.md")
-        _make_partial(
-            project / ".agentic-beacon" / "artifacts",
-            "deep-review-checklist.md",
-            content="# Deep-review checklist\n\nbody\n",
-        )
-
-        wire_agents_atomically(project, [artifact], {"claudecode"})
-
-        cc_wrap = (
-            project / ".claude" / "agents" / "_partials" / "deep-review-checklist.md"
-        )
-        content = cc_wrap.read_text()
-        # Frontmatter fence is the very first thing in the file — opencode
-        # parses YAML only at the head.
-        assert content.startswith("---\n")
-        # Extract the frontmatter block (everything between the first two ---).
-        head, _, body = content[4:].partition("\n---\n")
-        assert "mode: subagent" in head, f"frontmatter missing mode:\n{head}"
-        assert "disable: true" in head, f"frontmatter missing disable:\n{head}"
-        # Body is preserved verbatim after the frontmatter.
-        assert body.endswith("# Deep-review checklist\n\nbody\n"), body
-
-    def test_wrapper_replaces_pre_per238_symlink(self, tmp_path):
-        """Migration: an existing raw symlink (pre-PER-238 layout) must be
-        replaced by a wrapper file on the next wire pass — without raising.
-        """
-        project = tmp_path / "proj"
-        project.mkdir()
-        artifact = _make_artifact(tmp_path / "warehouse", "spec-planner.md")
-        partial = _make_partial(
-            project / ".agentic-beacon" / "artifacts",
-            "deep-review-checklist.md",
-            content="# checklist\n\nbody\n",
-        )
-
-        # Simulate the pre-PER-238 state: a raw symlink to the partial.
-        cc_dir = project / ".claude" / "agents" / "_partials"
-        cc_dir.mkdir(parents=True, exist_ok=True)
-        legacy = cc_dir / "deep-review-checklist.md"
-        legacy.symlink_to(partial)
-        assert legacy.is_symlink()
-
-        wire_agents_atomically(project, [artifact], {"claudecode"})
-
-        # Now a regular-file wrapper, not a symlink.
-        assert legacy.is_file() and not legacy.is_symlink()
-        assert "disable: true" in legacy.read_text()
-
-    def test_wrapper_strips_existing_partial_frontmatter(self, tmp_path):
-        """Defensive: if a partial ships with its own YAML frontmatter, the
-        wrapper must NOT emit two ``---`` blocks back-to-back (which would
-        confuse opencode's frontmatter parser). The partial's frontmatter is
-        stripped; only the body is inlined under our wrapper frontmatter.
-        """
-        project = tmp_path / "proj"
-        project.mkdir()
-        artifact = _make_artifact(tmp_path / "warehouse", "spec-planner.md")
-        _make_partial(
-            project / ".agentic-beacon" / "artifacts",
-            "with-fm.md",
-            content="---\nfoo: bar\n---\n\nactual body\n",
-        )
-
-        wire_agents_atomically(project, [artifact], {"claudecode"})
-
-        cc_wrap = project / ".claude" / "agents" / "_partials" / "with-fm.md"
-        content = cc_wrap.read_text()
-        # Exactly one frontmatter block at the head.
-        assert content.count("\n---\n") == 1, (
-            f"Expected exactly one frontmatter block, got:\n{content}"
-        )
-        # The partial's original frontmatter values are gone.
-        assert "foo: bar" not in content
-        # The body survives.
-        assert content.endswith("actual body\n")
-
-    def test_wrapper_conflicts_with_unrelated_user_file(self, tmp_path):
-        """If a user-authored regular file already sits at the wrapper path
-        and its content does NOT match the wrapper we'd write, the wire must
-        raise RegularFileConflictError — same protection as for top-level
-        agent destinations.
-        """
-        project = tmp_path / "proj"
-        project.mkdir()
-        artifact = _make_artifact(tmp_path / "warehouse", "spec-planner.md")
-        _make_partial(
-            project / ".agentic-beacon" / "artifacts",
-            "deep-review-checklist.md",
-            content="# checklist\n\nbody\n",
-        )
-
-        cc_dir = project / ".claude" / "agents" / "_partials"
-        cc_dir.mkdir(parents=True, exist_ok=True)
-        user_file = cc_dir / "deep-review-checklist.md"
-        user_file.write_text("hand-written user content")
-
-        with pytest.raises(RegularFileConflictError):
-            wire_agents_atomically(project, [artifact], {"claudecode"})
-
-        # User file untouched.
-        assert user_file.read_text() == "hand-written user content"
-
-    def test_wrapper_refreshes_when_warehouse_body_changes(self, tmp_path):
-        """Regression for opencode-review Medium finding on PR #157:
-
-        A wrapper written by a previous sync must be **refreshed in place**
-        when the warehouse partial body changes — not flagged as a user
-        conflict. Beacon-owned wrappers are recognised by the exact
-        frontmatter prefix; only the body below is allowed to drift.
-        """
-        project = tmp_path / "proj"
-        project.mkdir()
-        artifact = _make_artifact(tmp_path / "warehouse", "spec-planner.md")
-        partial = _make_partial(
-            project / ".agentic-beacon" / "artifacts",
-            "deep-review-checklist.md",
-            content="# checklist\n\nv1 body\n",
-        )
-
-        # First sync: wrapper holds v1 body.
-        wire_agents_atomically(project, [artifact], {"claudecode"})
-        cc_wrap = (
-            project / ".claude" / "agents" / "_partials" / "deep-review-checklist.md"
-        )
-        assert "v1 body" in cc_wrap.read_text()
-
-        # Warehouse partial body edited.
-        partial.write_text("# checklist\n\nv2 body\n")
-
-        # Re-sync must succeed and refresh the wrapper to v2 — NOT raise
-        # RegularFileConflictError.
-        wire_agents_atomically(project, [artifact], {"claudecode"})
-
-        refreshed = cc_wrap.read_text()
-        assert "v2 body" in refreshed, (
-            f"Wrapper did not refresh after warehouse partial edit:\n{refreshed}"
-        )
-        assert "v1 body" not in refreshed, (
-            f"Stale v1 body still present in wrapper:\n{refreshed}"
-        )
-        # Frontmatter still intact.
-        assert refreshed.startswith("---\n")
-        assert "disable: true" in refreshed.split("\n---\n", 1)[0]
-
-    def test_wrapper_with_drifted_body_not_user_conflict_in_preflight(self, tmp_path):
-        """Companion to the refresh test, exercising the **pre-flight** path.
-
-        When two partials are wired and only the second triggers a refresh,
-        the pre-flight scan must NOT short-circuit with a conflict on the
-        first partial just because its body has drifted. Bug from PR #157
-        opencode-review: the preflight compared full-file equality instead
-        of recognising Beacon-owned wrappers by frontmatter.
-        """
-        project = tmp_path / "proj"
-        project.mkdir()
-        artifact = _make_artifact(tmp_path / "warehouse", "spec-planner.md")
-        first = _make_partial(
-            project / ".agentic-beacon" / "artifacts", "first.md", "v1\n"
-        )
-        _make_partial(
-            project / ".agentic-beacon" / "artifacts", "second.md", "second body\n"
-        )
-        wire_agents_atomically(project, [artifact], {"claudecode"})
-
-        # Drift the first partial's warehouse body without touching the
-        # wrapper on disk.
-        first.write_text("v2\n")
-
-        # Pre-flight must accept the existing first wrapper as Beacon-owned
-        # despite the body drift, AND wire the second partial successfully.
-        wire_agents_atomically(project, [artifact], {"claudecode"})
-
-        cc_first = project / ".claude" / "agents" / "_partials" / "first.md"
-        cc_second = project / ".claude" / "agents" / "_partials" / "second.md"
-        assert "v2" in cc_first.read_text()
-        assert "second body" in cc_second.read_text()
-
-    def test_refreshed_wrapper_rolled_back_when_later_wire_fails(
-        self, tmp_path, monkeypatch
-    ):
-        """Regression for opencode-review round-2 Medium finding on PR #157:
-
-        When ``_wire_partial`` refreshes an existing Beacon-owned wrapper
-        in-place (because the warehouse partial body drifted), the refreshed
-        content must be rolled back to its pre-wire state if a later wire
-        step fails. Before the fix, ``snapshot_agent_path`` recorded
-        ``regular_file`` for the existing wrapper and the rollback closure
-        treated that snapshot as a no-op, leaving the partial-applied refresh
-        on disk after a failure.
-        """
-        from beacon.domains.setup import wiring as wiring_mod
-
-        project = tmp_path / "proj"
-        project.mkdir()
-        artifact = _make_artifact(tmp_path / "warehouse", "spec-planner.md")
-        first = _make_partial(
-            project / ".agentic-beacon" / "artifacts", "first.md", "v1\n"
-        )
-        _make_partial(
-            project / ".agentic-beacon" / "artifacts", "second.md", "second body\n"
-        )
-
-        # Initial sync — both wrappers written.
-        wire_agents_atomically(project, [artifact], {"claudecode"})
-        cc_first = project / ".claude" / "agents" / "_partials" / "first.md"
-        v1_content = cc_first.read_text()
-        assert "v1" in v1_content
-
-        # Drift the first partial body, then arrange for the SECOND wire to
-        # fail. The first wire will refresh the wrapper from v1 → v2 and
-        # rollback must put v1 back.
-        first.write_text("v2\n")
-        real_wire_partial = wiring_mod._wire_partial
-        calls = {"n": 0}
-
-        def flaky_wire_partial(*args, **kwargs):
-            calls["n"] += 1
-            if calls["n"] == 2:
-                raise BeaconSyncError("simulated mid-wire failure")
-            return real_wire_partial(*args, **kwargs)
-
-        monkeypatch.setattr(wiring_mod, "_wire_partial", flaky_wire_partial)
-
-        with pytest.raises(BeaconSyncError, match="simulated mid-wire failure"):
-            wire_agents_atomically(project, [artifact], {"claudecode"})
-
-        # The refreshed wrapper must be restored to the pre-wire (v1) state.
-        restored = cc_first.read_text()
-        assert restored == v1_content, (
-            "Refreshed wrapper not rolled back; expected pre-wire content "
-            f"but got:\n{restored}"
-        )
-        # Sanity: the flaky wrapper was actually invoked twice.
-        assert calls["n"] == 2

--- a/libs/beacon/tests/unit/warehouse/test_distributor.py
+++ b/libs/beacon/tests/unit/warehouse/test_distributor.py
@@ -7,7 +7,10 @@ Regression tests for:
 """
 
 import pytest
-from beacon.domains.distribution.distributor import WarehouseDistributor
+from beacon.domains.distribution.distributor import (
+    WarehouseDistributor,
+    is_partial_path,
+)
 from beacon.domains.warehouse.catalog import generate_warehouse_catalog
 
 
@@ -176,7 +179,7 @@ def test_catalog_skills_example_uses_skills_prefix(temp_dir):
     assert "skills/" in catalog
 
 
-# ========== PER-164: _partials filtering ==========
+# ========== Agent partial filtering ==========
 
 
 @pytest.fixture
@@ -185,12 +188,14 @@ def warehouse_with_partials(temp_dir):
     wh = temp_dir / "warehouse"
     wh.mkdir()
     (wh / "agents").mkdir()
+    (wh / "agent-partials").mkdir()
     (wh / "contexts").mkdir()
     (wh / "knowledge").mkdir()
     (wh / "skills").mkdir()
     (wh / "agents" / "foo.md").write_text("# Agent Foo")
     (wh / "agents" / "_partials").mkdir()
     (wh / "agents" / "_partials" / "p.md").write_text("# Partial")
+    (wh / "agent-partials" / "root.md").write_text("# Root Partial")
     (wh / "agents" / "_internal").mkdir()
     (wh / "agents" / "_internal" / "q.md").write_text("# Internal")
     (wh / "agents" / "some-dir").mkdir()
@@ -198,8 +203,24 @@ def warehouse_with_partials(temp_dir):
     return wh
 
 
+@pytest.mark.parametrize(
+    ("rel_path", "expected"),
+    [
+        ("agent-partials/deep-review-checklist.md", True),
+        ("agent-partials/sub/x.md", True),
+        ("agents/_partials/x.md", True),
+        ("_partials/x.md", True),
+        ("agents/spec-planner.md", False),
+        ("contexts/foo.md", False),
+    ],
+)
+def test_is_partial_path_cases(rel_path, expected):
+    """Recognize canonical and legacy partial locations, but not agents."""
+    assert is_partial_path(rel_path) is expected
+
+
 def test_list_agents_skips_partials_dir(warehouse_with_partials, temp_dir):
-    """_list_agents skips agents/_partials/*.md (PER-164)."""
+    """_list_agents skips legacy agents/_partials/*.md for safety."""
     distributor = WarehouseDistributor(
         warehouse_root=warehouse_with_partials,
         target_root=temp_dir / "project",
@@ -207,14 +228,13 @@ def test_list_agents_skips_partials_dir(warehouse_with_partials, temp_dir):
     result = distributor._list_agents(warehouse_with_partials / "agents")
     assert "agents/_partials/p.md" not in result
     assert "agents/foo.md" in result
+    assert is_partial_path("agent-partials/root.md") is True
 
 
 def test_list_agents_only_skips_partials_not_other_underscore_dirs(
     warehouse_with_partials, temp_dir
 ):
-    """Filter is scoped to ``_partials/`` specifically — other underscore dirs
-    are still listed because sync only co-distributes ``_partials/`` (PER-164).
-    """
+    """Filter is scoped to partial paths specifically, not all underscore dirs."""
     distributor = WarehouseDistributor(
         warehouse_root=warehouse_with_partials,
         target_root=temp_dir / "project",

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -88,6 +88,7 @@ nav:
     - Day-to-Day Workflow: guides/day-to-day-workflow.md
     - Contributing Back:
       - Overview: guides/contributing-back.md
+      - Canonical Links: guides/canonical-links.md
       - Creating Skills: guides/creating-skills.md
       - Creating Knowledge and Contexts: guides/creating-knowledge-and-contexts.md
       - Creating an Agent: guides/creating-agents.md

--- a/openspec/changes/gate-artifact-reference-paths/tasks.md
+++ b/openspec/changes/gate-artifact-reference-paths/tasks.md
@@ -78,7 +78,7 @@ pytest tests/ -v --tb=short
 <!-- opsx:phase-summary:1:end -->
 
 
-- [ ] 1.1 Add `slugify_heading()` (GitHub-exact: lowercase, strip non-alnum/space/hyphen, spaces→hyphen, preserve punctuation double-hyphens, dedup `-1/-2`) and a heading-extractor for a markdown file
+- [x] 1.1 Add `slugify_heading()` (GitHub-exact: lowercase, strip non-alnum/space/hyphen, spaces→hyphen, preserve punctuation double-hyphens, dedup `-1/-2`) and a heading-extractor for a markdown file
 <!-- opsx:tdd:1.1:begin -->
   - **Input**: pytest tests/unit/test_scanner_slugify.py -v
   - **Expected Output**: All slugify cases pass; slugs match GitHub for ASCII, emoji, em-dash, and duplicate-heading inputs
@@ -92,7 +92,7 @@ pytest tests/ -v --tb=short
     - TC6: heading with inline code `## Use `foo()`` → backticks stripped, slug `use-foo`
     - TC7: non-heading lines and fenced ``` blocks → not extracted as headings
 <!-- opsx:tdd:1.1:end -->
-- [ ] 1.2 Add `CANONICAL_PREFIX = ".agentic-beacon/artifacts/"` and `resolve_canonical_link()` (strip prefix → warehouse-root path; optional anchor)
+- [x] 1.2 Add `CANONICAL_PREFIX = ".agentic-beacon/artifacts/"` and `resolve_canonical_link()` (strip prefix → warehouse-root path; optional anchor)
 <!-- opsx:tdd:1.2:begin -->
   - **Input**: pytest tests/unit/test_scanner_resolve.py -v
   - **Expected Output**: Canonical links resolve to <warehouse>/<rel>; anchor split out; non-canonical input returns None/unresolved
@@ -104,7 +104,7 @@ pytest tests/ -v --tb=short
     - TC4: input without the canonical prefix → not treated as canonical
     - TC5: URL-encoded anchor (`#%EF%B8%8F-...`) → decoded before comparison
 <!-- opsx:tdd:1.2:end -->
-- [ ] 1.3 Add `classify_link()` returning one of: absolute-url / canonical / own-skill-folder / cross-artifact-relative / warehouse-escape (own-folder applies only to skills)
+- [x] 1.3 Add `classify_link()` returning one of: absolute-url / canonical / own-skill-folder / cross-artifact-relative / warehouse-escape (own-folder applies only to skills)
 <!-- opsx:tdd:1.3:begin -->
   - **Input**: pytest tests/unit/test_scanner_classify.py -v
   - **Expected Output**: Each link classified into exactly one of the five categories given the linking file path + warehouse root
@@ -119,7 +119,7 @@ pytest tests/ -v --tb=short
     - TC7: `../../../apps/backtest/docs/schema.md` resolving outside warehouse → warehouse-escape
     - TC8: `references/api.md` from contexts/foo.md → cross-artifact-relative (own-folder is skills-only)
 <!-- opsx:tdd:1.3:end -->
-- [ ] 1.4 Add `to_canonical()` helper: given a cross-artifact relative link + linking file, compute the canonical form (preserve anchor) — shared by lint and `--fix`
+- [x] 1.4 Add `to_canonical()` helper: given a cross-artifact relative link + linking file, compute the canonical form (preserve anchor) — shared by lint and `--fix`
 <!-- opsx:tdd:1.4:begin -->
   - **Input**: pytest tests/unit/test_scanner_to_canonical.py -v
   - **Expected Output**: Cross-artifact relative link rewritten to `.agentic-beacon/artifacts/<warehouse-rel>` with anchor preserved
@@ -130,7 +130,7 @@ pytest tests/ -v --tb=short
     - TC3: `_partials/deep-review-checklist.md` from agents/sup.md → `.agentic-beacon/artifacts/agents/_partials/deep-review-checklist.md` (pre-move) round-trips
     - TC4: idempotency — passing an already-canonical link is a no-op
 <!-- opsx:tdd:1.4:end -->
-- [ ] 1.5 Unit tests: slugifier table seeded from real warehouse anchors (emoji, `---`, dup headings); classifier table covering all five categories; resolver happy/missing/anchor cases
+- [x] 1.5 Unit tests: slugifier table seeded from real warehouse anchors (emoji, `---`, dup headings); classifier table covering all five categories; resolver happy/missing/anchor cases
 <!-- opsx:tdd:1.5:begin -->
   - **Input**: pytest tests/unit -k 'scanner' -v
   - **Expected Output**: All scanner unit tests pass with real-anchor-seeded slugifier table

--- a/openspec/changes/gate-artifact-reference-paths/tasks.md
+++ b/openspec/changes/gate-artifact-reference-paths/tasks.md
@@ -243,13 +243,13 @@ pytest tests/ -v --tb=short
 <!-- opsx:phase-summary:4:end -->
 
 
-- [ ] 4.1 Retarget partial dependency glob `agents/_partials/**` → `agent-partials/**` in `orchestrator.py` (still gated on ≥1 declared agent)
+- [x] 4.1 Retarget partial dependency glob `agents/_partials/**` → `agent-partials/**` in `orchestrator.py` (still gated on ≥1 declared agent)
 <!-- opsx:tdd:4.1:begin -->
   - **Input**: pytest tests/unit -k 'orchestrator and partial' -v
   - **Expected Output**: Partials pulled from agent-partials/** only when ≥1 agent declared; mirrored to .agentic-beacon/artifacts/agent-partials/**
   - **Validation**: No agents declared → no partials pulled; agents declared → agent-partials/ files in artifact_paths
 <!-- opsx:tdd:4.1:end -->
-- [ ] 4.2 Update `is_partial_path()` in `distributor.py` and stale-partial handling in `delta.py` for the new `agent-partials/` location
+- [x] 4.2 Update `is_partial_path()` in `distributor.py` and stale-partial handling in `delta.py` for the new `agent-partials/` location
 <!-- opsx:tdd:4.2:begin -->
   - **Input**: pytest tests/unit -k 'is_partial_path or delta' -v
   - **Expected Output**: is_partial_path matches agent-partials/ paths; delta prunes stale agent-partials and legacy _partials symlinks
@@ -260,7 +260,7 @@ pytest tests/ -v --tb=short
     - TC3: legacy `agents/_partials/x.md` → recognized as stale for prune
     - TC4: nested `agent-partials/sub/x.md` → is_partial_path True
 <!-- opsx:tdd:4.2:end -->
-- [ ] 4.3 Remove partial co-distribution + `disable: true` stopgap wrapper in `setup/wiring.py`; prune stale Beacon-owned tool-dir partials on sync
+- [x] 4.3 Remove partial co-distribution + `disable: true` stopgap wrapper in `setup/wiring.py`; prune stale Beacon-owned tool-dir partials on sync
 <!-- opsx:tdd:4.3:begin -->
   - **Input**: pytest tests/unit -k 'wiring and partial' -v
   - **Expected Output**: No partial wrapper emitted into .claude/.opencode; Beacon-owned stale tool-dir partials pruned; user-owned files preserved
@@ -271,7 +271,7 @@ pytest tests/ -v --tb=short
     - TC3: user-created file at the partial path → preserved with warning
     - TC4: disable:true wrapper builder no longer invoked anywhere
 <!-- opsx:tdd:4.3:end -->
-- [ ] 4.4 Unit tests: partial materialized at `.agentic-beacon/artifacts/agent-partials/`, absent from `.claude/`/`.opencode/`, stale tool-dir partial pruned, no-op when no agents declared
+- [x] 4.4 Unit tests: partial materialized at `.agentic-beacon/artifacts/agent-partials/`, absent from `.claude/`/`.opencode/`, stale tool-dir partial pruned, no-op when no agents declared
 <!-- opsx:tdd:4.4:begin -->
   - **Input**: pytest tests/unit -k 'partial' -v
   - **Expected Output**: All partial-restructure unit tests pass

--- a/openspec/changes/gate-artifact-reference-paths/tasks.md
+++ b/openspec/changes/gate-artifact-reference-paths/tasks.md
@@ -288,8 +288,8 @@ pytest tests/ -v --tb=short
 <!-- opsx:phase-summary:5:end -->
 
 
-- [ ] 5.1 Add a pre-commit step to `data/skills/contribute-warehouse/SKILL.md`: run `abc warehouse lint`, block on error findings, suggest `--fix`
-- [ ] 5.2 Verify the gate flow end-to-end against a dirty fixture warehouse
+- [x] 5.1 Add a pre-commit step to `data/skills/contribute-warehouse/SKILL.md`: run `abc warehouse lint`, block on error findings, suggest `--fix`
+- [x] 5.2 Verify the gate flow end-to-end against a dirty fixture warehouse
 <!-- opsx:tdd:5.2:begin -->
   - **Input**: Follow the contribute-warehouse skill against a fixture warehouse containing one planted cross-artifact-relative link, then re-run after `abc warehouse lint --fix`
   - **Expected Output**: First run blocks at the lint gate citing the malformed link; after --fix the gate passes and contribute proceeds
@@ -306,20 +306,20 @@ pytest tests/ -v --tb=short
 <!-- opsx:phase-summary:6:end -->
 
 
-- [ ] 6.1 Build a synthetic fixture warehouse (context→knowledge, skill→context, skill own-folder asset, agent→partial, knowledge→knowledge) + a negative fixture with a broken link
+- [x] 6.1 Build a synthetic fixture warehouse (context→knowledge, skill→context, skill own-folder asset, agent→partial, knowledge→knowledge) + a negative fixture with a broken link
 <!-- opsx:tdd:6.1:begin -->
   - **Input**: Construct tmp warehouse dirs/files in a pytest fixture under tests/integration
   - **Expected Output**: Fixture warehouse with all canonical link kinds plus one negative-fixture broken link
   - **Validation**: Fixture builds deterministically; positive links canonical, negative link malformed
   - **Note**: Coverage mix must include: context→knowledge, skill→context, skill own-folder asset, agent→agent-partial, knowledge→knowledge.
 <!-- opsx:tdd:6.1:end -->
-- [ ] 6.2 Stand up tmp project, connect, declare artifacts, run real `abc sync` (real symlinks)
+- [x] 6.2 Stand up tmp project, connect, declare artifacts, run real `abc sync` (real symlinks)
 <!-- opsx:tdd:6.2:begin -->
   - **Input**: abc connect + beacon.yaml declaring the fixture artifacts, then abc sync against the synthetic warehouse
   - **Expected Output**: Real symlink tree under .agentic-beacon/artifacts/ plus agent symlinks under .claude/.opencode; agent-partials mirrored
   - **Validation**: Symlinks resolve to warehouse files; sync exits 0; agent-partials present in mirror, absent from tool dirs
 <!-- opsx:tdd:6.2:end -->
-- [ ] 6.3 Walk every distributed artifact under `.agentic-beacon/artifacts/` and the agent files in `.claude/agents/`/`.opencode/agents/`; assert each canonical link resolves as `(project_root / target).exists()` + anchor resolves
+- [x] 6.3 Walk every distributed artifact under `.agentic-beacon/artifacts/` and the agent files in `.claude/agents/`/`.opencode/agents/`; assert each canonical link resolves as `(project_root / target).exists()` + anchor resolves
 <!-- opsx:tdd:6.3:begin -->
   - **Input**: pytest tests/integration/test_link_resolution.py -v
   - **Expected Output**: Every canonical link in every distributed artifact resolves via (project_root / target).exists(); anchors match a heading slug
@@ -332,7 +332,7 @@ pytest tests/ -v --tb=short
     - TC5: canonical link with anchor → anchor matches a heading slug in the target
     - TC6: skill own-folder asset link → resolves relative to the skill dir (not flagged)
 <!-- opsx:tdd:6.3:end -->
-- [ ] 6.4 Assert the negative fixture is caught by `abc warehouse lint` (exit 1, correct finding)
+- [x] 6.4 Assert the negative fixture is caught by `abc warehouse lint` (exit 1, correct finding)
 <!-- opsx:tdd:6.4:begin -->
   - **Input**: abc warehouse lint <synthetic-warehouse-with-negative-fixture>
   - **Expected Output**: Exit code 1 with a finding scoped to the negative-fixture file naming the malformed/broken link
@@ -342,7 +342,7 @@ pytest tests/ -v --tb=short
     - TC2: negative fixture with canonical link to missing target → exit 1, missing-target finding
     - TC3: after lint --fix on the fixable defect → exit 0
 <!-- opsx:tdd:6.4:end -->
-- [ ] 6.5 Mark integration test appropriately (`tests/integration/`, its own conftest) so it runs in CI
+- [x] 6.5 Mark integration test appropriately (`tests/integration/`, its own conftest) so it runs in CI
 
 ## 7. Docs
 
@@ -354,8 +354,8 @@ pytest tests/ -v --tb=short
 <!-- opsx:phase-summary:7:end -->
 
 
-- [ ] 7.1 Document the canonical-link convention + resolution rule in `CONTRIBUTING.md` and the authoring guide
-- [ ] 7.2 Document the `abc warehouse lint` / `--fix` workflow and the contribute-time gate
+- [x] 7.1 Document the canonical-link convention + resolution rule in `CONTRIBUTING.md` and the authoring guide
+- [x] 7.2 Document the `abc warehouse lint` / `--fix` workflow and the contribute-time gate
 
 ## 8. Release & warehouse migration (post-merge)
 

--- a/openspec/changes/gate-artifact-reference-paths/tasks.md
+++ b/openspec/changes/gate-artifact-reference-paths/tasks.md
@@ -147,13 +147,13 @@ pytest tests/ -v --tb=short
 <!-- opsx:phase-summary:2:end -->
 
 
-- [ ] 2.1 Replace `_lint_knowledge_links` with `_lint_artifact_links` scanning `contexts/*.md`, `skills/*/SKILL.md`, `agents/*.md`, `knowledge/**/*.md`
+- [x] 2.1 Replace `_lint_knowledge_links` with `_lint_artifact_links` scanning `contexts/*.md`, `skills/*/SKILL.md`, `agents/*.md`, `knowledge/**/*.md`
 <!-- opsx:tdd:2.1:begin -->
   - **Input**: pytest tests/unit/test_lint.py -k artifact_links -v
   - **Expected Output**: All four artifact families scanned; findings sorted stably by (artifact_path, message)
   - **Validation**: Each family contributes findings; ordering deterministic cross-platform
 <!-- opsx:tdd:2.1:end -->
-- [ ] 2.2 Emit distinct error findings: malformed-cross-artifact, missing-target, unresolved-anchor, warehouse-escape; allow own-folder + absolute-url
+- [x] 2.2 Emit distinct error findings: malformed-cross-artifact, missing-target, unresolved-anchor, warehouse-escape; allow own-folder + absolute-url
 <!-- opsx:tdd:2.2:begin -->
   - **Input**: pytest tests/unit/test_lint.py -k findings -v
   - **Expected Output**: One LintFinding per defect with a category-specific message scoped to the artifact path
@@ -167,7 +167,7 @@ pytest tests/ -v --tb=short
     - TC6: absolute URL → no finding
     - TC7: valid canonical link with valid anchor → no finding
 <!-- opsx:tdd:2.2:end -->
-- [ ] 2.3 Validate same-file bare anchors (`#section`) against the file's own headings
+- [x] 2.3 Validate same-file bare anchors (`#section`) against the file's own headings
 <!-- opsx:tdd:2.3:begin -->
   - **Input**: pytest tests/unit/test_lint.py -k same_file_anchor -v
   - **Expected Output**: Bare `#slug` resolves against the linking file's own headings
@@ -177,14 +177,14 @@ pytest tests/ -v --tb=short
     - TC2: `#missing-heading` absent in same file → unresolved-anchor error
     - TC3: `#setup-1` resolves to the second duplicate `## Setup`
 <!-- opsx:tdd:2.3:end -->
-- [ ] 2.4 Keep `scan_file_for_knowledge` untouched (sync stays warning-only)
+- [x] 2.4 Keep `scan_file_for_knowledge` untouched (sync stays warning-only)
 <!-- opsx:tdd:2.4:begin -->
   - **Input**: pytest tests/unit -k 'scan_file_for_knowledge or sync_warning' -v
   - **Expected Output**: scan_file_for_knowledge signature/behaviour unchanged; abc sync logs warning and exits 0 on a broken link
   - **Validation**: No regression in the warning-only sync path; lint errors do not leak into sync
   - **Note**: Guard task: the lint-side error promotion must NOT modify scan_file_for_knowledge — verify by diff and by the sync-unchanged scenario.
 <!-- opsx:tdd:2.4:end -->
-- [ ] 2.5 Unit tests: fixture warehouses asserting each finding type + clean-pass + exit codes
+- [x] 2.5 Unit tests: fixture warehouses asserting each finding type + clean-pass + exit codes
 <!-- opsx:tdd:2.5:begin -->
   - **Input**: pytest tests/unit/test_lint.py -v
   - **Expected Output**: All lint finding-type tests pass; clean warehouse exits 0; any defect exits 1
@@ -201,8 +201,8 @@ pytest tests/ -v --tb=short
 <!-- opsx:phase-summary:3:end -->
 
 
-- [ ] 3.1 Add `--fix` flag to `abc warehouse lint`; default remains read-only
-- [ ] 3.2 Implement in-place rewrite of cross-artifact-relative links via `to_canonical()`, preserving anchors; never touch own-folder/absolute/canonical/warehouse-escape links
+- [x] 3.1 Add `--fix` flag to `abc warehouse lint`; default remains read-only
+- [x] 3.2 Implement in-place rewrite of cross-artifact-relative links via `to_canonical()`, preserving anchors; never touch own-folder/absolute/canonical/warehouse-escape links
 <!-- opsx:tdd:3.2:begin -->
   - **Input**: pytest tests/unit/test_lint_fix.py -k rewrite -v
   - **Expected Output**: Only cross-artifact-relative links rewritten in place; anchors preserved; other categories untouched byte-for-byte
@@ -215,13 +215,13 @@ pytest tests/ -v --tb=short
     - TC5: warehouse-escape link → unchanged (not rewritten)
     - TC6: multiple links on one line → each rewritten independently, surrounding prose intact
 <!-- opsx:tdd:3.2:end -->
-- [ ] 3.3 Report rewritten-count + files touched; warehouse-escape links remain errors (exit 1)
+- [x] 3.3 Report rewritten-count + files touched; warehouse-escape links remain errors (exit 1)
 <!-- opsx:tdd:3.3:begin -->
   - **Input**: abc warehouse lint --fix <fixture-warehouse>
   - **Expected Output**: Summary lists N rewritten links across M files; remaining warehouse-escape errors printed; exit 1 if any error remains, else 0
   - **Validation**: Exit code reflects residual errors; counts match actual file edits
 <!-- opsx:tdd:3.3:end -->
-- [ ] 3.4 Unit tests: fix rewrites fixable link, leaves escape link, idempotency (second run no-ops), read-only without `--fix`
+- [x] 3.4 Unit tests: fix rewrites fixable link, leaves escape link, idempotency (second run no-ops), read-only without `--fix`
 <!-- opsx:tdd:3.4:begin -->
   - **Input**: pytest tests/unit/test_lint_fix.py -v
   - **Expected Output**: All fix tests pass including idempotency and read-only guarantees

--- a/site-docs/guides/canonical-links.md
+++ b/site-docs/guides/canonical-links.md
@@ -1,0 +1,92 @@
+# Canonical Links
+
+Warehouse artifacts use one canonical link form for any reference that points at
+another artifact in the same warehouse:
+
+```text
+.agentic-beacon/artifacts/<warehouse-relative-path>
+```
+
+Example:
+
+```markdown
+[Team context](.agentic-beacon/artifacts/contexts/team-context.md)
+[Python standards](.agentic-beacon/artifacts/knowledge/python/standards.md#section-a)
+[Deep review checklist](.agentic-beacon/artifacts/agent-partials/deep-review-checklist.md)
+```
+
+The last example matters because agents are distributed outside the artifact mirror
+into `.claude/agents/` and `.opencode/agents/`. Canonical form is the only link style
+that still resolves for an agent pointing at a shared partial.
+
+---
+
+## Resolution Rule
+
+Beacon resolves a canonical link by stripping the `.agentic-beacon/artifacts/` prefix
+and treating the rest as a path relative to the warehouse root.
+
+- `.agentic-beacon/artifacts/contexts/team-context.md`
+  resolves to `contexts/team-context.md` in the warehouse.
+- `.agentic-beacon/artifacts/knowledge/python/standards.md#section-a`
+  resolves to `knowledge/python/standards.md`, then validates `section-a` against
+  the target file's headings using GitHub-compatible slugification.
+
+In a synced project this is equivalent to checking that
+`<project-root>/.agentic-beacon/artifacts/<warehouse-relative-path>` exists.
+
+---
+
+## Link Categories
+
+Beacon classifies every inline markdown link into one of four meaningful categories
+plus absolute URLs:
+
+| Category | Meaning | Outcome |
+|---|---|---|
+| Absolute URL | External target such as `https://...` or `mailto:...` | Allowed; ignored by canonical-link lint |
+| Canonical | Begins with `.agentic-beacon/artifacts/` | Allowed if the target file and optional anchor resolve |
+| Own-folder relative | Relative link that stays inside the current skill directory | Allowed for skill-local bundles such as `references/api.md` |
+| Cross-artifact relative | Relative link that reaches a different warehouse artifact | Invalid; rewrite to canonical form |
+| Warehouse-escape relative | Relative link that resolves outside the warehouse root | Invalid; manual fix required |
+
+The own-folder exception exists only for skills, because skills are the only
+directory-shaped artifact. Contexts, knowledge files, and agents are single files,
+so any non-canonical intra-warehouse link from them is malformed.
+
+---
+
+## Own-Folder Exception for Skills
+
+Supporting files that ship inside a skill stay relative to the skill directory:
+
+```markdown
+See [API notes](references/api.md).
+```
+
+That is valid when the target lives at `skills/<name>/references/api.md`. Beacon keeps
+this exception so bundled references, examples, templates, and scripts can travel with
+the skill without pretending to be cross-artifact links.
+
+---
+
+## Why Project-Root Form Wins
+
+Beacon distributes byte-identical symlinks into downstream projects. Project-root
+canonical form avoids per-file path math at read time and works uniformly for every
+artifact family, including agents that live outside `.agentic-beacon/artifacts/`.
+
+Directory-relative links like `../../contexts/team-context.md` are not canonical even
+when they happen to work inside the warehouse checkout. They are brittle under the
+symlinked distribution model and do not generalize to agent-to-partial references.
+
+---
+
+## Trade-Off
+
+Canonical links are for Beacon-aware consumers such as `abc warehouse lint`, synced
+projects, and agents reading from a project root. They do not resolve in a raw GitHub
+markdown view of the warehouse repository, and that is an accepted trade-off.
+
+If you need the target in a raw repo browser, navigate by path. If you need the target
+at runtime, use the canonical link.

--- a/site-docs/guides/contributing-back.md
+++ b/site-docs/guides/contributing-back.md
@@ -26,7 +26,7 @@ From an OpenCode or Claude Code session inside a connected project:
 The skill walks you through the contribution interactively:
 
 1. **Resolves the warehouse** from `.agentic-beacon/config.toml`.
-2. **Runs `abc warehouse lint`** as a hard gate — aborts if the warehouse has any integrity errors.
+2. **Runs `abc warehouse lint`** as a hard gate — aborts if the warehouse has any integrity errors. When the failure is a fixable malformed cross-artifact-relative link, the skill suggests `abc warehouse lint --fix <warehouse>` as the local rewrite path before you retry.
 3. **Summarises dirty paths** and asks you which to include and which to leave for later.
 4. **Scans `knowledge/` files for semantic duplicates** so you don't ship the same lesson twice under different names.
 5. **Splits the included files into cohesive commits** with drafted Conventional Commits messages.

--- a/site-docs/guides/creating-agents.md
+++ b/site-docs/guides/creating-agents.md
@@ -4,6 +4,10 @@ An **agent** is a distinct AI persona with its own scoped responsibility, instru
 
 There is **no bundled skill** for authoring an agent — you write the markdown directly. Either by hand or by asking your current agent to author one for you. Both are fine.
 
+For links from an agent to any other warehouse artifact, use the
+[canonical link convention](canonical-links.md). This is mandatory for agent-to-partial
+references because agents are wired outside `.agentic-beacon/artifacts/`.
+
 > Why an agent instead of a skill? Skills are best for cognitive or low-state procedures (a code review checklist, a templated transformation). Agents are better when the work has multiple phases, decision points, or wants its own context and tool surface. See [Skills design — Workflow Skills Probably Belong to Agents](../design/skills.md#workflow-skills-probably-belong-to-agents) for the line of reasoning.
 
 ---
@@ -121,32 +125,33 @@ Both directories are gitignored — they're per-machine state. The shared source
 
 ---
 
-## Sharing Fragments Between Agents — `agents/_partials/`
+## Sharing Fragments Between Agents — `agent-partials/`
 
-When several agents share a long checklist, decision table, or boilerplate block, you can extract it into a fragment under `agents/_partials/` and reference it from each agent's markdown via a relative link. Beacon understands this convention and co-distributes partials automatically.
+When several agents share a long checklist, decision table, or boilerplate block, extract it into a fragment under `agent-partials/` and reference it from each agent's markdown via a canonical link. Beacon mirrors partials into `.agentic-beacon/artifacts/agent-partials/` when at least one agent is declared, but it does not wire them into `.claude/agents/` or `.opencode/agents/`.
 
 ```
 agents/
 ├── agents.yaml
 ├── code-reviewer.md
-├── spec-planner.md
-└── _partials/
-    └── deep-review-checklist.md     ← shared between code-reviewer and spec-planner
+└── spec-planner.md
+
+agent-partials/
+└── deep-review-checklist.md
 ```
 
 Inside an agent file:
 
 ```markdown
-For the full per-file checklist, see [`_partials/deep-review-checklist.md`](_partials/deep-review-checklist.md).
+For the full per-file checklist, see [deep review checklist](.agentic-beacon/artifacts/agent-partials/deep-review-checklist.md).
 ```
 
 **Convention rules:**
 
-- Files under `agents/_partials/` are **fragments, not agents.** They are excluded from `abc warehouse list agents`, do not need entries in `agents.yaml`, and are not validated by `abc warehouse lint` as agents.
-- When any agent is declared in a project's `beacon.yaml`, every file under `agents/_partials/` is **co-distributed** alongside it. Partials appear as symlinks under `.claude/agents/_partials/` and `.opencode/agents/_partials/`, so relative markdown links inside the agent file resolve at tool runtime.
-- The filter is **scoped to `_partials/` specifically.** Other leading-underscore directories (e.g. `agents/_internal/`, `agents/_drafts/`) are **not** treated as partials and will trigger lint errors. Use the name `_partials/` exactly.
+- Files under `agent-partials/` are **fragments, not agents.** They do not need entries in `agents.yaml` and are not listed by `abc warehouse list agents`.
+- When any agent is declared in a project's `beacon.yaml`, every file under `agent-partials/` is mirrored into `.agentic-beacon/artifacts/agent-partials/`.
+- Agents must point at partials via canonical `.agentic-beacon/artifacts/agent-partials/...` links, not relative links.
 
-> **Why one shared name?** Broadening the filter without also broadening co-distribution would hide files from agent listings while silently failing to ship them. Keeping the convention narrow keeps the warehouse predictable.
+> Partials live outside the `agents/` tree so they cannot be mistaken for standalone agents by discovery or tool wiring.
 
 ---
 

--- a/site-docs/guides/creating-knowledge-and-contexts.md
+++ b/site-docs/guides/creating-knowledge-and-contexts.md
@@ -9,6 +9,10 @@ Progressive disclosure â€” pulling deep detail in only when the agent needs it â
 
 This guide covers authoring each.
 
+For links from a context or knowledge file to another warehouse artifact, use the
+[canonical link convention](canonical-links.md). Relative cross-artifact links are not
+portable under Beacon's symlinked distribution model.
+
 ---
 
 ## Knowledge

--- a/site-docs/guides/creating-skills.md
+++ b/site-docs/guides/creating-skills.md
@@ -2,6 +2,10 @@
 
 A skill is a packaged, reusable workflow that an agent can invoke as a slash command. In Agentic Beacon, a skill is a directory under `<warehouse>/skills/<name>/` containing a `SKILL.md` entry point (with required frontmatter) plus optional supporting files.
 
+For cross-artifact references from a skill to a context, knowledge file, agent partial,
+or another warehouse artifact, use the [canonical link convention](canonical-links.md).
+Only skill-local bundled files stay relative to the skill directory.
+
 There are two equally valid ways to author one. Pick the path that fits the situation.
 
 ---

--- a/site-docs/guides/warehouse-lint/github-actions.md
+++ b/site-docs/guides/warehouse-lint/github-actions.md
@@ -116,6 +116,15 @@ abc warehouse lint .
 
 If it fails on a current artifact, fix it first — landing the workflow against a broken tree blocks every future PR until someone unblocks `main`.
 
+For local repair before you push, run:
+
+```bash
+abc warehouse lint --fix .
+```
+
+That rewrites fixable malformed cross-artifact-relative links into canonical form.
+Keep CI read-only: the workflow should check and fail, not mutate the branch.
+
 ---
 
 ## Troubleshooting

--- a/site-docs/guides/warehouse-lint/pre-commit.md
+++ b/site-docs/guides/warehouse-lint/pre-commit.md
@@ -45,6 +45,15 @@ pre-commit install
 
 From then on, every `git commit` runs the lint against the whole working tree. A failure aborts the commit; fix the artifact and re-commit.
 
+For fixable malformed cross-artifact-relative links, the local repair path is:
+
+```bash
+abc warehouse lint --fix .
+```
+
+This rewrites only the canonicalizable link category. Keep the hook itself read-only;
+the commit should fail fast and let the contributor decide when to apply the rewrite.
+
 ---
 
 ## Field rationale

--- a/site-docs/reference/cli.md
+++ b/site-docs/reference/cli.md
@@ -162,6 +162,7 @@ abc warehouse lint [WAREHOUSE_PATH]
 | Option | Description |
 |--------|-------------|
 | `WAREHOUSE_PATH` | Path to warehouse directory (defaults to current directory) |
+| `--fix` | Rewrite fixable cross-artifact-relative links to canonical `.agentic-beacon/artifacts/...` form before reporting remaining findings |
 
 **Validation rules:**
 
@@ -170,7 +171,7 @@ abc warehouse lint [WAREHOUSE_PATH]
 3. **Skill context references** — every context name in `requires.contexts` exists as `contexts/<name>.md`.
 4. **Agent manifest** — `agents.yaml` is valid YAML; every `agents/*.md` file has a matching entry and vice versa; no legacy `requires:` keys in agent frontmatter; every declared skill exists under `skills/`.
 5. **Agent frontmatter** — every `agents/*.md` (excluding `README.md`) has both a `name:` and `description:` YAML frontmatter key.
-6. **Knowledge link integrity** — every inline Markdown link in `contexts/*.md` and `skills/*/SKILL.md` that resolves to a `knowledge/…/*.md` path exists on disk. This rule is **lint-only**: `abc sync` retains its current warning-only behaviour for broken knowledge links.
+6. **Artifact link integrity** — every inline Markdown link in `contexts/*.md`, `skills/*/SKILL.md`, `agents/*.md`, and `knowledge/**/*.md` must satisfy the canonical artifact-link contract. Lint emits one finding per defect across four error categories: malformed cross-artifact-relative links, missing canonical targets, unresolved anchors, and warehouse-escape links. This rule is **lint-only**: `abc sync` retains its current warning-only behaviour for broken knowledge links.
 
 **Exit codes:**
 
@@ -185,7 +186,16 @@ abc warehouse lint
 
 # Lint a specific path
 abc warehouse lint ~/my-org-warehouse
+
+# Auto-rewrite fixable malformed links, then report any remaining errors
+abc warehouse lint ~/my-org-warehouse --fix
 ```
+
+With `--fix`, lint rewrites only cross-artifact-relative links into canonical
+`.agentic-beacon/artifacts/<warehouse-relative-path>` form. Anchors are preserved,
+the rewrite is idempotent, and running `--fix` on an already-clean file is a no-op.
+It does not rewrite warehouse-escape links or invent missing targets; those remain
+errors for a human to resolve.
 
 > **Note:** `abc warehouse lint` is designed for warehouse-side CI. A freshly
 > `abc warehouse init`-ed warehouse passes lint with exit code 0. The

--- a/site-docs/reference/contribute-warehouse.md
+++ b/site-docs/reference/contribute-warehouse.md
@@ -30,7 +30,7 @@ The skill walks you through the full flow interactively.
 The skill runs these steps in order:
 
 1. **Resolve warehouse** — locate `.agentic-beacon/config.toml` and extract the warehouse path
-2. **Lint pre-flight gate** — run `abc warehouse lint <warehouse>`; abort on any error
+2. **Lint pre-flight gate** — run `abc warehouse lint <warehouse>`; abort on any error and suggest `abc warehouse lint --fix <warehouse>` for fixable malformed cross-artifact-relative links
 3. **Summarize dirty paths** — call `summarize_changes.py` to get a structured JSON view of what has changed
 4. **Intent triage** — ask you which files to include or leave for later
 5. **Dedup scan** (knowledge/ files only) — scan sibling files for overlapping content
@@ -52,6 +52,7 @@ abc warehouse lint <warehouse-path>
 This is a **hard gate** — if lint reports any error, the skill aborts. This applies
 even to files outside your intended contribution scope. Resolve lint failures first:
 
+- Run `abc warehouse lint --fix <warehouse-path>` when the failure is a fixable malformed cross-artifact-relative link. The rewrite is idempotent, preserves anchors, and leaves warehouse-escape or missing-target findings for manual repair.
 - Fix the failing files
 - Or discard them: `git -C <warehouse> checkout -- <file>`
 


### PR DESCRIPTION
## Summary

Implements the OpenSpec change `gate-artifact-reference-paths`: every intra-warehouse markdown link must use the canonical project-root form `.agentic-beacon/artifacts/<warehouse-relative-path>`, enforced by an extended `abc warehouse lint` and an in-place `--fix` migrator. Closes PER-238 by restructuring agent partials.

Phased implementation across 4 supervised delegate dispatches; each phase merged into this feat branch with `--no-ff` to preserve provenance.

## What lands

### Phase 1 — scanner primitives (`24fd599`)
- `slugify_heading()` (GitHub-exact, dedup-aware, fenced-code-aware)
- `extract_markdown_headings()`
- `CANONICAL_PREFIX`, `resolve_canonical_link()`
- `classify_link()` returning one of `LINK_ABSOLUTE_URL` / `LINK_CANONICAL` / `LINK_OWN_SKILL_FOLDER` / `LINK_CROSS_ARTIFACT_RELATIVE` / `LINK_WAREHOUSE_ESCAPE`
- `to_canonical()` round-trip helper

### Phase 2/3 — lint integrity + `--fix` (`e4fd143`)
- Replaced `_lint_knowledge_links` with `_lint_artifact_links` scanning `contexts/*.md`, `skills/*/SKILL.md`, `agents/*.md`, `knowledge/**/*.md`
- Distinct, greppable error messages per category: `malformed cross-artifact link:`, `missing canonical target:`, `unresolved anchor:`, `warehouse-escape link:`
- Same-file bare anchors validated against the file's own headings (`#setup-1` resolves to the 2nd duplicate `## Setup`)
- `lint_warehouse(path, *, fix: bool = False) -> LintReport` extended with `rewritten_links` + `files_touched` counters; CLI `abc warehouse lint [--fix]` (read-only by default)
- `--fix` rewrites only `LINK_CROSS_ARTIFACT_RELATIVE` via `to_canonical()`, idempotent, preserves anchors, never touches own-folder/absolute/canonical/warehouse-escape
- `scan_file_for_knowledge` left untouched per spec — `abc sync` retains warning-only posture

### Phase 4 — agent partials restructure / PER-238 closure (`5a69a92`)
- Distribution glob retargeted: `agents/_partials/**` → `agent-partials/**` (gated on ≥1 declared agent)
- `is_partial_path()` recognises canonical (`agent-partials/`) AND legacy (`agents/_partials/`, `_partials/`) for stale-prune compatibility
- Removed PER-238 `disable: true` stopgap wrapper machinery (`_build_partial_wrapper`, `_wire_partial`, `_snapshot_partial_path`, `_strip_existing_frontmatter` deleted)
- New `_prune_stale_tool_dir_partials()` runs as the first step of `wire_agents_atomically`; cleans up Beacon-owned wrappers from four legacy/transitional tool-dir paths; preserves user-owned files with a warning
- Kept `_LEGACY_PARTIAL_WRAPPER_FRONTMATTER` (with byte-exact em-dash `\u2014`) for live-wrapper detection during prune
- `delta.py` comment refreshed; `agents/` iteration block now covers agent files only (partials moved out of `agents/` tree)
- Test surface rewritten: `test_wire_agents.py` partials class now asserts the new contract (no wiring, prune semantics, user-file preservation, builder helper removed); integration test fixture migrated to top-level `agent-partials/`

### Phase 5/6/7 — contribute gate, integration test, docs (`c738c96`)
- `data/skills/contribute-warehouse/SKILL.md`: lint-failure recovery list now mentions `abc warehouse lint --fix`; agent checklist updated
- `tests/integration/test_link_resolution.py` (new, 10 tests, ~430 lines): hermetic synthetic-warehouse fixture (positive + two negative variants), real `abc connect` + `abc sync`, project-side canonical-link resolution walk for skills/contexts/agents/agent-partials, warehouse-side walk for knowledge→knowledge, anchor resolution against GitHub-slugified headings, negative-fixture lint+`--fix` exit-code assertions
- New `site-docs/guides/canonical-links.md` authoring guide; cross-linked from `creating-skills.md`, `creating-knowledge-and-contexts.md`, `creating-agents.md`; wired into mkdocs.yml nav
- `site-docs/reference/cli.md`: validation rule 6 rewritten from knowledge-only to full artifact-link integrity; `--fix` flag documented (idempotent, preserves anchors, only rewrites cross-artifact-relative)
- `warehouse-lint/github-actions.md` + `pre-commit.md`: local `--fix` repair callout (CI stays read-only)
- `contribute-warehouse.md`, `contributing-back.md`: `--fix` annotation in lint-gate prose
- `creating-agents.md` updated to reflect Phase 4 layout (`agents/_partials/` → `agent-partials/`)
- Pre-existing Phase 2 oversight folded in: `tests/integration/.../test_lint_cli.py` was asserting on legacy `"broken knowledge link"` wording; updated to match the shipped `"malformed cross-artifact link"` wording for the fixture's defect (was failing on feat HEAD `5a69a92` before this dispatch)

## Test plan

- [x] All four verification gates pass on the final merged HEAD `c738c96`:
  - **Full unit suite:** 1200 passed, 2 skipped, 0 failed (`pytest libs/beacon/tests/unit`)
  - **Full integration suite:** 314 passed, 6 skipped (BEACON_OFFLINE), 0 failed (`pytest libs/beacon/tests/integration`)
  - **Architecture test (CLI thin-handler rule):** 14 passed (`pytest libs/beacon/tests/unit/test_architecture.py`)
  - **Targeted Phase-6 integration:** 10 passed (`pytest libs/beacon/tests/integration/test_link_resolution.py`)
- [x] `tasks.md` checkboxes accurate: 1.x, 2.x, 3.x, 4.x, 5.x, 6.x, 7.x all `[x]`; 8.1 stays `[ ]` (release happens after merge); 8.2/8.3 retain pre-existing `[x]` (cross-repo deferrals to `hl-knowledge-market`)
- [ ] CI green (this PR)
- [ ] `opencode-review` bot clean (will iterate per Operating rule #10)

## Known limitation — separate follow-up ticket required before warehouse migration

`scan_file_for_knowledge` (the transitive auto-pull primitive) does not yet recognise canonical-form links — it resolves links directory-relative, so `.agentic-beacon/artifacts/knowledge/...` from a context/skill is not detected as a knowledge reference, and the target is not added to the effective set.

This is **intentionally out-of-scope for this change** per spec task 2.4 ("scan_file_for_knowledge SHALL NOT be modified — sync stays warning-only"), but the warehouse migration in `hl-knowledge-market` (Phase 8.2 — already `[x]`-marked as a conscious cross-repo deferral) WILL land after this releases. After that migration, every `knowledge/...` link in contexts/skills will be canonical, so transitive auto-pull will silently stop pulling them.

**Mitigation:** filing a follow-up Linear ticket immediately after this PR opens; that ticket extends `scan_file_for_knowledge` to also recognise canonical-form links, and must land before the `hl-knowledge-market` PR. The new integration test documents this in its fixture comment and validates knowledge→knowledge canonical links at the warehouse-side instead of the project-side until the auto-pull fix lands.

## Out of scope (consciously deferred or filed elsewhere)

- **Task 8.1 — release a new `agentic-beacon` version**: happens after merge via the existing release-please flow; pushing the tag to `release/vX.X.X` triggers PyPI publish.
- **Tasks 8.2 and 8.3 — warehouse migration in `hl-knowledge-market`**: already `[x]` in `tasks.md` as conscious deferrals. The lint and `--fix` shipped here are the prerequisites; the warehouse PR lands separately after this release.

Closes PER-238 (agent partials no longer mis-discovered as opencode subagents).