### PR TITLE
feat(record-knowledge): support authoring new context files

### DIFF
--- a/libs/beacon/src/beacon/data/skills/record-knowledge/SKILL.md
+++ b/libs/beacon/src/beacon/data/skills/record-knowledge/SKILL.md
@@ -16,13 +16,19 @@ requires:
 Capture decisions, lessons, and facts into the connected warehouse knowledge base.
 Knowledge files are written **directly to the warehouse** by the bundled
 `write_knowledge.py` script — never to the project. Knowledge files are
-auto-derived during `abc sync` / `abc adopt`; only optional context pointer edits
-are queued in `.agentic-beacon/pending.yaml` for project wiring.
+auto-derived during `abc sync` / `abc adopt`; only optional context edits
+(a pointer into an existing context, or a brand-new context file) are queued in
+`.agentic-beacon/pending.yaml` for project wiring.
 
 > **Important:** Do NOT write knowledge files using your editor tools directly.
 > Always go through `write_knowledge.py`. The script enforces that the file
 > lands inside the warehouse and refuses to write into the project's symlink
 > mirror at `.agentic-beacon/artifacts/knowledge/`.
+>
+> Likewise, when creating a **new** context file, go through `write_context.py`
+> — it enforces the same warehouse-only guarantee for `contexts/`. (Appending a
+> pointer to an *existing* context is an in-place edit and uses your editor's
+> edit tool, since the path is fully qualified to the warehouse.)
 
 ---
 
@@ -248,7 +254,8 @@ List the available warehouse context files:
 ls "$WAREHOUSE_ROOT/contexts/"*.md 2>/dev/null
 ```
 
-Present options to the user — **only warehouse context files plus "skip"**:
+Present options to the user — **warehouse context files, "create a new context
+file", plus "skip"**:
 
 ```
 Where should I add a pointer to this knowledge?
@@ -257,15 +264,70 @@ Options:
 1. contexts/development-guidelines.md
 2. contexts/architecture.md
 ...
-N. Skip — don't add a pointer yet
+N. Create a new context file
+N+1. Skip — don't add a pointer yet
 
 Default: Skip
 ```
 
 **Constraints:**
-- Only offer files found under `$WAREHOUSE_ROOT/contexts/`.
+- Only offer existing files found under `$WAREHOUSE_ROOT/contexts/`.
 - Do NOT offer any project-local files as pointer targets.
-- If no context files exist in the warehouse, skip this step automatically.
+- Always offer "Create a new context file" — even when no context files exist
+  yet. If none exist, this option and "Skip" are the only choices.
+
+If the user picks an existing context file, proceed to Step 6 (pointer edit).
+If the user picks "Create a new context file", go to **Step 5a** first.
+If the user picks "Skip", go straight to Step 8.
+
+### Step 5a: Create a New Context File (only if chosen in Step 5)
+
+Gather the new context's identity from the user (infer sensible defaults from the
+knowledge subject and confirm):
+
+- **Name** (`--name`): kebab-case stem, no `.md` — e.g. `linear-ops`.
+- **Title:** Title-case heading — e.g. `Linear Operations`.
+- **Load when:** one line describing when an agent should load this context.
+
+Render the new context body using this template:
+
+```markdown
+# [Title]
+
+**Load when:** [one-line trigger]
+**Last Updated:** YYYY-MM-DD
+
+---
+
+## [Section relevant to the knowledge]
+
+[Optional prose introducing the topic.]
+```
+
+Show the rendered body and the target path (`contexts/<name>.md`) to the user and
+get explicit confirmation. Then write it via `write_context.py` — **this is the
+only way a new context file is created**; do not use your editor's write tool:
+
+```bash
+NEW_CONTEXT_PATH=$(uv run ${SKILL_DIR}/scripts/write_context.py \
+  --name <kebab-name> <<'CONTEXT_EOF'
+<rendered context body>
+CONTEXT_EOF
+)
+```
+
+The script resolves the warehouse, refuses to write outside `<warehouse>/contexts/`,
+refuses to overwrite an existing file unless `--overwrite` is passed, and prints
+the warehouse-relative path (e.g. `contexts/linear-ops.md`) on stdout. If it
+exits non-zero, surface stderr and stop.
+
+If the warehouse has a `contexts/README.md` index, add a one-line index row for
+the new file under the appropriate section (in-place edit of the README — the
+path is fully qualified to `$WAREHOUSE_ROOT`). Do not create a README if none
+exists.
+
+Then continue to Step 6 to add the knowledge pointer **into the newly created
+context file** (it now exists, so it is a valid pointer target).
 
 ### Step 6: Diff-Confirm Before Writing Pointer
 
@@ -297,13 +359,15 @@ auto-derived from context and skill references during `abc sync` / `abc adopt`
 and does not require beacon.yaml or symlink adoption.
 
 If the user confirmed a context pointer write in Step 6, append only that
-context entry:
+context entry. Use `--action created` when the context file was newly authored in
+Step 5a, or `--action modified` when you appended a pointer to a pre-existing
+context:
 
 ```bash
 uv run ${SKILL_DIR}/scripts/append_pending.py \
   --path contexts/<file>.md \
   --type context \
-  --action modified \
+  --action {created|modified} \
   --source record-knowledge
 ```
 
@@ -314,10 +378,10 @@ uv run ${SKILL_DIR}/scripts/append_pending.py \
 
 Type:            [Decision|Lesson|Fact]
 Warehouse file:  $WAREHOUSE_ROOT/<written-path>
-Context pointer: [contexts/<file>.md | Skipped]
-Pending entries: [1 if context pointer written, otherwise 0]
+Context pointer: [contexts/<file>.md (new) | contexts/<file>.md | Skipped]
+Pending entries: [1 if context written/modified, otherwise 0]
 
-Run 'abc adopt' to wire the context pointer if one was queued.
+Run 'abc adopt' to wire the context if one was queued.
 ```
 
 ---
@@ -358,6 +422,23 @@ Run 'abc adopt' to wire the context pointer if one was queued.
 6. Does not call `append_pending.py` (knowledge is auto-derived).
 7. Reports completion with no `abc adopt` reminder.
 
+### Example 3: Recording a Fact + creating a new context
+
+**User:**
+```
+/record-knowledge The Linear GraphQL API authenticates with a raw $LINEAR_PAT header (no Bearer prefix) and priority is an inverted int
+```
+
+**Agent:**
+1. Analyzes: this is a **fact**.
+2. Resolves warehouse; picks `--topic linear` (or omits if none fits).
+3. Renders the fact body; writes via `write_knowledge.py` → `knowledge/linear/facts/linear-graphql-auth.md`.
+4. Lists warehouse contexts → none fit. User picks "Create a new context file".
+5. **Step 5a:** confirms name `linear-ops`, title `Linear Operations`, Load-when line; renders the context template and writes it via `write_context.py` → `contexts/linear-ops.md`. Adds an index row to `contexts/README.md` if one exists.
+6. Adds the knowledge pointer into the new `contexts/linear-ops.md` under its section; user confirms the diff.
+7. Runs `append_pending.py --path contexts/linear-ops.md --type context --action created --source record-knowledge`.
+8. Reports completion with an `abc adopt` reminder to wire the new context.
+
 ---
 
 ## Checklist for Agent
@@ -368,13 +449,14 @@ Run 'abc adopt' to wire the context pointer if one was queued.
 - [ ] Inspect `$WAREHOUSE_ROOT/knowledge/` to pick a topic that matches existing convention (or omit for flat layout)
 - [ ] Render the markdown body using the type-specific template
 - [ ] Write the file by piping the body into `write_knowledge.py` — do NOT write the file with your editor's write tool
-- [ ] Ask user which warehouse `contexts/` file for the pointer — or skip
+- [ ] Ask user which warehouse `contexts/` file for the pointer — an existing one, a new one, or skip
+- [ ] If creating a new context: confirm name/title/Load-when, write via `write_context.py` (NOT your editor's write tool), and add a `contexts/README.md` index row if a README exists
 - [ ] Show diff before writing the pointer; wait for explicit confirmation
 - [ ] Do NOT run `append_pending.py` for the knowledge file
-- [ ] Run `append_pending.py` for the context file if a pointer was written
-- [ ] Confirm completion; remind user to run `abc adopt` only if a context pointer was queued
+- [ ] Run `append_pending.py` for the context file if a pointer was written — `--action created` for a new context, `--action modified` for an existing one
+- [ ] Confirm completion; remind user to run `abc adopt` only if a context was queued
 
 ---
 
-**Skill Version:** 2.1.0
-**Last Updated:** 2026-05-07
+**Skill Version:** 2.2.0
+**Last Updated:** 2026-06-16

--- a/libs/beacon/src/beacon/data/skills/record-knowledge/scripts/write_context.py
+++ b/libs/beacon/src/beacon/data/skills/record-knowledge/scripts/write_context.py
@@ -1,0 +1,154 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
+"""Write a new context file to the connected warehouse.
+
+This script exists so the record-knowledge skill cannot accidentally write into
+the project's symlink-mirror at .agentic-beacon/artifacts/contexts/. The
+warehouse is resolved from .agentic-beacon/config.toml in the project root, and
+the script refuses to write anywhere outside `<warehouse>/contexts/`.
+
+Use this only when authoring a *new* context file. Appending a knowledge pointer
+to an *existing* context is a normal in-place edit and does not go through here.
+
+Usage:
+    write_context.py --name <kebab-name> \
+                     [--overwrite] \
+                     [--content-file <path>]
+
+Content is read from stdin unless --content-file is given.
+
+On success: prints the final warehouse-relative path on stdout (e.g.
+"contexts/linear-ops.md") and exits 0.
+
+On failure: prints an error to stderr and exits non-zero.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+import tomllib
+from pathlib import Path
+
+NAME_PATTERN = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+
+ERROR_NO_WAREHOUSE = (
+    "Error: no warehouse connected. Run 'abc warehouse connect <path>' first."
+)
+
+
+def find_project_root(start: Path) -> Path | None:
+    """Walk up from start to find a directory containing .agentic-beacon/config.toml."""
+    current = start.resolve()
+    while True:
+        if (current / ".agentic-beacon" / "config.toml").exists():
+            return current
+        parent = current.parent
+        if parent == current:
+            return None
+        current = parent
+
+
+def resolve_warehouse(cwd: Path) -> Path:
+    """Return the absolute warehouse path or exit with an error."""
+    project_root = find_project_root(cwd)
+    if project_root is None:
+        print(ERROR_NO_WAREHOUSE, file=sys.stderr)
+        sys.exit(1)
+
+    config_path = project_root / ".agentic-beacon" / "config.toml"
+    with open(config_path, "rb") as f:
+        data = tomllib.load(f)
+
+    if "warehouse" not in data or "local_path" not in data["warehouse"]:
+        print(
+            f"Error: {config_path} is missing warehouse.local_path.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    return Path(data["warehouse"]["local_path"]).resolve()
+
+
+def assert_under_warehouse(target: Path, warehouse: Path) -> None:
+    """Refuse to proceed if *target* resolves outside <warehouse>/contexts/."""
+    contexts_root = (warehouse / "contexts").resolve()
+    try:
+        target.resolve().relative_to(contexts_root)
+    except ValueError:
+        print(
+            f"Error: refusing to write outside warehouse: {target} is not under "
+            f"{contexts_root}",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Write a new context file directly to the connected warehouse.",
+    )
+    parser.add_argument(
+        "--name",
+        required=True,
+        help="Context file stem in kebab-case (without .md extension)",
+    )
+    parser.add_argument(
+        "--content-file",
+        default=None,
+        help="Read body content from this file. Default: stdin.",
+    )
+    parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="Overwrite the file if it already exists.",
+    )
+    args = parser.parse_args()
+
+    if not NAME_PATTERN.match(args.name):
+        print(
+            f"Error: --name must be kebab-case (got {args.name!r})",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+    warehouse = resolve_warehouse(Path.cwd())
+
+    target = warehouse / "contexts" / f"{args.name}.md"
+    assert_under_warehouse(target, warehouse)
+
+    if target.exists() and not args.overwrite:
+        print(
+            f"Error: {target} already exists. Pass --overwrite to replace it.",
+            file=sys.stderr,
+        )
+        sys.exit(3)
+
+    if args.content_file:
+        content_path = Path(args.content_file)
+        if not content_path.is_file():
+            print(
+                f"Error: --content-file not found: {content_path}",
+                file=sys.stderr,
+            )
+            sys.exit(2)
+        content = content_path.read_text(encoding="utf-8")
+    else:
+        content = sys.stdin.read()
+
+    if not content.strip():
+        print("Error: refusing to write an empty context file.", file=sys.stderr)
+        sys.exit(2)
+
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(content, encoding="utf-8")
+
+    rel = target.resolve().relative_to(warehouse)
+    print(rel.as_posix())
+
+
+if __name__ == "__main__":
+    main()

--- a/libs/beacon/tests/unit/test_record_write_scripts.py
+++ b/libs/beacon/tests/unit/test_record_write_scripts.py
@@ -244,6 +244,150 @@ class TestWriteKnowledge:
 
 
 # ─────────────────────────────────────────────────────────────
+# write_context.py
+# ─────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def write_context():
+    return _load_script("record-knowledge", "write_context.py")
+
+
+class TestWriteContext:
+    def test_writes_to_warehouse_contexts(
+        self, write_context, tmp_path, monkeypatch, capsys
+    ):
+        project, warehouse = _make_project_with_warehouse(tmp_path)
+        monkeypatch.chdir(project)
+        monkeypatch.setattr(
+            "sys.argv",
+            ["write_context.py", "--name", "linear-ops"],
+        )
+        monkeypatch.setattr("sys.stdin", _StringStream("# Linear Operations\nbody\n"))
+
+        write_context.main()
+
+        target = warehouse / "contexts" / "linear-ops.md"
+        assert target.is_file()
+        assert target.read_text() == "# Linear Operations\nbody\n"
+        out = capsys.readouterr().out.strip()
+        assert out == "contexts/linear-ops.md"
+
+    def test_does_not_write_to_project_artifacts(
+        self, write_context, tmp_path, monkeypatch
+    ):
+        """Regression: must never create files under project/.agentic-beacon/artifacts/."""
+        project, warehouse = _make_project_with_warehouse(tmp_path)
+        artifacts = project / ".agentic-beacon" / "artifacts"
+        artifacts.mkdir()
+
+        monkeypatch.chdir(project)
+        monkeypatch.setattr(
+            "sys.argv",
+            ["write_context.py", "--name", "x"],
+        )
+        monkeypatch.setattr("sys.stdin", _StringStream("# X\n"))
+
+        write_context.main()
+
+        assert list(artifacts.rglob("*")) == []
+        assert (warehouse / "contexts" / "x.md").is_file()
+
+    def test_refuses_to_overwrite_without_flag(
+        self, write_context, tmp_path, monkeypatch, capsys
+    ):
+        project, warehouse = _make_project_with_warehouse(tmp_path)
+        target = warehouse / "contexts" / "exists.md"
+        target.parent.mkdir(parents=True)
+        target.write_text("OLD")
+
+        monkeypatch.chdir(project)
+        monkeypatch.setattr(
+            "sys.argv",
+            ["write_context.py", "--name", "exists"],
+        )
+        monkeypatch.setattr("sys.stdin", _StringStream("NEW"))
+
+        with pytest.raises(SystemExit) as exc:
+            write_context.main()
+        assert exc.value.code == 3
+        assert target.read_text() == "OLD"
+        assert "already exists" in capsys.readouterr().err
+
+    def test_overwrite_flag_replaces_existing(
+        self, write_context, tmp_path, monkeypatch
+    ):
+        project, warehouse = _make_project_with_warehouse(tmp_path)
+        target = warehouse / "contexts" / "exists.md"
+        target.parent.mkdir(parents=True)
+        target.write_text("OLD")
+
+        monkeypatch.chdir(project)
+        monkeypatch.setattr(
+            "sys.argv",
+            ["write_context.py", "--name", "exists", "--overwrite"],
+        )
+        monkeypatch.setattr("sys.stdin", _StringStream("NEW"))
+
+        write_context.main()
+        assert target.read_text() == "NEW"
+
+    def test_rejects_non_kebab_name(self, write_context, tmp_path, monkeypatch, capsys):
+        project, _ = _make_project_with_warehouse(tmp_path)
+        monkeypatch.chdir(project)
+        monkeypatch.setattr(
+            "sys.argv",
+            ["write_context.py", "--name", "Bad_Name"],
+        )
+        with pytest.raises(SystemExit) as exc:
+            write_context.main()
+        assert exc.value.code == 2
+        assert "kebab-case" in capsys.readouterr().err
+
+    def test_rejects_empty_content(self, write_context, tmp_path, monkeypatch, capsys):
+        project, _ = _make_project_with_warehouse(tmp_path)
+        monkeypatch.chdir(project)
+        monkeypatch.setattr(
+            "sys.argv",
+            ["write_context.py", "--name", "x"],
+        )
+        monkeypatch.setattr("sys.stdin", _StringStream("   \n"))
+        with pytest.raises(SystemExit) as exc:
+            write_context.main()
+        assert exc.value.code == 2
+        assert "empty" in capsys.readouterr().err.lower()
+
+    def test_no_warehouse_exits_nonzero(
+        self, write_context, tmp_path, monkeypatch, capsys
+    ):
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr(
+            "sys.argv",
+            ["write_context.py", "--name", "x"],
+        )
+        monkeypatch.setattr("sys.stdin", _StringStream("# X\n"))
+        with pytest.raises(SystemExit) as exc:
+            write_context.main()
+        assert exc.value.code == 1
+        assert "no warehouse connected" in capsys.readouterr().err
+
+    def test_content_file_argument_works(self, write_context, tmp_path, monkeypatch):
+        project, warehouse = _make_project_with_warehouse(tmp_path)
+        body = tmp_path / "body.md"
+        body.write_text("# From file\n")
+
+        monkeypatch.chdir(project)
+        monkeypatch.setattr(
+            "sys.argv",
+            ["write_context.py", "--name", "y", "--content-file", str(body)],
+        )
+
+        write_context.main()
+        target = warehouse / "contexts" / "y.md"
+        assert target.read_text() == "# From file\n"
+
+
+# ─────────────────────────────────────────────────────────────
 # write_skill.py
 # ─────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

`record-knowledge` could only create knowledge nodes and append pointers to **existing** context files — authoring a brand-new context had no guided path (it had to be hand-written into the warehouse). This adds that capability.

## What changed

- **New guarded writer** — `record-knowledge/scripts/write_context.py`. Same warehouse-only contract as `write_knowledge.py`: resolves the warehouse from `config.toml`, refuses to write outside `<warehouse>/contexts/` (exit 2), refuses overwrite without `--overwrite` (exit 3), rejects non-kebab names / empty bodies, prints the warehouse-relative path. Stops the skill from accidentally writing into the project symlink mirror.
- **SKILL.md** — added a "Create a new context file" option to Step 5, a new **Step 5a** (gather name/title/Load-when → render template → write via the script → add a `contexts/README.md` index row if a README exists → then add the pointer into it), updated Step 7 to use `--action created` vs `modified`, refreshed the completion report/checklist, added Example 3. Bumped skill to **v2.2.0**.
- **Tests** — 8 new cases in `TestWriteContext` mirroring the existing knowledge guardrails.

Note: `append_pending.py`'s valid actions are `created`/`modified` (no `added`), so new contexts are queued as `created`.

## Verification

- `pytest libs/beacon/tests/unit/test_record_write_scripts.py` → 25 passed
- Broader record-* suites → 97 passed / 1 skipped
- Real subprocess smoke test: happy path lands in `contexts/`, kebab guardrail fires (exit 2), overwrite refusal fires (exit 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)