### PR TITLE
feat(gitignore): managed-block gitignore engine + doctor drift check/--fix (AB-94)

### DIFF
--- a/libs/beacon/src/beacon/cli/diagnostics.py
+++ b/libs/beacon/src/beacon/cli/diagnostics.py
@@ -5,7 +5,6 @@ from pathlib import Path
 import click
 from rich.console import Console
 
-from beacon.core.gitignore import apply_all_gitignores, diff_gitignores
 from beacon.core.manifest.beacon import BeaconManifest
 from beacon.core.manifest.workspace import WorkspaceConfig
 from beacon.domains.setup.diagnostics import run_project_health_checks
@@ -142,6 +141,14 @@ def doctor(*, fix: bool) -> None:
                 f"Context entries: all {len(context_entries)} context(s) exist in warehouse"
             )
 
+    # Repair gitignore drift BEFORE health checks so the summary is accurate
+    if fix:
+        from beacon.domains.setup.diagnostics import repair_gitignore_drift
+
+        for msg in repair_gitignore_drift(project_root):
+            fixes_applied.append(msg)
+            console.print(f"  [green]✓[/green] {msg}")
+
     # Project-side checks (PER-193)
     project_issues = run_project_health_checks(
         project_root, warehouse_path, beacon_settings
@@ -151,26 +158,5 @@ def doctor(*, fix: bool) -> None:
             _warn(issue.message, issue.detail)
         else:
             _err(issue.message, issue.detail)
-
-    # Gitignore drift check + fix (AB-94: managed-block gitignore engine)
-    # Gate on beacon.yaml — never touch .gitignore in non-Beacon projects
-    if fix and beacon_yaml.exists():
-        drifts = diff_gitignores(project_root)
-        managed_kinds = {
-            "tier_a_missing",
-            "tier_a_incomplete",
-            "tier_b_missing",
-            "tier_b_incomplete",
-        }
-        managed = [d for d in drifts if d.kind in managed_kinds]
-        tracked = [d for d in drifts if d.kind == "tracked_set_ignored"]
-        if managed:
-            apply_all_gitignores(project_root)
-            fixes_applied.append("Repaired gitignore managed blocks (Tier A / Tier B)")
-            console.print("  [green]✓[/green] Gitignore managed blocks repaired")
-        for d in tracked:
-            console.print(
-                f"  [red]✗[/red] Cannot auto-fix: {d.message} — remove or negate the offending .gitignore pattern manually"
-            )
 
     print_doctor_summary(issues, fixes_applied)

--- a/libs/beacon/src/beacon/cli/diagnostics.py
+++ b/libs/beacon/src/beacon/cli/diagnostics.py
@@ -7,7 +7,7 @@ from rich.console import Console
 
 from beacon.core.manifest.beacon import BeaconManifest
 from beacon.core.manifest.workspace import WorkspaceConfig
-from beacon.domains.setup.diagnostics import run_project_health_checks
+from beacon.domains.setup.diagnostics import run_project_diagnostics
 from beacon.utils.display import print_doctor_summary
 from beacon.utils.git import find_project_root
 
@@ -141,18 +141,13 @@ def doctor(*, fix: bool) -> None:
                 f"Context entries: all {len(context_entries)} context(s) exist in warehouse"
             )
 
-    # Repair gitignore drift BEFORE health checks so the summary is accurate
-    if fix:
-        from beacon.domains.setup.diagnostics import repair_gitignore_drift
-
-        for msg in repair_gitignore_drift(project_root):
-            fixes_applied.append(msg)
-            console.print(f"  [green]✓[/green] {msg}")
-
-    # Project-side checks (PER-193)
-    project_issues = run_project_health_checks(
-        project_root, warehouse_path, beacon_settings
+    # Single domain call: repair + checks
+    project_issues, gitignore_fixes = run_project_diagnostics(
+        project_root, warehouse_path, beacon_settings, fix
     )
+    for msg in gitignore_fixes:
+        fixes_applied.append(msg)
+        console.print(f"  [green]✓[/green] {msg}")
     for issue in project_issues:
         if issue.severity == "warn":
             _warn(issue.message, issue.detail)

--- a/libs/beacon/src/beacon/cli/diagnostics.py
+++ b/libs/beacon/src/beacon/cli/diagnostics.py
@@ -153,7 +153,8 @@ def doctor(*, fix: bool) -> None:
             _err(issue.message, issue.detail)
 
     # Gitignore drift check + fix (AB-94: managed-block gitignore engine)
-    if fix:
+    # Gate on beacon.yaml — never touch .gitignore in non-Beacon projects
+    if fix and beacon_yaml.exists():
         drifts = diff_gitignores(project_root)
         managed_kinds = {
             "tier_a_missing",

--- a/libs/beacon/src/beacon/cli/diagnostics.py
+++ b/libs/beacon/src/beacon/cli/diagnostics.py
@@ -155,11 +155,21 @@ def doctor(*, fix: bool) -> None:
     # Gitignore drift check + fix (AB-94: managed-block gitignore engine)
     if fix:
         drifts = diff_gitignores(project_root)
-        if drifts:
+        managed_kinds = {
+            "tier_a_missing",
+            "tier_a_incomplete",
+            "tier_b_missing",
+            "tier_b_incomplete",
+        }
+        managed = [d for d in drifts if d.kind in managed_kinds]
+        tracked = [d for d in drifts if d.kind == "tracked_set_ignored"]
+        if managed:
             apply_all_gitignores(project_root)
             fixes_applied.append("Repaired gitignore managed blocks (Tier A / Tier B)")
+            console.print("  [green]✓[/green] Gitignore managed blocks repaired")
+        for d in tracked:
             console.print(
-                "  [green]✓[/green] Gitignore drift repaired via managed-block engine"
+                f"  [red]✗[/red] Cannot auto-fix: {d.message} — remove or negate the offending .gitignore pattern manually"
             )
 
     print_doctor_summary(issues, fixes_applied)

--- a/libs/beacon/src/beacon/cli/diagnostics.py
+++ b/libs/beacon/src/beacon/cli/diagnostics.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import click
 from rich.console import Console
 
+from beacon.core.gitignore import apply_all_gitignores, diff_gitignores
 from beacon.core.manifest.beacon import BeaconManifest
 from beacon.core.manifest.workspace import WorkspaceConfig
 from beacon.domains.setup.diagnostics import run_project_health_checks
@@ -150,5 +151,15 @@ def doctor(*, fix: bool) -> None:
             _warn(issue.message, issue.detail)
         else:
             _err(issue.message, issue.detail)
+
+    # Gitignore drift check + fix (AB-94: managed-block gitignore engine)
+    if fix:
+        drifts = diff_gitignores(project_root)
+        if drifts:
+            apply_all_gitignores(project_root)
+            fixes_applied.append("Repaired gitignore managed blocks (Tier A / Tier B)")
+            console.print(
+                "  [green]✓[/green] Gitignore drift repaired via managed-block engine"
+            )
 
     print_doctor_summary(issues, fixes_applied)

--- a/libs/beacon/src/beacon/core/gitignore.py
+++ b/libs/beacon/src/beacon/core/gitignore.py
@@ -135,37 +135,39 @@ def apply_managed_block(gitignore_path: Path, entries: list[str]) -> bool:
     # No managed block — surgical migration of legacy block
     existing_lines = existing_content.splitlines(keepends=True)
     entry_set = set(entries)
+
+    # Step 1: Remove every loose line that exactly matches an entry
     filtered_lines: list[str] = []
-    skip_until: int | None = None
-    for i, line in enumerate(existing_lines):
-        if skip_until is not None:
-            if i < skip_until:
-                continue
-            skip_until = None
+    for line in existing_lines:
         stripped = line.rstrip("\n").rstrip("\r")
-        if stripped != _LEGACY_HEADER:
-            filtered_lines.append(line)
-            continue
-        j = i + 1
-        owned_removed = False
-        while j < len(existing_lines):
-            s = existing_lines[j].rstrip("\n").rstrip("\r")
-            if not s or s.startswith("#"):
-                break
-            if s in entry_set:
-                owned_removed = True
-                j += 1
-            else:
-                break
-        if owned_removed:
-            skip_until = j
+        if stripped in entry_set:
             continue
         filtered_lines.append(line)
-        for k in range(i + 1, j):
-            filtered_lines.append(existing_lines[k])
-        skip_until = j
 
-    raw = "".join(filtered_lines)
+    # Step 2: Drop orphaned legacy headers (no owned line beneath them)
+    result_lines: list[str] = []
+    i = 0
+    while i < len(filtered_lines):
+        line = filtered_lines[i]
+        stripped = line.rstrip("\n").rstrip("\r")
+        if stripped == _LEGACY_HEADER:
+            j = i + 1
+            has_owned_below = False
+            while j < len(filtered_lines):
+                s = filtered_lines[j].rstrip("\n").rstrip("\r")
+                if not s or s.startswith("#"):
+                    break
+                if s in entry_set:
+                    has_owned_below = True
+                    break
+                j += 1
+            if not has_owned_below:
+                i += 1
+                continue
+        result_lines.append(line)
+        i += 1
+
+    raw = "".join(result_lines)
     block_text = _build_block_text(entries)
 
     new_content = raw.rstrip("\n") + "\n" + block_text
@@ -191,24 +193,30 @@ def read_managed_block(gitignore_path: Path) -> list[str] | None:
     return entries
 
 
-def apply_all_gitignores(project_root: Path) -> None:
+def apply_all_gitignores(project_root: Path) -> bool:
     """Apply both tiers of gitignore managed blocks.
 
     Tier A is always written to the project root ``.gitignore``.
     Tier B nested files are written only when their tool directory exists:
     - ``.claude/.gitignore`` iff ``.claude/`` is a directory
     - ``.opencode/.gitignore`` iff ``.opencode/`` is a directory
+
+    Returns True if any file was modified.
     """
     root_gitignore = project_root / ".gitignore"
-    apply_managed_block(root_gitignore, TIER_A_ENTRIES)
+    modified = apply_managed_block(root_gitignore, TIER_A_ENTRIES)
 
     claude_dir = project_root / ".claude"
     if claude_dir.is_dir():
-        apply_managed_block(claude_dir / ".gitignore", TIER_B_CLAUDE_ENTRIES)
+        if apply_managed_block(claude_dir / ".gitignore", TIER_B_CLAUDE_ENTRIES):
+            modified = True
 
     opencode_dir = project_root / ".opencode"
     if opencode_dir.is_dir():
-        apply_managed_block(opencode_dir / ".gitignore", TIER_B_OPENCODE_ENTRIES)
+        if apply_managed_block(opencode_dir / ".gitignore", TIER_B_OPENCODE_ENTRIES):
+            modified = True
+
+    return modified
 
 
 def diff_gitignores(project_root: Path) -> list[GitignoreDrift]:

--- a/libs/beacon/src/beacon/core/gitignore.py
+++ b/libs/beacon/src/beacon/core/gitignore.py
@@ -8,6 +8,7 @@ loose-line blocks.
 Architecture boundary: core/ must not import from domains/ or cli/.
 """
 
+import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -77,6 +78,23 @@ TRACKED_ON_PURPOSE = [
     "opencode.json",
     ".worktreeinclude",
 ]
+
+# ─────────────────────────────────────────────────────────────
+# Git ignore evaluation helper
+# ─────────────────────────────────────────────────────────────
+
+
+def _git_would_ignore(project_root: Path, rel_path: str) -> bool:
+    """True if git's ignore rules would exclude rel_path. False if not, or not a git repo."""
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(project_root), "check-ignore", "-q", rel_path],
+            capture_output=True,
+        )
+    except (OSError, ValueError):
+        return False
+    return result.returncode == 0  # 0 = ignored, 1 = not ignored, 128 = not a git repo
+
 
 # ─────────────────────────────────────────────────────────────
 # Drift record
@@ -296,22 +314,17 @@ def diff_gitignores(project_root: Path) -> list[GitignoreDrift]:
                     )
                 )
 
-    # Check tracked-set — any tracked-on-purpose file currently git-ignored
-    if root_gitignore.exists():
-        content = root_gitignore.read_text(encoding="utf-8")
-        for tracked in TRACKED_ON_PURPOSE:
-            tracked_short = Path(tracked).name
-            for line in content.splitlines():
-                stripped = line.strip()
-                if stripped == tracked_short or stripped == tracked:
-                    if not stripped.startswith("!"):
-                        drifts.append(
-                            GitignoreDrift(
-                                kind="tracked_set_ignored",
-                                message=f"Tracked-on-purpose file would be ignored: {tracked}",
-                            )
-                        )
-                        break
+    # Check tracked-set — any tracked-on-purpose file currently git-ignored.
+    # Uses real git ignore evaluation so glob/prefix/directory patterns
+    # (.agentic-beacon/, *.yaml, .claude/) are correctly detected.
+    for tracked in TRACKED_ON_PURPOSE:
+        if _git_would_ignore(project_root, tracked):
+            drifts.append(
+                GitignoreDrift(
+                    kind="tracked_set_ignored",
+                    message=f"Tracked-on-purpose file would be ignored: {tracked}",
+                )
+            )
 
     return drifts
 

--- a/libs/beacon/src/beacon/core/gitignore.py
+++ b/libs/beacon/src/beacon/core/gitignore.py
@@ -262,18 +262,23 @@ def diff_gitignores(project_root: Path) -> list[GitignoreDrift]:
                 message="Tier A managed block missing from root .gitignore",
             )
         )
-    else:
-        tier_a_set = set(tier_a_entries)
-        expected_a = set(TIER_A_ENTRIES)
-        missing = expected_a - tier_a_set
+    elif tier_a_entries != TIER_A_ENTRIES:
+        missing = set(TIER_A_ENTRIES) - set(tier_a_entries)
+        extra = set(tier_a_entries) - set(TIER_A_ENTRIES)
+        detail_parts = []
         if missing:
-            drifts.append(
-                GitignoreDrift(
-                    kind="tier_a_incomplete",
-                    message="Tier A managed block incomplete in root .gitignore",
-                    detail=f"Missing entries: {', '.join(sorted(missing))}",
-                )
+            detail_parts.append(f"Missing entries: {', '.join(sorted(missing))}")
+        if extra:
+            detail_parts.append(f"Extra entries: {', '.join(sorted(extra))}")
+        if not missing and not extra:
+            detail_parts.append("Entries reordered")
+        drifts.append(
+            GitignoreDrift(
+                kind="tier_a_incomplete",
+                message="Tier A managed block incomplete in root .gitignore",
+                detail="; ".join(detail_parts),
             )
+        )
 
     # Check Tier B
     claude_dir = project_root / ".claude"
@@ -287,17 +292,23 @@ def diff_gitignores(project_root: Path) -> list[GitignoreDrift]:
                     message="Tier B managed block missing from .claude/.gitignore",
                 )
             )
-        else:
-            expected_b = set(TIER_B_CLAUDE_ENTRIES)
-            missing_b = expected_b - set(b_entries)
+        elif b_entries != TIER_B_CLAUDE_ENTRIES:
+            missing_b = set(TIER_B_CLAUDE_ENTRIES) - set(b_entries)
+            extra_b = set(b_entries) - set(TIER_B_CLAUDE_ENTRIES)
+            detail_parts = []
             if missing_b:
-                drifts.append(
-                    GitignoreDrift(
-                        kind="tier_b_incomplete",
-                        message="Tier B managed block incomplete in .claude/.gitignore",
-                        detail=f"Missing entries: {', '.join(sorted(missing_b))}",
-                    )
+                detail_parts.append(f"Missing entries: {', '.join(sorted(missing_b))}")
+            if extra_b:
+                detail_parts.append(f"Extra entries: {', '.join(sorted(extra_b))}")
+            if not missing_b and not extra_b:
+                detail_parts.append("Entries reordered")
+            drifts.append(
+                GitignoreDrift(
+                    kind="tier_b_incomplete",
+                    message="Tier B managed block incomplete in .claude/.gitignore",
+                    detail="; ".join(detail_parts),
                 )
+            )
 
     opencode_dir = project_root / ".opencode"
     if opencode_dir.is_dir():
@@ -310,17 +321,23 @@ def diff_gitignores(project_root: Path) -> list[GitignoreDrift]:
                     message="Tier B managed block missing from .opencode/.gitignore",
                 )
             )
-        else:
-            expected_b = set(TIER_B_OPENCODE_ENTRIES)
-            missing_b = expected_b - set(b_entries)
+        elif b_entries != TIER_B_OPENCODE_ENTRIES:
+            missing_b = set(TIER_B_OPENCODE_ENTRIES) - set(b_entries)
+            extra_b = set(b_entries) - set(TIER_B_OPENCODE_ENTRIES)
+            detail_parts = []
             if missing_b:
-                drifts.append(
-                    GitignoreDrift(
-                        kind="tier_b_incomplete",
-                        message="Tier B managed block incomplete in .opencode/.gitignore",
-                        detail=f"Missing entries: {', '.join(sorted(missing_b))}",
-                    )
+                detail_parts.append(f"Missing entries: {', '.join(sorted(missing_b))}")
+            if extra_b:
+                detail_parts.append(f"Extra entries: {', '.join(sorted(extra_b))}")
+            if not missing_b and not extra_b:
+                detail_parts.append("Entries reordered")
+            drifts.append(
+                GitignoreDrift(
+                    kind="tier_b_incomplete",
+                    message="Tier B managed block incomplete in .opencode/.gitignore",
+                    detail="; ".join(detail_parts),
                 )
+            )
 
     # Check tracked-set — any tracked-on-purpose file currently git-ignored.
     # Uses real git ignore evaluation so glob/prefix/directory patterns

--- a/libs/beacon/src/beacon/core/gitignore.py
+++ b/libs/beacon/src/beacon/core/gitignore.py
@@ -88,7 +88,15 @@ def _git_would_ignore(project_root: Path, rel_path: str) -> bool:
     """True if git's ignore rules would exclude rel_path. False if not, or not a git repo."""
     try:
         result = subprocess.run(
-            ["git", "-C", str(project_root), "check-ignore", "-q", rel_path],
+            [
+                "git",
+                "-C",
+                str(project_root),
+                "check-ignore",
+                "--no-index",
+                "-q",
+                rel_path,
+            ],
             capture_output=True,
         )
     except (OSError, ValueError):

--- a/libs/beacon/src/beacon/core/gitignore.py
+++ b/libs/beacon/src/beacon/core/gitignore.py
@@ -126,6 +126,23 @@ def _build_block_text(entries: list[str]) -> str:
     return "\n".join(lines) + "\n"
 
 
+def _find_managed_block(lines: list[str]) -> tuple[int, int] | None:
+    i = 0
+    n = len(lines)
+    while i < n:
+        if lines[i].rstrip("\n").rstrip("\r") == MANAGED_BLOCK_BEGIN:
+            j = i + 1
+            while j < n:
+                stripped = lines[j].rstrip("\n").rstrip("\r")
+                if stripped == MANAGED_BLOCK_BEGIN:
+                    break
+                if stripped == MANAGED_BLOCK_END:
+                    return (i, j)
+                j += 1
+        i += 1
+    return None
+
+
 def apply_managed_block(gitignore_path: Path, entries: list[str]) -> bool:
     """Create or regenerate the marker-delimited managed block in *gitignore_path*.
 
@@ -143,16 +160,15 @@ def apply_managed_block(gitignore_path: Path, entries: list[str]) -> bool:
     if gitignore_path.exists():
         existing_content = gitignore_path.read_text(encoding="utf-8")
 
-    # Check for existing managed block
-    begin_idx = existing_content.find(MANAGED_BLOCK_BEGIN)
-    end_idx = existing_content.find(MANAGED_BLOCK_END)
-
-    if begin_idx != -1 and end_idx != -1 and end_idx > begin_idx:
-        content_before = existing_content[:begin_idx]
-        content_after = existing_content[end_idx + len(MANAGED_BLOCK_END) :]
-        content_after = content_after.lstrip("\n")
+    existing_lines = existing_content.splitlines(keepends=True)
+    found = _find_managed_block(existing_lines)
+    if found is not None:
+        begin_i, end_i = found
+        before = "".join(existing_lines[:begin_i])
+        after = "".join(existing_lines[end_i + 1 :])
+        after = after.lstrip("\n")
         new_block = _build_block_text(entries)
-        new_content = content_before + new_block + content_after
+        new_content = before + new_block + after
         if new_content == existing_content:
             return False
         gitignore_path.write_text(new_content, encoding="utf-8")
@@ -192,16 +208,14 @@ def read_managed_block(gitignore_path: Path) -> list[str] | None:
     """Return the entry lines of the managed block, or None if absent."""
     if not gitignore_path.exists():
         return None
-    content = gitignore_path.read_text(encoding="utf-8")
-    begin_idx = content.find(MANAGED_BLOCK_BEGIN)
-    end_idx = content.find(MANAGED_BLOCK_END)
-    if begin_idx == -1 or end_idx == -1 or end_idx <= begin_idx:
+    lines = gitignore_path.read_text(encoding="utf-8").splitlines(keepends=True)
+    found = _find_managed_block(lines)
+    if found is None:
         return None
-    body = content[begin_idx + len(MANAGED_BLOCK_BEGIN) : end_idx]
-    entries = [
-        line.rstrip("\n").rstrip("\r") for line in body.splitlines() if line.strip()
+    begin_i, end_i = found
+    return [
+        ln.rstrip("\n").rstrip("\r") for ln in lines[begin_i + 1 : end_i] if ln.strip()
     ]
-    return entries
 
 
 def apply_all_gitignores(project_root: Path) -> bool:

--- a/libs/beacon/src/beacon/core/gitignore.py
+++ b/libs/beacon/src/beacon/core/gitignore.py
@@ -196,7 +196,8 @@ def apply_managed_block(gitignore_path: Path, entries: list[str]) -> bool:
     raw = "".join(result_lines)
     block_text = _build_block_text(entries)
 
-    new_content = raw.rstrip("\n") + "\n" + block_text
+    stripped_raw = raw.rstrip("\n")
+    new_content = (stripped_raw + "\n" + block_text) if stripped_raw else block_text
     if new_content == existing_content:
         return False
     gitignore_path.write_text(new_content, encoding="utf-8")

--- a/libs/beacon/src/beacon/core/gitignore.py
+++ b/libs/beacon/src/beacon/core/gitignore.py
@@ -1,53 +1,326 @@
 """Gitignore management for Agentic Beacon.
 
-Automatically manages .gitignore entries to ensure:
-- .agentic-beacon/config.toml is excluded (local config)
-- .agentic-beacon/artifacts/ is excluded (warehouse symlinks)
-- .agentic-beacon/beacon.yaml is NOT excluded (team config)
+Managed-block gitignore engine — the single cross-domain source of truth for
+Beacon's .gitignore ownership.  Applies a marker-delimited managed block that
+is regenerated wholesale on every run, with surgical migration of legacy
+loose-line blocks.
+
+Architecture boundary: core/ must not import from domains/ or cli/.
 """
 
+from dataclasses import dataclass
 from pathlib import Path
 
 from loguru import logger
 
-# Entries that should be in .gitignore
+# ─────────────────────────────────────────────────────────────
+# Managed-block markers
+# ─────────────────────────────────────────────────────────────
+
+MANAGED_BLOCK_BEGIN = "# >>> Agentic Beacon (managed) >>>"
+MANAGED_BLOCK_END = "# <<< Agentic Beacon (managed) <<<"
+
+# Minimal set for the old-style GitignoreManager (backward compat)
 GITIGNORE_ENTRIES = [
     ".agentic-beacon/config.toml",
     ".agentic-beacon/artifacts/",
     ".agentic-beacon/pending.yaml",
 ]
 
-# Section header for our entries
 SECTION_HEADER = "# Agentic Beacon"
+
+# ─────────────────────────────────────────────────────────────
+# Tier A — unconditional root .gitignore entries
+# ─────────────────────────────────────────────────────────────
+
+TIER_A_ENTRIES = [
+    ".agentic-beacon/config.toml",
+    ".agentic-beacon/artifacts/",
+    ".agentic-beacon/warehouse-catalog.md",
+    ".agentic-beacon/pending.yaml",
+    ".claude/skills/",
+    ".claude/commands/",
+    ".claude/agents/",
+    ".opencode/skills/",
+    ".opencode/command/",
+    ".opencode/agents/",
+]
+
+# ─────────────────────────────────────────────────────────────
+# Tier B — nested tool-dir .gitignore entries
+# ─────────────────────────────────────────────────────────────
+
+TIER_B_CLAUDE_ENTRIES = [
+    "skills/",
+    "scheduled_tasks.lock",
+    "worktrees/",
+]
+
+TIER_B_OPENCODE_ENTRIES = [
+    "skills/",
+    "command/",
+    "bun.lock",
+    "package.json",
+    "package-lock.json",
+    "node_modules/",
+]
+
+# ─────────────────────────────────────────────────────────────
+# Tracked-on-purpose — files that must never be git-ignored
+# ─────────────────────────────────────────────────────────────
+
+TRACKED_ON_PURPOSE = [
+    ".agentic-beacon/beacon.yaml",
+    ".claude/.gitignore",
+    ".opencode/.gitignore",
+    "CLAUDE.md",
+    "opencode.json",
+    ".worktreeinclude",
+]
+
+# ─────────────────────────────────────────────────────────────
+# Drift record
+# ─────────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class GitignoreDrift:
+    kind: str  # "tier_a_missing", "tier_a_incomplete", "tier_b_missing", "tier_b_incomplete", "tracked_set_ignored"
+    message: str
+    detail: str = ""
+
+
+_LEGACY_HEADER = "# Agentic Beacon"
+
+
+def _build_block_text(entries: list[str]) -> str:
+    lines = [MANAGED_BLOCK_BEGIN]
+    lines.extend(entries)
+    lines.append(MANAGED_BLOCK_END)
+    return "\n".join(lines) + "\n"
+
+
+def apply_managed_block(gitignore_path: Path, entries: list[str]) -> bool:
+    """Create or regenerate the marker-delimited managed block in *gitignore_path*.
+
+    If the file already contains a managed block (bounded by MANAGED_BLOCK_BEGIN /
+    MANAGED_BLOCK_END), the body between the markers is replaced wholesale.
+
+    If no managed block exists, performs surgical migration: removes any loose
+    line that exactly matches an entry, drops an emptied bare legacy header
+    (``# Agentic Beacon``), then appends the managed block.
+
+    Returns True if the file was modified, False if it was already current.
+    Idempotent when re-applied with the same entries.
+    """
+    existing_content = ""
+    if gitignore_path.exists():
+        existing_content = gitignore_path.read_text(encoding="utf-8")
+
+    # Check for existing managed block
+    begin_idx = existing_content.find(MANAGED_BLOCK_BEGIN)
+    end_idx = existing_content.find(MANAGED_BLOCK_END)
+
+    if begin_idx != -1 and end_idx != -1 and end_idx > begin_idx:
+        content_before = existing_content[:begin_idx]
+        content_after = existing_content[end_idx + len(MANAGED_BLOCK_END) :]
+        content_after = content_after.lstrip("\n")
+        new_block = _build_block_text(entries)
+        new_content = content_before + new_block + content_after
+        if new_content == existing_content:
+            return False
+        gitignore_path.write_text(new_content, encoding="utf-8")
+        return True
+
+    # No managed block — surgical migration of legacy block
+    existing_lines = existing_content.splitlines(keepends=True)
+    entry_set = set(entries)
+    filtered_lines: list[str] = []
+    skip_until: int | None = None
+    for i, line in enumerate(existing_lines):
+        if skip_until is not None:
+            if i < skip_until:
+                continue
+            skip_until = None
+        stripped = line.rstrip("\n").rstrip("\r")
+        if stripped != _LEGACY_HEADER:
+            filtered_lines.append(line)
+            continue
+        j = i + 1
+        owned_removed = False
+        while j < len(existing_lines):
+            s = existing_lines[j].rstrip("\n").rstrip("\r")
+            if not s or s.startswith("#"):
+                break
+            if s in entry_set:
+                owned_removed = True
+                j += 1
+            else:
+                break
+        if owned_removed:
+            skip_until = j
+            continue
+        filtered_lines.append(line)
+        for k in range(i + 1, j):
+            filtered_lines.append(existing_lines[k])
+        skip_until = j
+
+    raw = "".join(filtered_lines)
+    block_text = _build_block_text(entries)
+
+    new_content = raw.rstrip("\n") + "\n" + block_text
+    if new_content == existing_content:
+        return False
+    gitignore_path.write_text(new_content, encoding="utf-8")
+    return True
+
+
+def read_managed_block(gitignore_path: Path) -> list[str] | None:
+    """Return the entry lines of the managed block, or None if absent."""
+    if not gitignore_path.exists():
+        return None
+    content = gitignore_path.read_text(encoding="utf-8")
+    begin_idx = content.find(MANAGED_BLOCK_BEGIN)
+    end_idx = content.find(MANAGED_BLOCK_END)
+    if begin_idx == -1 or end_idx == -1 or end_idx <= begin_idx:
+        return None
+    body = content[begin_idx + len(MANAGED_BLOCK_BEGIN) : end_idx]
+    entries = [
+        line.rstrip("\n").rstrip("\r") for line in body.splitlines() if line.strip()
+    ]
+    return entries
+
+
+def apply_all_gitignores(project_root: Path) -> None:
+    """Apply both tiers of gitignore managed blocks.
+
+    Tier A is always written to the project root ``.gitignore``.
+    Tier B nested files are written only when their tool directory exists:
+    - ``.claude/.gitignore`` iff ``.claude/`` is a directory
+    - ``.opencode/.gitignore`` iff ``.opencode/`` is a directory
+    """
+    root_gitignore = project_root / ".gitignore"
+    apply_managed_block(root_gitignore, TIER_A_ENTRIES)
+
+    claude_dir = project_root / ".claude"
+    if claude_dir.is_dir():
+        apply_managed_block(claude_dir / ".gitignore", TIER_B_CLAUDE_ENTRIES)
+
+    opencode_dir = project_root / ".opencode"
+    if opencode_dir.is_dir():
+        apply_managed_block(opencode_dir / ".gitignore", TIER_B_OPENCODE_ENTRIES)
+
+
+def diff_gitignores(project_root: Path) -> list[GitignoreDrift]:
+    """Return drift records comparing expected vs actual gitignore state.
+
+    Read-only: does not write to any file.
+    """
+    drifts: list[GitignoreDrift] = []
+    root_gitignore = project_root / ".gitignore"
+
+    # Check Tier A
+    tier_a_entries = read_managed_block(root_gitignore)
+    if tier_a_entries is None:
+        drifts.append(
+            GitignoreDrift(
+                kind="tier_a_missing",
+                message="Tier A managed block missing from root .gitignore",
+            )
+        )
+    else:
+        tier_a_set = set(tier_a_entries)
+        expected_a = set(TIER_A_ENTRIES)
+        missing = expected_a - tier_a_set
+        if missing:
+            drifts.append(
+                GitignoreDrift(
+                    kind="tier_a_incomplete",
+                    message="Tier A managed block incomplete in root .gitignore",
+                    detail=f"Missing entries: {', '.join(sorted(missing))}",
+                )
+            )
+
+    # Check Tier B
+    claude_dir = project_root / ".claude"
+    if claude_dir.is_dir():
+        claude_gitignore = claude_dir / ".gitignore"
+        b_entries = read_managed_block(claude_gitignore)
+        if b_entries is None:
+            drifts.append(
+                GitignoreDrift(
+                    kind="tier_b_missing",
+                    message="Tier B managed block missing from .claude/.gitignore",
+                )
+            )
+        else:
+            expected_b = set(TIER_B_CLAUDE_ENTRIES)
+            missing_b = expected_b - set(b_entries)
+            if missing_b:
+                drifts.append(
+                    GitignoreDrift(
+                        kind="tier_b_incomplete",
+                        message="Tier B managed block incomplete in .claude/.gitignore",
+                        detail=f"Missing entries: {', '.join(sorted(missing_b))}",
+                    )
+                )
+
+    opencode_dir = project_root / ".opencode"
+    if opencode_dir.is_dir():
+        opencode_gitignore = opencode_dir / ".gitignore"
+        b_entries = read_managed_block(opencode_gitignore)
+        if b_entries is None:
+            drifts.append(
+                GitignoreDrift(
+                    kind="tier_b_missing",
+                    message="Tier B managed block missing from .opencode/.gitignore",
+                )
+            )
+        else:
+            expected_b = set(TIER_B_OPENCODE_ENTRIES)
+            missing_b = expected_b - set(b_entries)
+            if missing_b:
+                drifts.append(
+                    GitignoreDrift(
+                        kind="tier_b_incomplete",
+                        message="Tier B managed block incomplete in .opencode/.gitignore",
+                        detail=f"Missing entries: {', '.join(sorted(missing_b))}",
+                    )
+                )
+
+    # Check tracked-set — any tracked-on-purpose file currently git-ignored
+    if root_gitignore.exists():
+        content = root_gitignore.read_text(encoding="utf-8")
+        for tracked in TRACKED_ON_PURPOSE:
+            tracked_short = Path(tracked).name
+            for line in content.splitlines():
+                stripped = line.strip()
+                if stripped == tracked_short or stripped == tracked:
+                    if not stripped.startswith("!"):
+                        drifts.append(
+                            GitignoreDrift(
+                                kind="tracked_set_ignored",
+                                message=f"Tracked-on-purpose file would be ignored: {tracked}",
+                            )
+                        )
+                        break
+
+    return drifts
+
+
+# ═════════════════════════════════════════════════════════════
+# Legacy GitignoreManager (backward compat — used by connect)
+# ═════════════════════════════════════════════════════════════
 
 
 class GitignoreManager:
     """Manages .gitignore entries for agentic-beacon files."""
 
     def __init__(self, project_root: Path | str = "."):
-        """Initialize with project root directory.
-
-        Args:
-            project_root: Path to project root containing .gitignore
-        """
         self.project_root = Path(project_root).resolve()
         self.gitignore_path = self.project_root / ".gitignore"
 
     def ensure_entries(self, entries: list[str] | None = None) -> bool:
-        """Ensure all required entries are in .gitignore.
-
-        Creates .gitignore if it doesn't exist.
-        Appends entries only if they're missing.
-
-        Args:
-            entries: Specific entries to add. Defaults to GITIGNORE_ENTRIES.
-
-        Returns:
-            True if .gitignore was modified, False if no changes needed
-
-        Raises:
-            PermissionError: If cannot write to .gitignore
-        """
         entries = entries or GITIGNORE_ENTRIES
 
         if self.gitignore_path.exists():
@@ -57,24 +330,20 @@ class GitignoreManager:
             existing_content = ""
             existing_lines = set()
 
-        # Find missing entries
         missing_entries = [e for e in entries if e not in existing_lines]
 
         if not missing_entries:
             logger.debug("No .gitignore entries to add")
-            return False  # No changes needed
+            return False
 
-        # Build new content to append
         new_lines = []
 
-        # Add section header if not present
         if SECTION_HEADER not in existing_lines:
             new_lines.append(SECTION_HEADER)
 
         for entry in missing_entries:
             new_lines.append(entry)
 
-        # Append to existing content
         if existing_content and not existing_content.endswith("\n"):
             prefix = "\n\n"
         elif existing_content:
@@ -97,24 +366,6 @@ class GitignoreManager:
         return True
 
     def remove_entries(self, entries: list[str]) -> bool:
-        """Remove specific entries from .gitignore.
-
-        Reads the .gitignore, drops any line that exactly matches one of the
-        given entries, and writes the result back. The `# Agentic Beacon`
-        section header is preserved (other Beacon entries may still be using it).
-
-        Args:
-            entries: Lines to remove. Each is matched against `.gitignore`
-                lines via exact-string equality (after splitting on newlines).
-                Comments and unrelated entries are preserved.
-
-        Returns:
-            True if .gitignore was modified, False otherwise (file missing or
-            no matching entries).
-
-        Raises:
-            PermissionError: If cannot write to .gitignore.
-        """
         if not self.gitignore_path.exists():
             return False
 
@@ -125,9 +376,8 @@ class GitignoreManager:
         filtered = [line for line in existing_lines if line not in to_remove]
 
         if len(filtered) == len(existing_lines):
-            return False  # nothing matched
+            return False
 
-        # Preserve trailing-newline state to match the original file's shape.
         new_content = "\n".join(filtered)
         if existing_content.endswith("\n") and filtered:
             new_content += "\n"
@@ -147,14 +397,6 @@ class GitignoreManager:
         return True
 
     def has_entry(self, entry: str) -> bool:
-        """Check if a specific entry exists in .gitignore.
-
-        Args:
-            entry: The gitignore entry to check for
-
-        Returns:
-            True if entry exists in .gitignore
-        """
         if not self.gitignore_path.exists():
             return False
 
@@ -163,13 +405,8 @@ class GitignoreManager:
         return entry in existing_lines
 
     def verify_beacon_yaml_not_ignored(self) -> bool:
-        """Verify that beacon.yaml is NOT being ignored.
-
-        Returns:
-            True if beacon.yaml is safe (not ignored), False if it's being ignored
-        """
         if not self.gitignore_path.exists():
-            return True  # No .gitignore means nothing is ignored
+            return True
 
         content = self.gitignore_path.read_text(encoding="utf-8")
         lines = content.splitlines()
@@ -184,6 +421,6 @@ class GitignoreManager:
         for line in lines:
             stripped = line.strip()
             if stripped in beacon_patterns and not stripped.startswith("!"):
-                return False  # beacon.yaml might be ignored
+                return False
 
         return True

--- a/libs/beacon/src/beacon/core/gitignore.py
+++ b/libs/beacon/src/beacon/core/gitignore.py
@@ -159,41 +159,25 @@ def apply_managed_block(gitignore_path: Path, entries: list[str]) -> bool:
         return True
 
     # No managed block — surgical migration of legacy block
+    # Single pass over ORIGINAL lines: drop owned entries + legacy block header
+    # iff the ORIGINAL next line is owned.
     existing_lines = existing_content.splitlines(keepends=True)
     entry_set = set(entries)
 
-    # Step 1: Remove every loose line that exactly matches an entry
-    filtered_lines: list[str] = []
-    for line in existing_lines:
+    kept: list[str] = []
+    for i, line in enumerate(existing_lines):
         stripped = line.rstrip("\n").rstrip("\r")
         if stripped in entry_set:
             continue
-        filtered_lines.append(line)
-
-    # Step 2: Drop orphaned legacy headers (no owned line beneath them)
-    result_lines: list[str] = []
-    i = 0
-    while i < len(filtered_lines):
-        line = filtered_lines[i]
-        stripped = line.rstrip("\n").rstrip("\r")
         if stripped == _LEGACY_HEADER:
-            j = i + 1
-            has_owned_below = False
-            while j < len(filtered_lines):
-                s = filtered_lines[j].rstrip("\n").rstrip("\r")
-                if not s or s.startswith("#"):
-                    break
-                if s in entry_set:
-                    has_owned_below = True
-                    break
-                j += 1
-            if not has_owned_below:
-                i += 1
+            nxt = ""
+            if i + 1 < len(existing_lines):
+                nxt = existing_lines[i + 1].rstrip("\n").rstrip("\r")
+            if nxt in entry_set:
                 continue
-        result_lines.append(line)
-        i += 1
+        kept.append(line)
 
-    raw = "".join(result_lines)
+    raw = "".join(kept)
     block_text = _build_block_text(entries)
 
     stripped_raw = raw.rstrip("\n")

--- a/libs/beacon/src/beacon/domains/adoption/apply.py
+++ b/libs/beacon/src/beacon/domains/adoption/apply.py
@@ -255,10 +255,7 @@ def commit_session(
             wire_skills_post_sync(project_root, artifacts_path)
 
         if agent_candidates:
-            from beacon.domains.artifact.agent import (
-                detect_agent_targets,
-                ensure_agent_dirs_gitignored,
-            )
+            from beacon.domains.artifact.agent import detect_agent_targets
             from beacon.domains.setup.wiring import (
                 wire_agent_claudecode,
                 wire_agent_opencode,
@@ -290,8 +287,12 @@ def commit_session(
                     "    mkdir .opencode  [dim]# for OpenCode[/dim]"
                 )
 
-            # PER-113 (Finding 2): ensure root .gitignore has agent dir entries
-            ensure_agent_dirs_gitignored(project_root)
+        # Apply both tiers of gitignore managed blocks — Tier A is unconditional,
+        # Tier B is written per tool-dir existence. Fixes the bug where adopt
+        # skipped Tier A (the root .gitignore block).
+        from beacon.core.gitignore import apply_all_gitignores
+
+        apply_all_gitignores(project_root)
 
         # Wire bundled skills into the project's agent directories
         from beacon.domains.artifact.skill import wire_bundled_skills_per_project

--- a/libs/beacon/src/beacon/domains/adoption/apply.py
+++ b/libs/beacon/src/beacon/domains/adoption/apply.py
@@ -223,6 +223,8 @@ def commit_session(
     # Per-path pre-state snapshot for tool symlinks; reconciled on rollback.
     # Each entry: (path, kind, prior_target) where kind is "missing"/"symlink"/"regular_file".
     tool_snapshots: list[tuple[Path, str, Path | None]] = []
+    # Pre-commit snapshots of gitignore files written by _default_post_sync_wiring.
+    gitignore_snapshots: list[tuple[Path, bytes | None]] = []
 
     def _snapshot_path(p: Path) -> tuple[str, Path | None]:
         """Capture pre-state of a path for rollback restoration."""
@@ -304,6 +306,15 @@ def commit_session(
                 f"  [yellow]warning[/yellow] Bundled skill wiring: {err}"
             )
 
+        # Snapshot gitignore files BEFORE writing so _rollback() can restore them.
+        for _gi_path in (
+            project_root / ".gitignore",
+            project_root / ".claude" / ".gitignore",
+            project_root / ".opencode" / ".gitignore",
+        ):
+            _prior = _gi_path.read_bytes() if _gi_path.exists() else None
+            gitignore_snapshots.append((_gi_path, _prior))
+
         # Apply both tiers of gitignore managed blocks — Tier A is unconditional,
         # Tier B is written per tool-dir existence. MUST run after every other
         # wiring step so tool directories created by the upstream wiring (e.g.
@@ -345,6 +356,12 @@ def commit_session(
                         path.unlink()
                     path.parent.mkdir(parents=True, exist_ok=True)
                     path.symlink_to(prior_target)
+        for gi_path, prior in gitignore_snapshots:
+            if prior is None:
+                if gi_path.exists():
+                    gi_path.unlink()
+            else:
+                gi_path.write_bytes(prior)
 
     try:
         # 1. Update beacon.yaml — add adopts + pending accepts, remove unadopts.

--- a/libs/beacon/src/beacon/domains/adoption/apply.py
+++ b/libs/beacon/src/beacon/domains/adoption/apply.py
@@ -287,13 +287,6 @@ def commit_session(
                     "    mkdir .opencode  [dim]# for OpenCode[/dim]"
                 )
 
-        # Apply both tiers of gitignore managed blocks — Tier A is unconditional,
-        # Tier B is written per tool-dir existence. Fixes the bug where adopt
-        # skipped Tier A (the root .gitignore block).
-        from beacon.core.gitignore import apply_all_gitignores
-
-        apply_all_gitignores(project_root)
-
         # Wire bundled skills into the project's agent directories
         from beacon.domains.artifact.skill import wire_bundled_skills_per_project
 
@@ -310,6 +303,15 @@ def commit_session(
             wiring_notes.append(
                 f"  [yellow]warning[/yellow] Bundled skill wiring: {err}"
             )
+
+        # Apply both tiers of gitignore managed blocks — Tier A is unconditional,
+        # Tier B is written per tool-dir existence. MUST run after every other
+        # wiring step so tool directories created by the upstream wiring (e.g.
+        # bundled-skill wiring into .opencode/command/, .claude/skills/) are
+        # covered by Tier B nested .gitignore files.
+        from beacon.core.gitignore import apply_all_gitignores
+
+        apply_all_gitignores(project_root)
 
     post_sync_wiring_fn = _post_sync_wiring_fn or _default_post_sync_wiring
 

--- a/libs/beacon/src/beacon/domains/artifact/agent.py
+++ b/libs/beacon/src/beacon/domains/artifact/agent.py
@@ -2,8 +2,6 @@
 
 from pathlib import Path
 
-from beacon.core.gitignore import GitignoreManager
-
 _ALL_KNOWN_AGENTS = ["opencode", "claudecode"]
 
 
@@ -72,50 +70,6 @@ def detect_agent_targets(project_root: Path) -> list[str]:
     if (project_root / ".opencode").is_dir():
         targets.append("opencode")
     return targets
-
-
-def ensure_agent_dirs_gitignored(project_root: Path) -> None:
-    """Ensure `.claude/agents/` and `.opencode/agents/` are in the project root .gitignore.
-
-    Idempotent. Creates the .gitignore file if it does not exist. Delegates
-    to `GitignoreManager.ensure_entries` so the agent-dir entries are
-    consistent with the rest of Beacon's gitignore management (skill dirs,
-    `.agentic-beacon/artifacts/`, etc.).
-
-    Args:
-        project_root: Project root directory (must be a directory).
-
-    Raises:
-        FileNotFoundError: If project_root is not a directory.
-    """
-    if not project_root.is_dir():
-        raise FileNotFoundError(f"project_root is not a directory: {project_root}")
-
-    GitignoreManager(project_root).ensure_entries(
-        [".claude/agents/", ".opencode/agents/"]
-    )
-
-
-def prune_agent_dirs_gitignore_entries(project_root: Path) -> None:
-    """Remove `.claude/agents/` and `.opencode/agents/` entries from the project root .gitignore.
-
-    Used when all agents are removed from beacon.yaml — the entries are
-    pruned so the project's .gitignore stays in sync with the declared
-    artifact set. Idempotent: a no-op if .gitignore is missing or the
-    entries are not present.
-
-    Args:
-        project_root: Project root directory (must be a directory).
-
-    Raises:
-        FileNotFoundError: If project_root is not a directory.
-    """
-    if not project_root.is_dir():
-        raise FileNotFoundError(f"project_root is not a directory: {project_root}")
-
-    GitignoreManager(project_root).remove_entries(
-        [".claude/agents/", ".opencode/agents/"]
-    )
 
 
 def snapshot_agent_path(p: Path) -> tuple[str, Path | None]:

--- a/libs/beacon/src/beacon/domains/distribution/orchestrator.py
+++ b/libs/beacon/src/beacon/domains/distribution/orchestrator.py
@@ -25,14 +25,10 @@ from beacon.core.dependencies.resolver import (
     compute_effective_set,
 )
 from beacon.core.exceptions import BeaconSyncError, DependencyError
-from beacon.core.gitignore import GitignoreManager
+from beacon.core.gitignore import apply_all_gitignores
 from beacon.core.manifest.beacon import BeaconManifest
 from beacon.domains.adoption.discovery import count_unadopted_since
-from beacon.domains.artifact.agent import (
-    detect_agent_targets,
-    ensure_agent_dirs_gitignored,
-    prune_agent_dirs_gitignore_entries,
-)
+from beacon.domains.artifact.agent import detect_agent_targets
 from beacon.domains.artifact.skill import (
     install_bundled_skills_globally,
     normalize_skill_entry,
@@ -67,25 +63,6 @@ from beacon.domains.warehouse.preconditions import ensure_sync_ready
 from beacon.utils.git import find_project_root
 
 MIGRATION_DOC_URL = "docs/archive/migrations/artifact-dependencies-frontmatter.md"
-
-# Per-tool entries written into agent-folder .gitignore files during sync.
-# Covers Beacon-owned subdirs (skills/, command/) plus tool-runtime byproducts
-# (lockfiles, package manifests, local-only state) created by opencode / Claude
-# Code when running inside those folders. Distribution-domain policy — not a
-# cross-domain primitive, so kept here rather than in core/gitignore.
-CLAUDE_DIR_GITIGNORE_ENTRIES = [
-    "skills/",
-    "scheduled_tasks.lock",
-    "worktrees/",
-]
-OPENCODE_DIR_GITIGNORE_ENTRIES = [
-    "skills/",
-    "command/",
-    "bun.lock",
-    "package.json",
-    "package-lock.json",
-    "node_modules/",
-]
 
 
 @dataclass
@@ -458,10 +435,6 @@ def run_sync(
             f"See {MIGRATION_DOC_URL} for details."
         ) from e
 
-    if not dry_run:
-        gitignore_mgr = GitignoreManager(project_root)
-        gitignore_mgr.ensure_entries()
-
     # Post-sync wiring
     oc_added: list[str] = []
     cc_added: list[str] = []
@@ -537,29 +510,8 @@ def run_sync(
             skill_conflict_callback=skill_conflict_callback,
         )
 
-    # Per-tool gitignore entries — gated on directory existence only (PER-136).
-    # Covers Beacon-owned subdirs (skills/, command/) plus tool-runtime
-    # byproducts (bun.lock, node_modules/, scheduled_tasks.lock, …) that
-    # opencode / Claude Code create inside their agent folders.
-    # Wrapped in `if not dry_run:` to match the rest of run_sync — no
-    # mutations during dry-run.
-    if not dry_run:
-        claude_dir = project_root / ".claude"
-        if claude_dir.is_dir():
-            GitignoreManager(claude_dir).ensure_entries(CLAUDE_DIR_GITIGNORE_ENTRIES)
-        opencode_dir = project_root / ".opencode"
-        if opencode_dir.is_dir():
-            GitignoreManager(opencode_dir).ensure_entries(
-                OPENCODE_DIR_GITIGNORE_ENTRIES
-            )
-
-    # PER-113 / PER-135: keep root .gitignore in sync with declared agents —
-    # ensure entries are present when agents are declared, pruned otherwise.
-    if not dry_run:
-        if beacon_settings.artifacts.agents:
-            ensure_agent_dirs_gitignored(project_root)
-        else:
-            prune_agent_dirs_gitignore_entries(project_root)
+    # Gitignore managed blocks are applied unconditionally above (Tier A always,
+    # Tier B per tool-dir existence) — no per-tool or per-agent gating needed.
 
     if not dry_run:
         bundled_installed, bundled_skipped = install_bundled_skills_globally()
@@ -592,6 +544,10 @@ def run_sync(
                 )
         except Exception:
             pass
+
+    # Apply gitignore managed blocks after all wiring so tool dirs exist.
+    if not dry_run:
+        apply_all_gitignores(project_root)
 
     return SyncOrchestrationResult(
         dry_run=dry_run,

--- a/libs/beacon/src/beacon/domains/setup/diagnostics.py
+++ b/libs/beacon/src/beacon/domains/setup/diagnostics.py
@@ -30,6 +30,24 @@ class DoctorIssue:
     severity: str = "error"  # "error" or "warn"
 
 
+def run_project_diagnostics(
+    project_root: Path,
+    warehouse_path: Path | None,
+    beacon_manifest: BeaconManifest | None,
+    fix: bool,
+) -> tuple[list[DoctorIssue], list[str]]:
+    """Optionally repair gitignore drift, then run all project-side health checks.
+
+    Returns (issues, applied_fixes). Repair runs first so the returned issues
+    reflect the post-repair state.
+    """
+    applied_fixes: list[str] = []
+    if fix:
+        applied_fixes = repair_gitignore_drift(project_root)
+    issues = run_project_health_checks(project_root, warehouse_path, beacon_manifest)
+    return issues, applied_fixes
+
+
 def repair_gitignore_drift(project_root: Path) -> list[str]:
     """Repair managed-block gitignore drift in place (Tier A / Tier B).
 

--- a/libs/beacon/src/beacon/domains/setup/diagnostics.py
+++ b/libs/beacon/src/beacon/domains/setup/diagnostics.py
@@ -16,6 +16,7 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 
+from beacon.core.gitignore import diff_gitignores
 from beacon.core.manifest.beacon import BeaconManifest
 from beacon.domains.distribution.sync_engine import SyncEngine
 
@@ -47,6 +48,7 @@ def run_project_health_checks(
         issues.extend(_check_warehouse_git(warehouse_path))
 
     issues.extend(_check_path_references(project_root, beacon_manifest))
+    issues.extend(_check_gitignore_drift(project_root))
     issues.extend(_check_platform())
 
     return issues
@@ -358,6 +360,25 @@ def _check_warehouse_git(warehouse_path: Path) -> list[DoctorIssue]:
                 message="Warehouse is not a git working tree",
                 detail=f"{warehouse_path} missing .git directory",
                 severity="warn",
+            )
+        )
+    return issues
+
+
+# ---------------------------------------------------------------------------
+# Check 5: Gitignore drift
+# ---------------------------------------------------------------------------
+
+
+def _check_gitignore_drift(project_root: Path) -> list[DoctorIssue]:
+    issues: list[DoctorIssue] = []
+    drifts = diff_gitignores(project_root)
+    for drift in drifts:
+        issues.append(
+            DoctorIssue(
+                message=drift.message,
+                detail=drift.detail,
+                severity="error",
             )
         )
     return issues

--- a/libs/beacon/src/beacon/domains/setup/diagnostics.py
+++ b/libs/beacon/src/beacon/domains/setup/diagnostics.py
@@ -16,7 +16,7 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 
-from beacon.core.gitignore import diff_gitignores
+from beacon.core.gitignore import apply_all_gitignores, diff_gitignores
 from beacon.core.manifest.beacon import BeaconManifest
 from beacon.domains.distribution.sync_engine import SyncEngine
 
@@ -28,6 +28,29 @@ class DoctorIssue:
     message: str
     detail: str = ""
     severity: str = "error"  # "error" or "warn"
+
+
+def repair_gitignore_drift(project_root: Path) -> list[str]:
+    """Repair managed-block gitignore drift in place (Tier A / Tier B).
+
+    Returns human-readable descriptions of the fixes applied (empty if none).
+    Non-fixable drift (tracked_set_ignored — a user pattern ignoring a
+    tracked-on-purpose file) is NOT touched here; it is left for
+    _check_gitignore_drift to report as remaining drift.
+    """
+    if not (project_root / ".agentic-beacon" / "beacon.yaml").exists():
+        return []
+    drifts = diff_gitignores(project_root)
+    managed_kinds = {
+        "tier_a_missing",
+        "tier_a_incomplete",
+        "tier_b_missing",
+        "tier_b_incomplete",
+    }
+    if any(d.kind in managed_kinds for d in drifts):
+        apply_all_gitignores(project_root)
+        return ["Repaired gitignore managed blocks (Tier A / Tier B)"]
+    return []
 
 
 def run_project_health_checks(

--- a/libs/beacon/src/beacon/domains/setup/diagnostics.py
+++ b/libs/beacon/src/beacon/domains/setup/diagnostics.py
@@ -371,6 +371,9 @@ def _check_warehouse_git(warehouse_path: Path) -> list[DoctorIssue]:
 
 
 def _check_gitignore_drift(project_root: Path) -> list[DoctorIssue]:
+    if not (project_root / ".agentic-beacon" / "beacon.yaml").exists():
+        return []
+
     issues: list[DoctorIssue] = []
     drifts = diff_gitignores(project_root)
     for drift in drifts:

--- a/libs/beacon/src/beacon/domains/warehouse/connector.py
+++ b/libs/beacon/src/beacon/domains/warehouse/connector.py
@@ -3,7 +3,7 @@
 from dataclasses import dataclass, field
 from pathlib import Path
 
-from beacon.core.gitignore import GitignoreManager
+from beacon.core.gitignore import apply_all_gitignores
 from beacon.core.manifest.workspace import WorkspaceConfig
 from beacon.domains.warehouse.validator import WarehouseValidator
 
@@ -44,7 +44,7 @@ def connect_to_warehouse(
         main_branch=main_branch,
     )
 
-    gitignore_mgr = GitignoreManager(project_root)
-    updated = gitignore_mgr.ensure_entries()
+    apply_all_gitignores(project_root)
+    updated = True
 
     return ConnectResult(valid=True, gitignore_updated=updated)

--- a/libs/beacon/src/beacon/domains/warehouse/connector.py
+++ b/libs/beacon/src/beacon/domains/warehouse/connector.py
@@ -44,7 +44,6 @@ def connect_to_warehouse(
         main_branch=main_branch,
     )
 
-    apply_all_gitignores(project_root)
-    updated = True
+    updated = apply_all_gitignores(project_root)
 
     return ConnectResult(valid=True, gitignore_updated=updated)

--- a/libs/beacon/tests/integration/test_adopt_apply.py
+++ b/libs/beacon/tests/integration/test_adopt_apply.py
@@ -249,3 +249,69 @@ def test_mixed_warehouse_and_pending(tmp_path: Path, warehouse: Path):
 
     manifest = PendingManifest.from_yaml(ab / "pending.yaml")
     assert manifest.pending == []  # ctx-b accepted = removed
+
+
+# ═════════════════════════════════════════════════════════════
+# FIX A: adopt with no tool dirs → bundled-skills wiring creates them
+#   → apply_all_gitignores runs LAST and writes Tier B
+# ═════════════════════════════════════════════════════════════
+
+
+def test_adopt_with_no_tool_dirs_creates_tier_b(tmp_path: Path, warehouse: Path):
+    """Adopt-accept on a project with NO pre-existing .claude//.opencode/
+    must end with BOTH Tier A root block AND Tier B nested .gitignore."""
+    # Add a skill to the warehouse
+    skill_dir = warehouse / "skills" / "my-test-skill"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: my-test-skill\ndescription: Test skill\n"
+        "requires:\n  contexts: []\n---\n# Test\n"
+    )
+    _git_commit(warehouse, "add skill")
+
+    p = tmp_path / "fix-a-project"
+    p.mkdir()
+    ab = p / ".agentic-beacon"
+    ab.mkdir()
+    artifacts = ab / "artifacts"
+    artifacts.mkdir()
+    beacon_yaml = ab / "beacon.yaml"
+    beacon_yaml.write_text("artifacts:\n  contexts: []\n  skills: []\n  agents: []\n")
+
+    commit_session(
+        to_adopt=["skills/my-test-skill/"],
+        to_unadopt=[],
+        pending_accept=[],
+        pending_reject=[],
+        candidates=[
+            AdoptCandidate(artifact_type="skills", path="skills/my-test-skill/")
+        ],
+        pending_entries=[],
+        project_root=p,
+        warehouse_path=warehouse,
+        artifacts_path=artifacts,
+        beacon_yaml_path=beacon_yaml,
+    )
+
+    # Tier A root block must be present
+    root_gitignore = p / ".gitignore"
+    assert root_gitignore.exists(), "Tier A .gitignore must exist"
+    root_content = root_gitignore.read_text()
+    assert ">>> Agentic Beacon (managed) >>>" in root_content, (
+        "Root managed block must exist"
+    )
+
+    # Tier B .gitignore must exist for any tool dir that was created
+    claude_gitignore = p / ".claude" / ".gitignore"
+    opencode_gitignore = p / ".opencode" / ".gitignore"
+    assert claude_gitignore.exists(), (
+        "Tier B .claude/.gitignore must exist after adopt with skill wiring"
+    )
+    assert opencode_gitignore.exists(), (
+        "Tier B .opencode/.gitignore must exist after adopt with skill wiring"
+    )
+    for tb in (claude_gitignore, opencode_gitignore):
+        tb_content = tb.read_text()
+        assert ">>> Agentic Beacon (managed) >>>" in tb_content, (
+            f"Tier B managed block must exist in {tb}"
+        )

--- a/libs/beacon/tests/integration/test_adopt_apply.py
+++ b/libs/beacon/tests/integration/test_adopt_apply.py
@@ -315,3 +315,71 @@ def test_adopt_with_no_tool_dirs_creates_tier_b(tmp_path: Path, warehouse: Path)
         assert ">>> Agentic Beacon (managed) >>>" in tb_content, (
             f"Tier B managed block must exist in {tb}"
         )
+
+
+# ═════════════════════════════════════════════════════════════
+# FIX L: gitignore rollback
+# ═════════════════════════════════════════════════════════════
+
+
+def test_rollback_restores_gitignore_after_post_sync_failure(
+    project: dict, warehouse: Path, monkeypatch
+):
+    """Injected failure in apply_all_gitignores → gitignore files restored on rollback.
+
+    Uses monkeypatch so that apply_all_gitignores writes its real content (via
+    the original implementation) and THEN raises. The snapshots captured by the
+    new gitignore_snapshots code in _default_post_sync_writing fire before the
+    write, so _rollback() must restore pre-state bytes (or remove files that
+    didn't exist before).
+    """
+    pre = _snapshot(project)
+
+    root_gi = project["root"] / ".gitignore"
+    claude_gi = project["root"] / ".claude" / ".gitignore"
+    opencode_gi = project["root"] / ".opencode" / ".gitignore"
+
+    def _gi_state(path: Path) -> bytes | None:
+        return path.read_bytes() if path.exists() else None
+
+    pre_root_gi = _gi_state(root_gi)
+    pre_claude_gi = _gi_state(claude_gi)
+    pre_opencode_gi = _gi_state(opencode_gi)
+
+    from beacon.core.gitignore import apply_all_gitignores as _real_apply
+
+    def _failing_apply(project_root):
+        _real_apply(project_root)
+        raise RuntimeError("forced post-gitignore failure")
+
+    monkeypatch.setattr(
+        "beacon.core.gitignore.apply_all_gitignores",
+        _failing_apply,
+    )
+
+    with pytest.raises(CommitError):
+        commit_session(
+            to_adopt=[],
+            to_unadopt=[],
+            pending_accept=["contexts/ctx-a.md", "contexts/ctx-b.md"],
+            pending_reject=["contexts/ctx-reject.md"],
+            candidates=[],
+            pending_entries=project["pending_entries"],
+            project_root=project["root"],
+            warehouse_path=warehouse,
+            artifacts_path=project["artifacts"],
+            beacon_yaml_path=project["beacon_yaml"],
+        )
+
+    # beacon.yaml and pending.yaml restored
+    post = _snapshot(project)
+    assert pre == post, (
+        "beacon.yaml and pending.yaml must be byte-identical after rollback"
+    )
+
+    # gitignore files restored to pre-state
+    assert _gi_state(root_gi) == pre_root_gi, "root .gitignore must be restored"
+    assert _gi_state(claude_gi) == pre_claude_gi, ".claude/.gitignore must be restored"
+    assert _gi_state(opencode_gi) == pre_opencode_gi, (
+        ".opencode/.gitignore must be restored"
+    )

--- a/libs/beacon/tests/integration/test_agent_sync_lifecycle.py
+++ b/libs/beacon/tests/integration/test_agent_sync_lifecycle.py
@@ -305,14 +305,13 @@ def test_sync_with_only_agents_updates_gitignore(
     )
 
 
-def test_sync_with_no_agents_declared_does_not_mutate_gitignore(
+def test_sync_with_no_agents_declared_writes_agent_dir_entries(
     project_dir: Path, warehouse: Path, monkeypatch
 ):
-    """A sync with zero declared agents must NOT add agent entries to .gitignore.
+    """A sync with zero declared agents MUST still include agent dirs in Tier A block.
 
-    Regression guard for the round-5 over-correction where ensure_agent_dirs_gitignored
-    was hoisted to run on every real sync, dirtying contexts-only and skills-only
-    repos with unused .claude/agents/ / .opencode/agents/ entries.
+    Agent dirs are now unconditional in the Tier A managed block — the old
+    gated behavior (ensure_agent_dirs_gitignored) is retired.
     """
     runner = CliRunner()
     monkeypatch.chdir(project_dir)
@@ -320,9 +319,7 @@ def test_sync_with_no_agents_declared_does_not_mutate_gitignore(
     beacon_yaml = project_dir / ".agentic-beacon" / "beacon.yaml"
     beacon_yaml.write_text("artifacts:\n  contexts: []\n  skills: []\n  agents: []\n")
 
-    # Reset .gitignore to a clean state with no agent dir entries so we can
-    # detect whether sync mutates it. (The fixture's default .gitignore may
-    # already contain agent entries from a prior setup step.)
+    # Reset .gitignore to a clean state so we can detect what sync writes.
     gitignore_path = project_dir / ".gitignore"
     clean_content = "# Test fixture — clean gitignore for regression check\n"
     gitignore_path.write_text(clean_content)
@@ -331,32 +328,26 @@ def test_sync_with_no_agents_declared_does_not_mutate_gitignore(
     assert r.exit_code == 0, f"sync failed: {r.output}"
 
     post_state = gitignore_path.read_text()
-    # The orchestrator's broader gitignore manager may append unrelated
-    # .agentic-beacon/* entries; we only assert that THE AGENT-DIR entries
-    # weren't added, since ensure_agent_dirs_gitignored is the gated function.
-    assert ".claude/agents/" not in post_state, (
-        f"sync with agents=[] must not add .claude/agents/ to .gitignore: {post_state!r}"
+    # Agent dirs are now unconditional Tier A entries — always present.
+    assert ".claude/agents/" in post_state, (
+        f"sync with agents=[] must add .claude/agents/ to .gitignore: {post_state!r}"
     )
-    assert ".opencode/agents/" not in post_state, (
-        f"sync with agents=[] must not add .opencode/agents/ to .gitignore: {post_state!r}"
+    assert ".opencode/agents/" in post_state, (
+        f"sync with agents=[] must add .opencode/agents/ to .gitignore: {post_state!r}"
     )
 
 
-def test_sync_with_emptied_agents_prunes_gitignore_entries(
+def test_sync_with_emptied_agents_keeps_agent_dir_entries(
     project_dir: Path, warehouse: Path, monkeypatch
 ):
-    """When agents are removed from beacon.yaml, the prior .gitignore entries are pruned.
+    """When agents are removed from beacon.yaml, agent dir entries persist (unconditional).
 
-    Regression guard for PER-135: previously the .claude/agents/ and
-    .opencode/agents/ entries were never removed once added. Now the
-    orchestrator's prune-on-empty path removes them when artifacts.agents
-    becomes empty.
+    The old prune-on-remove behavior (PER-135) is retired — agent dirs are
+    unconditional Tier A entries that are never pruned.
     """
     runner = CliRunner()
     monkeypatch.chdir(project_dir)
 
-    # Pre-populate the .gitignore with the agent-dir entries (as if a prior
-    # sync with agents declared had added them).
     gitignore_path = project_dir / ".gitignore"
     gitignore_path.write_text(
         "# Existing project content\n__pycache__/\n.claude/agents/\n.opencode/agents/\n"
@@ -369,14 +360,15 @@ def test_sync_with_emptied_agents_prunes_gitignore_entries(
     assert r.exit_code == 0, f"sync failed: {r.output}"
 
     post = gitignore_path.read_text()
-    assert ".claude/agents/" not in post, (
-        f"sync with agents=[] must prune .claude/agents/: {post!r}"
+    # Agent dirs are unconditional — they must survive even when agents=[].
+    assert ".claude/agents/" in post, (
+        f"sync with agents=[] must keep .claude/agents/: {post!r}"
     )
-    assert ".opencode/agents/" not in post, (
-        f"sync with agents=[] must prune .opencode/agents/: {post!r}"
+    assert ".opencode/agents/" in post, (
+        f"sync with agents=[] must keep .opencode/agents/: {post!r}"
     )
     # User's other content must be preserved.
-    assert "__pycache__/" in post, "pre-existing user entries must survive prune"
+    assert "__pycache__/" in post, "pre-existing user entries must survive"
 
 
 def test_sync_with_no_skills_declared_writes_skill_gitignore_entries(
@@ -438,13 +430,13 @@ def test_sync_with_no_skills_declared_writes_skill_gitignore_entries(
 def test_sync_appends_missing_entries_to_existing_per_tool_gitignore(
     project_dir: Path, warehouse: Path, monkeypatch
 ):
-    """Sync must extend an existing per-tool .gitignore without duplicating lines.
+    """Sync migrates a legacy per-tool .gitignore to the managed block without dupes.
 
     Projects upgrading from an older Beacon may already have `.opencode/.gitignore`
-    with the original `skills/` + `command/` entries. Re-syncing must:
-      - leave the existing entries untouched (no duplicates)
-      - preserve any user-added lines
-      - append the newly-tracked entries (bun.lock, node_modules/, …)
+    with a legacy `# Agentic Beacon` header. The managed-block engine:
+      - deduplicates managed entries into the block
+      - preserves user-added lines
+      - drops the bare legacy header in favor of managed block markers
     """
     runner = CliRunner()
     monkeypatch.chdir(project_dir)
@@ -462,16 +454,18 @@ def test_sync_appends_missing_entries_to_existing_per_tool_gitignore(
     r = runner.invoke(main, ["sync", "--skip-git-check"])
     assert r.exit_code == 0, f"sync failed: {r.output}"
 
-    lines = opencode_gitignore.read_text().splitlines()
-    # No duplicates of pre-existing entries.
+    content = opencode_gitignore.read_text()
+    lines = content.splitlines()
+    # No duplicates of pre-existing entries — the managed block has them once.
     assert lines.count("skills/") == 1, f"duplicate 'skills/': {lines!r}"
     assert lines.count("command/") == 1, f"duplicate 'command/': {lines!r}"
-    assert lines.count("# Agentic Beacon") == 1, f"duplicate section header: {lines!r}"
+    # Legacy bare header replaced by managed block markers.
+    assert "(managed)" in content, f"managed block markers missing: {content!r}"
     # User content preserved.
     assert "my-local-notes.md" in lines, f"user entry dropped: {lines!r}"
-    # New entries appended.
+    # The managed block contains ALL Tier B opencode entries.
     for entry in ("bun.lock", "package.json", "package-lock.json", "node_modules/"):
-        assert entry in lines, f"missing newly-tracked entry {entry!r}: {lines!r}"
+        assert entry in lines, f"missing entry {entry!r}: {lines!r}"
 
 
 def test_sync_dry_run_does_not_write_skill_gitignore_entries(

--- a/libs/beacon/tests/integration/test_doctor_command.py
+++ b/libs/beacon/tests/integration/test_doctor_command.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import pytest
 from beacon.cli.main import main
+from beacon.core.gitignore import apply_all_gitignores
 from beacon.core.manifest.beacon import BeaconManifest
 from click.testing import CliRunner
 
@@ -43,6 +44,9 @@ def _setup_project(
     )
     # Write beacon.yaml
     (beacon_dir / "beacon.yaml").write_text(beacon_yaml_content)
+
+    # Apply Tier A gitignore managed block so doctor doesn't flag it as drift
+    apply_all_gitignores(project)
 
     return project, warehouse
 

--- a/libs/beacon/tests/integration/test_sync_wiring.py
+++ b/libs/beacon/tests/integration/test_sync_wiring.py
@@ -15,7 +15,11 @@ from unittest.mock import patch
 
 import pytest
 from beacon.cli.main import main
-from beacon.domains.artifact.agent import ensure_agent_dirs_gitignored
+from beacon.core.gitignore import (
+    TIER_A_ENTRIES,
+    apply_all_gitignores,
+    read_managed_block,
+)
 from beacon.domains.artifact.skill import (
     normalize_skill_entry,
     skill_name_from_entry,
@@ -308,44 +312,48 @@ def test_wire_skills_post_sync_reinstalls_when_content_changes(project_with_skil
 
 
 # ---------------------------------------------------------------------------
-# Unit tests: ensure_agent_dirs_gitignored
+# Unit tests: apply_all_gitignores (supersedes ensure_agent_dirs_gitignored)
 # ---------------------------------------------------------------------------
 
 
-def test_ensure_agent_dirs_gitignored_creates_claude_gitignore(tmp_path):
-    """PER-113: ensure_agent_dirs_gitignored writes to project root .gitignore."""
-    ensure_agent_dirs_gitignored(tmp_path)
-    content = (tmp_path / ".gitignore").read_text()
-    assert ".claude/agents/" in content
+def test_apply_all_gitignores_writes_tier_a_block(tmp_path):
+    """apply_all_gitignores writes Tier A block with agent dirs to root .gitignore."""
+    apply_all_gitignores(tmp_path)
+    body = read_managed_block(tmp_path / ".gitignore")
+    assert body is not None
+    assert ".claude/agents/" in body
+    assert ".opencode/agents/" in body
+    assert set(body) == set(TIER_A_ENTRIES)
 
 
-def test_ensure_agent_dirs_gitignored_creates_opencode_gitignore(tmp_path):
-    """PER-113: project .gitignore gets .opencode/agents/ entry."""
-    ensure_agent_dirs_gitignored(tmp_path)
-    content = (tmp_path / ".gitignore").read_text()
-    assert ".opencode/agents/" in content
+def test_apply_all_gitignores_writes_tier_b_when_dir_exists(tmp_path):
+    """apply_all_gitignores writes nested .gitignore when tool dir exists."""
+    (tmp_path / ".claude").mkdir()
+    (tmp_path / ".opencode").mkdir()
+    apply_all_gitignores(tmp_path)
+    claude_body = read_managed_block(tmp_path / ".claude" / ".gitignore")
+    assert claude_body is not None
+    assert "skills/" in claude_body
+    opencode_body = read_managed_block(tmp_path / ".opencode" / ".gitignore")
+    assert opencode_body is not None
+    assert "skills/" in opencode_body
 
 
-def test_ensure_agent_dirs_gitignored_skips_when_no_agent_dirs(tmp_path):
-    """ensure_agent_dirs_gitignored always writes to project root .gitignore."""
-    ensure_agent_dirs_gitignored(tmp_path)
-    # Now writes to root .gitignore regardless of whether .claude/ / .opencode/ exist
-    assert (tmp_path / ".gitignore").exists()
+def test_apply_all_gitignores_idempotent(tmp_path):
+    """apply_all_gitignores is idempotent on repeated calls."""
+    apply_all_gitignores(tmp_path)
+    body = read_managed_block(tmp_path / ".gitignore")
+    assert body is not None
+
+    apply_all_gitignores(tmp_path)
+    body2 = read_managed_block(tmp_path / ".gitignore")
+    assert body2 == body
 
 
-def test_ensure_agent_dirs_gitignored_idempotent(tmp_path):
-    """ensure_agent_dirs_gitignored is idempotent on repeated calls."""
-    ensure_agent_dirs_gitignored(tmp_path)
-    ensure_agent_dirs_gitignored(tmp_path)
-    content = (tmp_path / ".gitignore").read_text()
-    assert content.count(".claude/agents/") == 1
-    assert content.count(".opencode/agents/") == 1
-
-
-def test_ensure_agent_dirs_gitignored_appends_to_existing_gitignore(tmp_path):
-    """ensure_agent_dirs_gitignored appends to an existing project .gitignore."""
+def test_apply_all_gitignores_preserves_existing_content(tmp_path):
+    """apply_all_gitignores appends to an existing .gitignore."""
     (tmp_path / ".gitignore").write_text("settings.local.json\n")
-    ensure_agent_dirs_gitignored(tmp_path)
+    apply_all_gitignores(tmp_path)
     content = (tmp_path / ".gitignore").read_text()
     assert "settings.local.json" in content
     assert ".claude/agents/" in content

--- a/libs/beacon/tests/unit/core/test_gitignore_engine.py
+++ b/libs/beacon/tests/unit/core/test_gitignore_engine.py
@@ -143,12 +143,12 @@ class TestMigration:
     def test_tc3_mixed_block_with_scattered_agent_dir(self, tmp_path):
         path = tmp_path / ".gitignore"
         path.write_text(
-            "# Agentic Beacon\n.claude/agents/\n.opencode/agents/\ncustom-entry/\n"
+            "# Agentic Beacon\n.claude/agents/\nkeep-me/\n.opencode/agents/\n"
         )
         apply_managed_block(path, TIER_A_ENTRIES)
         content = path.read_text()
         assert "# Agentic Beacon" not in content
-        assert "custom-entry/" in content
+        assert "keep-me/" in content
         assert content.count(".claude/agents/") == 1
         assert content.count(".opencode/agents/") == 1
 
@@ -169,6 +169,41 @@ class TestMigration:
         apply_managed_block(path, TIER_A_ENTRIES)
         content = path.read_text()
         assert ".agentic-beacon/config.toml.extra" in content
+
+    def test_tc6_real_scattered_fixture(self, tmp_path):
+        path = tmp_path / ".gitignore"
+        path.write_text(
+            "# Editor and IDE\n"
+            ".vscode/\n"
+            "\n"
+            "# Agentic Beacon\n"
+            ".claude/scheduled_tasks.lock\n"
+            "\n"
+            ".agentic-beacon/config.toml\n"
+            ".agentic-beacon/artifacts/\n"
+            ".agentic-beacon/warehouse-catalog.md\n"
+            ".agentic-beacon/pending.yaml\n"
+            ".agentic-beacon/.legacy-migrated\n"
+            "\n"
+            "# Local sample-warehouse checkout (developer convenience; never a submodule)\n"
+            "sample-warehouse/\n"
+            ".claude/agents/\n"
+            ".opencode/agents/\n"
+        )
+        apply_managed_block(path, TIER_A_ENTRIES)
+        content = path.read_text()
+        for entry in TIER_A_ENTRIES:
+            assert content.splitlines().count(entry) == 1, (
+                f"{entry} should appear exactly once"
+            )
+        assert ".claude/scheduled_tasks.lock" in content
+        assert ".agentic-beacon/.legacy-migrated" in content
+        assert "sample-warehouse/" in content
+        assert ".vscode/" in content
+        assert "# Editor and IDE" in content
+        assert "Local sample-warehouse" in content
+        apply_managed_block(path, TIER_A_ENTRIES)
+        assert path.read_bytes() == content.encode("utf-8")
 
 
 # ═════════════════════════════════════════════════════════════
@@ -221,6 +256,10 @@ class TestApplyAllGitignores:
         apply_managed_block(path, TIER_B_CLAUDE_ENTRIES)
         body = read_managed_block(path)
         assert body == TIER_B_CLAUDE_ENTRIES
+
+    def test_returns_true_on_fresh_write_false_on_idempotent(self, tmp_path):
+        assert apply_all_gitignores(tmp_path) is True
+        assert apply_all_gitignores(tmp_path) is False
 
 
 # ═════════════════════════════════════════════════════════════

--- a/libs/beacon/tests/unit/core/test_gitignore_engine.py
+++ b/libs/beacon/tests/unit/core/test_gitignore_engine.py
@@ -365,6 +365,37 @@ class TestDiffGitignores:
             f"Expected zero drifts in healthy project, got: {[d.message for d in drifts]}"
         )
 
+    def test_tracked_file_shows_drift_with_no_index(self, tmp_path):
+        """ALREADY-TRACKED files ignored by .gitignore are detected with --no-index.
+
+        Without --no-index, git check-ignore silently exits 1 for tracked
+        files even when a .gitignore pattern matches them.
+        """
+        _git_init(tmp_path)
+        beacon_dir = tmp_path / ".agentic-beacon"
+        beacon_dir.mkdir()
+        beacon_yaml = beacon_dir / "beacon.yaml"
+        beacon_yaml.write_text("")
+        root_gitignore = tmp_path / ".gitignore"
+        root_gitignore.write_text(".agentic-beacon/\n")
+        subprocess.run(
+            ["git", "add", "-f", str(beacon_yaml), str(root_gitignore)],
+            cwd=tmp_path,
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "commit", "-q", "-m", "init"],
+            cwd=tmp_path,
+            check=True,
+            capture_output=True,
+        )
+        drifts = diff_gitignores(tmp_path)
+        tracked = [d for d in drifts if d.kind == "tracked_set_ignored"]
+        assert any(".agentic-beacon/beacon.yaml" in d.message for d in tracked), (
+            f"Expected tracked_set_ignored drift for beacon.yaml, got: {[d.message for d in tracked]}"
+        )
+
 
 # ═════════════════════════════════════════════════════════════
 # 4.3 Tier B regression lock

--- a/libs/beacon/tests/unit/core/test_gitignore_engine.py
+++ b/libs/beacon/tests/unit/core/test_gitignore_engine.py
@@ -243,8 +243,63 @@ class TestMigration:
         assert ".vscode/" in content
         assert "# Editor and IDE" in content
         assert "Local sample-warehouse" in content
+        # Header is followed by .claude/scheduled_tasks.lock (non-owned) → preserved
+        assert "# Agentic Beacon" in content, (
+            "Header preserved because .claude/scheduled_tasks.lock is not a managed entry"
+        )
         apply_managed_block(path, TIER_A_ENTRIES)
         assert path.read_bytes() == content.encode("utf-8")
+
+    # ── FIX J: preserve user '# Agentic Beacon' comment when followed by non-owned lines ──
+
+    def test_user_agentic_beacon_comment_preserved(self, tmp_path):
+        """User '# Agentic Beacon' comment followed by NON-owned lines is preserved."""
+        entries = [".agentic-beacon/config.toml", ".agentic-beacon/artifacts/"]
+        path = tmp_path / ".gitignore"
+        path.write_text(
+            "# my build ignores\n"
+            "build/\n"
+            "\n"
+            "# Agentic Beacon\n"
+            "some-user-artifact/\n"
+            "notes.txt\n"
+        )
+        apply_managed_block(path, entries)
+        content = path.read_text()
+        lines = content.splitlines()
+        assert "# Agentic Beacon" in lines, (
+            "User 'Agentic Beacon' comment must be preserved when followed by non-owned lines"
+        )
+        assert "build/" in lines
+        assert "some-user-artifact/" in lines
+        assert "notes.txt" in lines
+        assert content.count("some-user-artifact/") == 1
+        body = read_managed_block(path)
+        assert ".agentic-beacon/config.toml" in body
+        assert ".agentic-beacon/artifacts/" in body
+
+    def test_user_comment_idempotent_reapply(self, tmp_path):
+        """Reapplying preserves the user comment unchanged."""
+        entries = [".agentic-beacon/config.toml", ".agentic-beacon/artifacts/"]
+        path = tmp_path / ".gitignore"
+        path.write_text("# Agentic Beacon\nsome-user-artifact/\n")
+        apply_managed_block(path, entries)
+        first = path.read_bytes()
+        apply_managed_block(path, entries)
+        second = path.read_bytes()
+        assert first == second
+
+    def test_genuine_legacy_block_header_dropped(self, tmp_path):
+        """Genuine legacy '# Agentic Beacon' header followed by owned line is dropped."""
+        entries = [".agentic-beacon/config.toml", ".agentic-beacon/artifacts/"]
+        path = tmp_path / ".gitignore"
+        path.write_text("# Agentic Beacon\n.agentic-beacon/config.toml\n")
+        apply_managed_block(path, entries)
+        content = path.read_text()
+        assert "# Agentic Beacon" not in content.splitlines(), (
+            "Legacy block header followed by owned entry must be dropped"
+        )
+        assert content.count(".agentic-beacon/config.toml") == 1
 
 
 # ═════════════════════════════════════════════════════════════

--- a/libs/beacon/tests/unit/core/test_gitignore_engine.py
+++ b/libs/beacon/tests/unit/core/test_gitignore_engine.py
@@ -365,6 +365,55 @@ class TestDiffGitignores:
             f"Expected zero drifts in healthy project, got: {[d.message for d in drifts]}"
         )
 
+    # ── FIX G: order-sensitive comparison, extra/reordered detection ──
+
+    def test_extra_line_in_managed_block_detected(self, tmp_path):
+        """A managed block with an extra obsolete line reports tier_a_incomplete."""
+        entries = TIER_A_ENTRIES + [".deprecated/"]
+        apply_managed_block(tmp_path / ".gitignore", entries)
+        drifts = diff_gitignores(tmp_path)
+        incomplete = [d for d in drifts if d.kind == "tier_a_incomplete"]
+        assert len(incomplete) == 1
+        assert "Extra" in incomplete[0].detail
+
+    def test_reordered_entries_detected(self, tmp_path):
+        """Canonical entries in different order report drift."""
+        entries = list(reversed(TIER_A_ENTRIES))
+        apply_managed_block(tmp_path / ".gitignore", entries)
+        drifts = diff_gitignores(tmp_path)
+        incomplete = [d for d in drifts if d.kind == "tier_a_incomplete"]
+        assert len(incomplete) == 1
+        assert "reordered" in incomplete[0].detail
+
+    def test_extra_line_healed_by_apply(self, tmp_path):
+        """apply_all_gitignores repairs extra-line drift, then re-run is clean."""
+        entries = TIER_A_ENTRIES + [".deprecated/"]
+        apply_managed_block(tmp_path / ".gitignore", entries)
+        assert diff_gitignores(tmp_path)
+        apply_all_gitignores(tmp_path)
+        assert diff_gitignores(tmp_path) == []
+
+    def test_reorder_healed_by_apply(self, tmp_path):
+        """apply_all_gitignores repairs reorder drift, then re-run is clean."""
+        apply_managed_block(tmp_path / ".gitignore", list(reversed(TIER_A_ENTRIES)))
+        assert diff_gitignores(tmp_path)
+        apply_all_gitignores(tmp_path)
+        assert diff_gitignores(tmp_path) == []
+
+    def test_missing_entry_still_detected(self, tmp_path):
+        """Subset entries still report tier_a_incomplete."""
+        subset = TIER_A_ENTRIES[:-1]
+        apply_managed_block(tmp_path / ".gitignore", subset)
+        drifts = diff_gitignores(tmp_path)
+        incomplete = [d for d in drifts if d.kind == "tier_a_incomplete"]
+        assert len(incomplete) == 1
+        assert "Missing" in incomplete[0].detail
+
+    def test_healthy_still_clean(self, tmp_path):
+        """Fully populated managed block reports zero drift."""
+        apply_all_gitignores(tmp_path)
+        assert diff_gitignores(tmp_path) == []
+
     def test_tracked_file_shows_drift_with_no_index(self, tmp_path):
         """ALREADY-TRACKED files ignored by .gitignore are detected with --no-index.
 

--- a/libs/beacon/tests/unit/core/test_gitignore_engine.py
+++ b/libs/beacon/tests/unit/core/test_gitignore_engine.py
@@ -106,6 +106,28 @@ class TestApplyManagedBlock:
         body = read_managed_block(path)
         assert body == []
 
+    # ── FIX I: fresh file must not start with leading blank line ──
+
+    def test_non_existent_file_no_leading_newline(self, tmp_path):
+        path = tmp_path / ".gitignore"
+        entries = ["entry-a", "entry-b"]
+        apply_managed_block(path, entries)
+        content = path.read_text()
+        assert not content.startswith("\n"), (
+            f"Fresh file must not start with leading newline; got: {repr(content[:20])}"
+        )
+        block_text = f"{MANAGED_BLOCK_BEGIN}\nentry-a\nentry-b\n{MANAGED_BLOCK_END}\n"
+        assert content == block_text, f"Expected exact block text, got: {repr(content)}"
+
+    def test_non_existent_file_idempotent_reapply(self, tmp_path):
+        path = tmp_path / ".gitignore"
+        entries = ["entry-a", "entry-b"]
+        apply_managed_block(path, entries)
+        first = path.read_bytes()
+        apply_managed_block(path, entries)
+        second = path.read_bytes()
+        assert first == second
+
 
 # ═════════════════════════════════════════════════════════════
 # 1.3 Surgical migration tests

--- a/libs/beacon/tests/unit/core/test_gitignore_engine.py
+++ b/libs/beacon/tests/unit/core/test_gitignore_engine.py
@@ -572,3 +572,78 @@ class TestUnconditionalTierA:
         assert body is not None
         assert ".claude/agents/" in body
         assert ".opencode/agents/" in body
+
+
+# ═════════════════════════════════════════════════════════════
+# FIX M: well-formed managed-block detection (stray marker)
+# ═════════════════════════════════════════════════════════════
+
+
+class TestStrayMarker:
+    """Stray unmatched BEGIN markers must not cause user content deletion."""
+
+    def test_stray_begin_preserves_user_lines_and_regenerates_block(self, tmp_path):
+        path = tmp_path / ".gitignore"
+        path.write_text(
+            f"{MANAGED_BLOCK_BEGIN}\n"
+            "user-line-1\n"
+            "user-line-2\n"
+            f"{MANAGED_BLOCK_BEGIN}\n"
+            "stale-entry\n"
+            f"{MANAGED_BLOCK_END}\n"
+        )
+        apply_managed_block(path, ["entry-a", "entry-b"])
+        content = path.read_text()
+        lines = content.splitlines()
+        assert lines.count(MANAGED_BLOCK_BEGIN) == 2
+        assert lines.count(MANAGED_BLOCK_END) == 1
+        assert "user-line-1" in lines
+        assert "user-line-2" in lines
+        assert "stale-entry" not in content, (
+            "Stale entry inside real block must be replaced"
+        )
+        assert "entry-a" in lines
+        assert "entry-b" in lines
+        body = read_managed_block(path)
+        assert body == ["entry-a", "entry-b"]
+
+    def test_stray_begin_idempotent_with_user_lines(self, tmp_path):
+        path = tmp_path / ".gitignore"
+        path.write_text(
+            f"{MANAGED_BLOCK_BEGIN}\n"
+            "user-line\n"
+            f"{MANAGED_BLOCK_BEGIN}\n"
+            "entry-a\n"
+            f"{MANAGED_BLOCK_END}\n"
+        )
+        apply_managed_block(path, ["entry-a"])
+        first = path.read_bytes()
+        apply_managed_block(path, ["entry-a"])
+        second = path.read_bytes()
+        assert first == second
+        content = path.read_text()
+        assert "user-line" in content
+        assert content.count(MANAGED_BLOCK_BEGIN) == 2
+
+    def test_stray_begin_no_real_block_uses_migration(self, tmp_path):
+        path = tmp_path / ".gitignore"
+        path.write_text(f"{MANAGED_BLOCK_BEGIN}\nuser-data/\n")
+        apply_managed_block(path, ["entry-a"])
+        content = path.read_text()
+        lines = content.splitlines()
+        assert MANAGED_BLOCK_BEGIN in lines
+        assert "user-data/" in lines
+        assert "entry-a" in lines
+        assert MANAGED_BLOCK_END in lines
+
+    def test_read_with_stray_begin_returns_real_block(self, tmp_path):
+        path = tmp_path / ".gitignore"
+        path.write_text(
+            f"{MANAGED_BLOCK_BEGIN}\n"
+            "noise\n"
+            f"{MANAGED_BLOCK_BEGIN}\n"
+            "real-entry\n"
+            f"{MANAGED_BLOCK_END}\n"
+        )
+        body = read_managed_block(path)
+        assert body == ["real-entry"]

--- a/libs/beacon/tests/unit/core/test_gitignore_engine.py
+++ b/libs/beacon/tests/unit/core/test_gitignore_engine.py
@@ -8,6 +8,8 @@ Covers:
 - diff_gitignores (task 4.5)
 """
 
+import subprocess
+
 from beacon.core.gitignore import (
     MANAGED_BLOCK_BEGIN,
     MANAGED_BLOCK_END,
@@ -19,6 +21,23 @@ from beacon.core.gitignore import (
     diff_gitignores,
     read_managed_block,
 )
+
+
+def _git_init(path):
+    subprocess.run(["git", "init", "-q", str(path)], check=False)
+    subprocess.run(
+        ["git", "config", "user.email", "test@test.com"],
+        cwd=path,
+        check=False,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test"],
+        cwd=path,
+        check=False,
+        capture_output=True,
+    )
+
 
 # ═════════════════════════════════════════════════════════════
 # 1.2 apply_managed_block — fresh, regen, idempotent
@@ -299,6 +318,7 @@ class TestDiffGitignores:
         assert "tier_b_missing" in kinds
 
     def test_tc5_tracked_set_ignored(self, tmp_path):
+        _git_init(tmp_path)
         path = tmp_path / ".gitignore"
         path.write_text("beacon.yaml\n")
         apply_managed_block(path, TIER_A_ENTRIES)
@@ -322,6 +342,28 @@ class TestDiffGitignores:
         drifts = diff_gitignores(tmp_path)
         kinds = {d.kind for d in drifts}
         assert "tier_a_missing" in kinds
+
+    # ── FIX C: tracked-set detection with git check-ignore ──
+
+    def test_glob_prefix_pattern_detected(self, tmp_path):
+        """A directory glob pattern that would ignore a tracked-on-purpose file is detected."""
+        _git_init(tmp_path)
+        root = tmp_path / ".gitignore"
+        root.write_text(".agentic-beacon/\n")
+        drifts = diff_gitignores(tmp_path)
+        tracked = [d for d in drifts if d.kind == "tracked_set_ignored"]
+        assert any(".agentic-beacon/beacon.yaml" in d.message for d in tracked), (
+            f"Expected tracked_set_ignored drift for beacon.yaml, got: {[d.message for d in tracked]}"
+        )
+
+    def test_healthy_project_zero_tracked_drift(self, tmp_path):
+        """A properly-configured project with managed blocks must have zero tracked-set drift."""
+        _git_init(tmp_path)
+        apply_all_gitignores(tmp_path)
+        drifts = diff_gitignores(tmp_path)
+        assert len(drifts) == 0, (
+            f"Expected zero drifts in healthy project, got: {[d.message for d in drifts]}"
+        )
 
 
 # ═════════════════════════════════════════════════════════════

--- a/libs/beacon/tests/unit/core/test_gitignore_engine.py
+++ b/libs/beacon/tests/unit/core/test_gitignore_engine.py
@@ -1,0 +1,336 @@
+"""Tests for the managed-block gitignore engine (core/gitignore.py).
+
+Covers:
+- apply_managed_block: fresh-file, stale-body regen, idempotent (task 4.1)
+- Surgical migration of legacy blocks (task 4.2)
+- Tier B entry-set regression lock (task 4.3)
+- read_managed_block and apply_all_gitignores (tasks 1.4, 4.4)
+- diff_gitignores (task 4.5)
+"""
+
+from beacon.core.gitignore import (
+    MANAGED_BLOCK_BEGIN,
+    MANAGED_BLOCK_END,
+    TIER_A_ENTRIES,
+    TIER_B_CLAUDE_ENTRIES,
+    TIER_B_OPENCODE_ENTRIES,
+    apply_all_gitignores,
+    apply_managed_block,
+    diff_gitignores,
+    read_managed_block,
+)
+
+# ═════════════════════════════════════════════════════════════
+# 1.2 apply_managed_block — fresh, regen, idempotent
+# ═════════════════════════════════════════════════════════════
+
+
+class TestApplyManagedBlock:
+    def test_tc1_no_gitignore_creates_block(self, tmp_path):
+        path = tmp_path / ".gitignore"
+        entries = ["entry-a", "entry-b"]
+        apply_managed_block(path, entries)
+        assert path.exists()
+        content = path.read_text()
+        assert MANAGED_BLOCK_BEGIN in content
+        assert MANAGED_BLOCK_END in content
+        assert "entry-a" in content
+        assert "entry-b" in content
+        # Block is first-class content
+        assert content.strip().startswith(MANAGED_BLOCK_BEGIN)
+        assert content.strip().endswith(MANAGED_BLOCK_END)
+
+    def test_tc2_idempotent_reapply(self, tmp_path):
+        path = tmp_path / ".gitignore"
+        entries = ["entry-a", "entry-b"]
+        apply_managed_block(path, entries)
+        first = path.read_bytes()
+        apply_managed_block(path, entries)
+        second = path.read_bytes()
+        assert first == second
+
+    def test_tc3_stale_body_regenerated(self, tmp_path):
+        path = tmp_path / ".gitignore"
+        apply_managed_block(path, ["entry-a", "entry-b"])
+        # Now re-apply with different entries
+        apply_managed_block(path, ["entry-c", "entry-d"])
+        content = path.read_text()
+        assert "entry-a" not in content
+        assert "entry-b" not in content
+        assert "entry-c" in content
+        assert "entry-d" in content
+        # Out-of-block content preserved
+        assert content.count(MANAGED_BLOCK_BEGIN) == 1
+
+    def test_tc3_preserves_out_of_block_content(self, tmp_path):
+        path = tmp_path / ".gitignore"
+        path.write_text("user-line\n")
+        apply_managed_block(path, ["entry-a"])
+        content = path.read_text()
+        assert "user-line" in content
+        body = read_managed_block(path)
+        assert body == ["entry-a"]
+
+    def test_tc4_no_trailing_newline(self, tmp_path):
+        path = tmp_path / ".gitignore"
+        path.write_text("last-line")
+        apply_managed_block(path, ["entry-a"])
+        content = path.read_text()
+        assert content.endswith("\n")
+
+    def test_tc5_empty_entries(self, tmp_path):
+        path = tmp_path / ".gitignore"
+        apply_managed_block(path, [])
+        content = path.read_text()
+        assert MANAGED_BLOCK_BEGIN in content
+        assert MANAGED_BLOCK_END in content
+        body = read_managed_block(path)
+        assert body == []
+
+
+# ═════════════════════════════════════════════════════════════
+# 1.3 Surgical migration tests
+# ═════════════════════════════════════════════════════════════
+
+
+class TestMigration:
+    def _legacy_content(
+        self, managed_entries: list[str], unknown_entries: list[str]
+    ) -> str:
+        lines = ["# Agentic Beacon"]
+        lines.extend(managed_entries)
+        lines.extend(unknown_entries)
+        return "\n".join(lines) + "\n"
+
+    def test_tc1_migration_dedup_and_preserve(self, tmp_path):
+        path = tmp_path / ".gitignore"
+        path.write_text(
+            "node_modules/\n"
+            "# Agentic Beacon\n"
+            ".agentic-beacon/config.toml\n"
+            ".agentic-beacon/artifacts/\n"
+            ".agentic-beacon/.legacy-migrated\n"
+            "sample-warehouse/\n"
+        )
+        apply_managed_block(path, TIER_A_ENTRIES)
+        content = path.read_text()
+        assert "# Agentic Beacon" not in content
+        assert ".agentic-beacon/.legacy-migrated" in content
+        assert "sample-warehouse/" in content
+        assert "node_modules/" in content
+        body = read_managed_block(path)
+        assert body is not None
+        assert ".agentic-beacon/.legacy-migrated" not in body
+        assert "sample-warehouse/" not in body
+        assert content.count(".agentic-beacon/config.toml") == 1
+
+    def test_tc2_legacy_header_all_managed_dropped(self, tmp_path):
+        path = tmp_path / ".gitignore"
+        path.write_text(
+            "# Agentic Beacon\n"
+            ".agentic-beacon/config.toml\n"
+            ".agentic-beacon/artifacts/\n"
+        )
+        apply_managed_block(
+            path, [".agentic-beacon/config.toml", ".agentic-beacon/artifacts/"]
+        )
+        content = path.read_text()
+        assert "# Agentic Beacon" not in content
+        assert content.count(".agentic-beacon/config.toml") == 1
+        body = read_managed_block(path)
+        assert body is not None
+
+    def test_tc3_mixed_block_with_scattered_agent_dir(self, tmp_path):
+        path = tmp_path / ".gitignore"
+        path.write_text(
+            "# Agentic Beacon\n.claude/agents/\n.opencode/agents/\ncustom-entry/\n"
+        )
+        apply_managed_block(path, TIER_A_ENTRIES)
+        content = path.read_text()
+        assert "# Agentic Beacon" not in content
+        assert "custom-entry/" in content
+        assert content.count(".claude/agents/") == 1
+        assert content.count(".opencode/agents/") == 1
+
+    def test_tc4_migration_idempotent(self, tmp_path):
+        path = tmp_path / ".gitignore"
+        path.write_text(
+            "# Agentic Beacon\n.agentic-beacon/config.toml\ncustom-entry/\n"
+        )
+        apply_managed_block(path, TIER_A_ENTRIES)
+        first = path.read_bytes()
+        apply_managed_block(path, TIER_A_ENTRIES)
+        second = path.read_bytes()
+        assert first == second
+
+    def test_tc5_substring_not_deduped(self, tmp_path):
+        path = tmp_path / ".gitignore"
+        path.write_text("# Agentic Beacon\n.agentic-beacon/config.toml.extra\n")
+        apply_managed_block(path, TIER_A_ENTRIES)
+        content = path.read_text()
+        assert ".agentic-beacon/config.toml.extra" in content
+
+
+# ═════════════════════════════════════════════════════════════
+# 1.4 read_managed_block & apply_all_gitignores
+# ═════════════════════════════════════════════════════════════
+
+
+class TestApplyAllGitignores:
+    def test_tc1_no_tool_dirs_root_only(self, tmp_path):
+        apply_all_gitignores(tmp_path)
+        root = tmp_path / ".gitignore"
+        assert root.exists()
+        body = read_managed_block(root)
+        assert body is not None
+        assert set(body) == set(TIER_A_ENTRIES)
+        assert not (tmp_path / ".claude" / ".gitignore").exists()
+        assert not (tmp_path / ".opencode" / ".gitignore").exists()
+
+    def test_tc2_claude_only(self, tmp_path):
+        (tmp_path / ".claude").mkdir()
+        apply_all_gitignores(tmp_path)
+        root = tmp_path / ".gitignore"
+        assert root.exists()
+        claude_gitignore = tmp_path / ".claude" / ".gitignore"
+        assert claude_gitignore.exists()
+        assert not (tmp_path / ".opencode" / ".gitignore").exists()
+        claude_body = read_managed_block(claude_gitignore)
+        assert claude_body == TIER_B_CLAUDE_ENTRIES
+
+    def test_tc3_both_tool_dirs(self, tmp_path):
+        (tmp_path / ".claude").mkdir()
+        (tmp_path / ".opencode").mkdir()
+        apply_all_gitignores(tmp_path)
+        assert (tmp_path / ".claude" / ".gitignore").exists()
+        assert (tmp_path / ".opencode" / ".gitignore").exists()
+        oc_body = read_managed_block(tmp_path / ".opencode" / ".gitignore")
+        assert oc_body == TIER_B_OPENCODE_ENTRIES
+
+    def test_tc4_read_managed_block_no_markers(self, tmp_path):
+        path = tmp_path / ".gitignore"
+        path.write_text("some-line\n")
+        assert read_managed_block(path) is None
+
+    def test_tc4_read_managed_block_nonexistent(self, tmp_path):
+        path = tmp_path / ".gitignore"
+        assert read_managed_block(path) is None
+
+    def test_tc4_read_returns_entries(self, tmp_path):
+        path = tmp_path / ".gitignore"
+        apply_managed_block(path, TIER_B_CLAUDE_ENTRIES)
+        body = read_managed_block(path)
+        assert body == TIER_B_CLAUDE_ENTRIES
+
+
+# ═════════════════════════════════════════════════════════════
+# 1.5 diff_gitignores
+# ═════════════════════════════════════════════════════════════
+
+
+class TestDiffGitignores:
+    def test_tc1_healthy_project(self, tmp_path):
+        apply_all_gitignores(tmp_path)
+        drifts = diff_gitignores(tmp_path)
+        assert drifts == []
+
+    def test_tc2_tier_b_present_tier_a_absent(self, tmp_path):
+        (tmp_path / ".opencode").mkdir()
+        root = tmp_path / ".gitignore"
+        root.write_text("# user content\n")
+        apply_managed_block(
+            tmp_path / ".opencode" / ".gitignore", TIER_B_OPENCODE_ENTRIES
+        )
+        drifts = diff_gitignores(tmp_path)
+        kinds = {d.kind for d in drifts}
+        assert "tier_a_missing" in kinds
+
+    def test_tc3_tier_a_incomplete(self, tmp_path):
+        subset = TIER_A_ENTRIES[:-1]
+        apply_managed_block(tmp_path / ".gitignore", subset)
+        drifts = diff_gitignores(tmp_path)
+        kinds = {d.kind for d in drifts}
+        assert "tier_a_incomplete" in kinds
+
+    def test_tc4_tier_b_missing_when_dir_exists(self, tmp_path):
+        (tmp_path / ".claude").mkdir()
+        apply_managed_block(tmp_path / ".gitignore", TIER_A_ENTRIES)
+        drifts = diff_gitignores(tmp_path)
+        kinds = {d.kind for d in drifts}
+        assert "tier_b_missing" in kinds
+
+    def test_tc5_tracked_set_ignored(self, tmp_path):
+        path = tmp_path / ".gitignore"
+        path.write_text("beacon.yaml\n")
+        apply_managed_block(path, TIER_A_ENTRIES)
+        drifts = diff_gitignores(tmp_path)
+        kinds = {d.kind for d in drifts}
+        assert "tracked_set_ignored" in kinds
+
+    def test_tc6_read_only_no_writes(self, tmp_path):
+        apply_all_gitignores(tmp_path)
+        gitignore = tmp_path / ".gitignore"
+        mtime_before = gitignore.stat().st_mtime
+        diff_gitignores(tmp_path)
+        mtime_after = gitignore.stat().st_mtime
+        assert mtime_after == mtime_before
+
+    def test_tier_a_missing_while_tier_b_present(self, tmp_path):
+        (tmp_path / ".opencode").mkdir()
+        (tmp_path / ".opencode" / ".gitignore").write_text(
+            f"{MANAGED_BLOCK_BEGIN}\nskills/\n{MANAGED_BLOCK_END}\n"
+        )
+        drifts = diff_gitignores(tmp_path)
+        kinds = {d.kind for d in drifts}
+        assert "tier_a_missing" in kinds
+
+
+# ═════════════════════════════════════════════════════════════
+# 4.3 Tier B regression lock
+# ═════════════════════════════════════════════════════════════
+
+
+class TestTierBRegressionLock:
+    def test_claude_entries_match_prior(self):
+        assert TIER_B_CLAUDE_ENTRIES == [
+            "skills/",
+            "scheduled_tasks.lock",
+            "worktrees/",
+        ]
+
+    def test_opencode_entries_match_prior(self):
+        assert TIER_B_OPENCODE_ENTRIES == [
+            "skills/",
+            "command/",
+            "bun.lock",
+            "package.json",
+            "package-lock.json",
+            "node_modules/",
+        ]
+
+    def test_tier_b_gated_by_dir(self, tmp_path):
+        apply_all_gitignores(tmp_path)
+        assert not (tmp_path / ".claude" / ".gitignore").exists()
+        assert not (tmp_path / ".opencode" / ".gitignore").exists()
+
+
+# ═════════════════════════════════════════════════════════════
+# 4.1 Unconditional Tier A (no tool dirs, no agents)
+# ═════════════════════════════════════════════════════════════
+
+
+class TestUnconditionalTierA:
+    def test_all_10_entries_present_without_tool_dirs(self, tmp_path):
+        apply_all_gitignores(tmp_path)
+        body = read_managed_block(tmp_path / ".gitignore")
+        assert body is not None
+        assert len(body) == len(TIER_A_ENTRIES)
+        for entry in TIER_A_ENTRIES:
+            assert entry in body
+
+    def test_agent_dirs_in_block_no_declared_agents(self, tmp_path):
+        apply_all_gitignores(tmp_path)
+        body = read_managed_block(tmp_path / ".gitignore")
+        assert body is not None
+        assert ".claude/agents/" in body
+        assert ".opencode/agents/" in body

--- a/libs/beacon/tests/unit/domains/setup/test_diagnostics.py
+++ b/libs/beacon/tests/unit/domains/setup/test_diagnostics.py
@@ -10,6 +10,7 @@ from beacon.domains.setup.diagnostics import (
     _check_symlink_hygiene,
     _check_warehouse_git,
     _is_glob_pattern,
+    run_project_diagnostics,
     run_project_health_checks,
 )
 
@@ -417,3 +418,40 @@ class TestRunProjectHealthChecks:
         issues = run_project_health_checks(tmp_path, warehouse, None)
         messages = {i.message for i in issues}
         assert "Stale glob" not in messages
+
+
+# ---------------------------------------------------------------------------
+# run_project_diagnostics
+# ---------------------------------------------------------------------------
+
+
+class TestRunProjectDiagnostics:
+    def test_fix_true_repairs_drift(self, tmp_path):
+        warehouse = tmp_path / "warehouse"
+        warehouse.mkdir()
+        (warehouse / ".git").mkdir()
+        (tmp_path / ".agentic-beacon" / "beacon.yaml").parent.mkdir(parents=True)
+        (tmp_path / ".agentic-beacon" / "beacon.yaml").write_text(
+            "artifacts:\n  contexts: []\n  skills: []\n  agents: []\n"
+        )
+        beacon_dir = tmp_path / ".agentic-beacon"
+        beacon_yaml = beacon_dir / "beacon.yaml"
+        from beacon.core.manifest.beacon import BeaconManifest
+
+        manifest = BeaconManifest.from_yaml(beacon_yaml)
+        issues, fixes = run_project_diagnostics(tmp_path, warehouse, manifest, fix=True)
+        assert len(fixes) > 0, "Expected non-empty fixes on drifted project"
+        managed_issues = [
+            i
+            for i in issues
+            if "gitignore" in i.message.lower()
+            and ("Tier A" in i.message or "Tier B" in i.message)
+        ]
+        assert len(managed_issues) == 0, (
+            f"After repair, managed-block drift must not appear: {[i.message for i in managed_issues]}"
+        )
+
+    def test_fix_false_returns_no_fixes(self, tmp_path):
+        issues, fixes = run_project_diagnostics(tmp_path, None, None, fix=False)
+        assert fixes == []
+        assert isinstance(issues, list)

--- a/libs/beacon/tests/unit/domains/warehouse/test_connector.py
+++ b/libs/beacon/tests/unit/domains/warehouse/test_connector.py
@@ -107,7 +107,10 @@ class TestConnectToWarehouseSuccess:
             patch(
                 "beacon.domains.warehouse.connector.WorkspaceConfig.from_path"
             ) as mock_from_path,
-            patch("beacon.domains.warehouse.connector.apply_all_gitignores"),
+            patch(
+                "beacon.domains.warehouse.connector.apply_all_gitignores",
+                return_value=True,
+            ),
         ):
             mock_validator_cls.return_value.validate.return_value = _make_valid_result()
             mock_from_path.return_value = MagicMock()
@@ -124,7 +127,10 @@ class TestConnectToWarehouseSuccess:
             patch(
                 "beacon.domains.warehouse.connector.WorkspaceConfig.from_path"
             ) as mock_from_path,
-            patch("beacon.domains.warehouse.connector.apply_all_gitignores"),
+            patch(
+                "beacon.domains.warehouse.connector.apply_all_gitignores",
+                return_value=True,
+            ),
         ):
             mock_validator_cls.return_value.validate.return_value = _make_valid_result()
             mock_from_path.return_value = MagicMock()

--- a/libs/beacon/tests/unit/domains/warehouse/test_connector.py
+++ b/libs/beacon/tests/unit/domains/warehouse/test_connector.py
@@ -68,15 +68,15 @@ class TestConnectToWarehouseSuccess:
             patch(
                 "beacon.domains.warehouse.connector.WorkspaceConfig.from_path"
             ) as mock_from_path,
-            patch("beacon.domains.warehouse.connector.GitignoreManager") as mock_gi_cls,
+            patch("beacon.domains.warehouse.connector.apply_all_gitignores") as mock_gi,
         ):
             mock_validator_cls.return_value.validate.return_value = _make_valid_result()
             mock_from_path.return_value = MagicMock()
-            mock_gi_cls.return_value.ensure_entries.return_value = True
 
             connect_to_warehouse(project, warehouse)
 
         assert (project / ".agentic-beacon").is_dir()
+        mock_gi.assert_called_once_with(project)
 
     def test_persists_config_with_project_root(
         self, project: Path, warehouse: Path
@@ -88,11 +88,10 @@ class TestConnectToWarehouseSuccess:
             patch(
                 "beacon.domains.warehouse.connector.WorkspaceConfig.from_path"
             ) as mock_from_path,
-            patch("beacon.domains.warehouse.connector.GitignoreManager") as mock_gi_cls,
+            patch("beacon.domains.warehouse.connector.apply_all_gitignores"),
         ):
             mock_validator_cls.return_value.validate.return_value = _make_valid_result()
             mock_from_path.return_value = MagicMock()
-            mock_gi_cls.return_value.ensure_entries.return_value = False
 
             connect_to_warehouse(project, warehouse)
 
@@ -108,16 +107,13 @@ class TestConnectToWarehouseSuccess:
             patch(
                 "beacon.domains.warehouse.connector.WorkspaceConfig.from_path"
             ) as mock_from_path,
-            patch("beacon.domains.warehouse.connector.GitignoreManager") as mock_gi_cls,
+            patch("beacon.domains.warehouse.connector.apply_all_gitignores"),
         ):
             mock_validator_cls.return_value.validate.return_value = _make_valid_result()
             mock_from_path.return_value = MagicMock()
-            mock_gi_cls.return_value.ensure_entries.return_value = True
 
             result = connect_to_warehouse(project, warehouse)
 
-        mock_gi_cls.assert_called_once_with(project)
-        mock_gi_cls.return_value.ensure_entries.assert_called_once()
         assert result.gitignore_updated is True
 
     def test_returns_connect_result_shape(self, project: Path, warehouse: Path) -> None:
@@ -128,15 +124,14 @@ class TestConnectToWarehouseSuccess:
             patch(
                 "beacon.domains.warehouse.connector.WorkspaceConfig.from_path"
             ) as mock_from_path,
-            patch("beacon.domains.warehouse.connector.GitignoreManager") as mock_gi_cls,
+            patch("beacon.domains.warehouse.connector.apply_all_gitignores"),
         ):
             mock_validator_cls.return_value.validate.return_value = _make_valid_result()
             mock_from_path.return_value = MagicMock()
-            mock_gi_cls.return_value.ensure_entries.return_value = False
 
             result = connect_to_warehouse(project, warehouse)
 
         assert isinstance(result, ConnectResult)
         assert result.valid is True
         assert result.errors == []
-        assert result.gitignore_updated is False
+        assert result.gitignore_updated is True

--- a/libs/beacon/tests/unit/test_agent_gitignore.py
+++ b/libs/beacon/tests/unit/test_agent_gitignore.py
@@ -1,173 +1,68 @@
-"""Unit tests for ensure_agent_dirs_gitignored and prune_agent_dirs_gitignore_entries.
+"""Tests for unconditional agent-dir gitignore coverage via the managed-block engine.
 
-Covers TC1-TC5 from task 2.2.
+Agent dirs (`.claude/agents/`, `.opencode/agents/`) are now owned by the Tier A
+managed block unconditionally — the old conditional gating and prune behavior
+is retired. These tests verify the unconditional behavior via the managed-block
+engine that supersedes the removed `ensure_agent_dirs_gitignored` /
+`prune_agent_dirs_gitignore_entries` helpers.
 """
 
-import pytest
-from beacon.domains.artifact.agent import (
-    ensure_agent_dirs_gitignored,
-    prune_agent_dirs_gitignore_entries,
+from beacon.core.gitignore import (
+    TIER_A_ENTRIES,
+    apply_all_gitignores,
+    read_managed_block,
 )
 
-EXPECTED_ENTRIES = [".claude/agents/", ".opencode/agents/"]
 
-
-class TestEnsureAgentDirsGitignored:
-    def test_tc1_no_gitignore_creates_with_both_entries(self, tmp_path):
-        """TC1: no .gitignore exists → file is created with both entries."""
+class TestAgentDirsUnconditionalInTierA:
+    def test_agent_dirs_present_without_declared_agents(self, tmp_path):
+        """TC1: Agent dirs in Tier A block even with no declared agents."""
         project = tmp_path / "proj"
         project.mkdir()
 
-        ensure_agent_dirs_gitignored(project)
+        apply_all_gitignores(project)
 
-        gitignore = project / ".gitignore"
-        assert gitignore.exists()
-        content_lines = gitignore.read_text().splitlines()
-        for entry in EXPECTED_ENTRIES:
-            assert entry in content_lines
+        body = read_managed_block(project / ".gitignore")
+        assert body is not None
+        assert ".claude/agents/" in body
+        assert ".opencode/agents/" in body
 
-    def test_tc2_existing_gitignore_preserves_content(self, tmp_path):
-        """TC2: .gitignore exists with unrelated entries → both entries appended, originals preserved."""
+    def test_agent_dirs_present_without_tool_dirs(self, tmp_path):
+        """TC2: Agent dirs in Tier A block even without .claude/ / .opencode/ dirs."""
         project = tmp_path / "proj"
         project.mkdir()
-        gitignore = project / ".gitignore"
-        original = "__pycache__/\n*.pyc\n"
-        gitignore.write_text(original)
 
-        ensure_agent_dirs_gitignored(project)
+        apply_all_gitignores(project)
 
-        content = gitignore.read_text()
-        assert "__pycache__/" in content
-        assert "*.pyc" in content
-        for entry in EXPECTED_ENTRIES:
-            assert entry in content.splitlines()
-
-    def test_tc3_partial_entries_only_adds_missing(self, tmp_path):
-        """TC3: .gitignore already has .claude/agents/ but not .opencode/agents/ → only missing entry appended."""
-        project = tmp_path / "proj"
-        project.mkdir()
-        gitignore = project / ".gitignore"
-        gitignore.write_text(".claude/agents/\n")
-
-        ensure_agent_dirs_gitignored(project)
-
-        content_lines = gitignore.read_text().splitlines()
-        assert content_lines.count(".claude/agents/") == 1
-        assert ".opencode/agents/" in content_lines
-
-    def test_tc4_both_entries_present_no_op(self, tmp_path):
-        """TC4: .gitignore already has both → no-op, file unchanged."""
-        project = tmp_path / "proj"
-        project.mkdir()
-        gitignore = project / ".gitignore"
-        original = ".claude/agents/\n.opencode/agents/\n"
-        gitignore.write_text(original)
-
-        ensure_agent_dirs_gitignored(project)
-
-        # File should be byte-identical
-        assert gitignore.read_text() == original
-        # mtime may or may not change depending on OS; check content is canonical
-        content_lines = gitignore.read_text().splitlines()
-        assert content_lines.count(".claude/agents/") == 1
-        assert content_lines.count(".opencode/agents/") == 1
-
-    def test_tc5_nonexistent_project_root_raises(self, tmp_path):
-        """TC5: project_root is not a directory → raises FileNotFoundError, no partial write."""
-        non_dir = tmp_path / "not-a-dir.txt"
-        non_dir.write_text("I am a file")
-
-        with pytest.raises(FileNotFoundError):
-            ensure_agent_dirs_gitignored(non_dir)
+        body = read_managed_block(project / ".gitignore")
+        assert body is not None
+        assert set(body) == set(TIER_A_ENTRIES)
 
     def test_idempotent_multiple_calls(self, tmp_path):
-        """Calling ensure_agent_dirs_gitignored multiple times produces no duplicates."""
+        """Calling apply_all_gitignores multiple times produces no duplicates."""
         project = tmp_path / "proj"
         project.mkdir()
 
-        ensure_agent_dirs_gitignored(project)
-        ensure_agent_dirs_gitignored(project)
-        ensure_agent_dirs_gitignored(project)
+        apply_all_gitignores(project)
+        apply_all_gitignores(project)
+        apply_all_gitignores(project)
 
-        content_lines = (project / ".gitignore").read_text().splitlines()
-        assert content_lines.count(".claude/agents/") == 1
-        assert content_lines.count(".opencode/agents/") == 1
+        body = read_managed_block(project / ".gitignore")
+        assert body is not None
+        assert body.count(".claude/agents/") == 1 if isinstance(body, list) else True
+        assert ".claude/agents/" in body
+        assert ".opencode/agents/" in body
 
-
-class TestPruneAgentDirsGitignoreEntries:
-    def test_tc1_missing_gitignore_no_op(self, tmp_path):
-        """TC1: .gitignore missing → no-op, no file created."""
+    def test_entries_not_pruned_when_agents_removed(self, tmp_path):
+        """Agent dirs are NOT pruned — they're unconditional in Tier A."""
         project = tmp_path / "proj"
         project.mkdir()
 
-        prune_agent_dirs_gitignore_entries(project)
+        apply_all_gitignores(project)
+        body = read_managed_block(project / ".gitignore")
+        assert ".claude/agents/" in body
 
-        assert not (project / ".gitignore").exists()
-
-    def test_tc2_both_entries_present_removes_them(self, tmp_path):
-        """TC2: gitignore exists with both entries → both removed, other lines preserved."""
-        project = tmp_path / "proj"
-        project.mkdir()
-        gitignore = project / ".gitignore"
-        gitignore.write_text(
-            "__pycache__/\n.claude/agents/\n.opencode/agents/\n*.pyc\n"
-        )
-
-        prune_agent_dirs_gitignore_entries(project)
-
-        content_lines = gitignore.read_text().splitlines()
-        assert ".claude/agents/" not in content_lines
-        assert ".opencode/agents/" not in content_lines
-        assert "__pycache__/" in content_lines
-        assert "*.pyc" in content_lines
-
-    def test_tc3_entries_absent_no_op(self, tmp_path):
-        """TC3: gitignore exists without the entries → no-op (no modification)."""
-        project = tmp_path / "proj"
-        project.mkdir()
-        gitignore = project / ".gitignore"
-        original = "*.pyc\n__pycache__/\n"
-        gitignore.write_text(original)
-
-        prune_agent_dirs_gitignore_entries(project)
-
-        assert gitignore.read_text() == original
-
-    def test_tc4_only_one_entry_present(self, tmp_path):
-        """TC4: only one of the two entries present → only that one is removed."""
-        project = tmp_path / "proj"
-        project.mkdir()
-        gitignore = project / ".gitignore"
-        gitignore.write_text("*.pyc\n.claude/agents/\n")
-
-        prune_agent_dirs_gitignore_entries(project)
-
-        content_lines = gitignore.read_text().splitlines()
-        assert ".claude/agents/" not in content_lines
-        assert ".opencode/agents/" not in content_lines
-        assert "*.pyc" in content_lines
-
-    def test_tc5_nonexistent_project_root_raises(self, tmp_path):
-        """TC5: project_root is not a directory → raises FileNotFoundError."""
-        non_dir = tmp_path / "not-a-dir.txt"
-        non_dir.write_text("I am a file")
-
-        with pytest.raises(FileNotFoundError):
-            prune_agent_dirs_gitignore_entries(non_dir)
-
-    def test_tc6_idempotent(self, tmp_path):
-        """TC6: pruning twice produces the same result as pruning once."""
-        project = tmp_path / "proj"
-        project.mkdir()
-        gitignore = project / ".gitignore"
-        gitignore.write_text("__pycache__/\n.claude/agents/\n.opencode/agents/\n")
-
-        prune_agent_dirs_gitignore_entries(project)
-        content_after_first = gitignore.read_text()
-
-        prune_agent_dirs_gitignore_entries(project)
-        content_after_second = gitignore.read_text()
-
-        assert content_after_first == content_after_second
-        assert ".claude/agents/" not in content_after_second
-        assert ".opencode/agents/" not in content_after_second
+        # No prune happens — unconditional entries persist
+        apply_all_gitignores(project)
+        body2 = read_managed_block(project / ".gitignore")
+        assert ".claude/agents/" in body2

--- a/libs/beacon/tests/unit/test_architecture.py
+++ b/libs/beacon/tests/unit/test_architecture.py
@@ -462,9 +462,6 @@ _TC9B_WAIVERS: set[tuple[str, str]] = {
     ("sync.py", "status"),
     # TODO: wrap discovery + commit + cleanup into a single adopt domain function
     ("adoption.py", "adopt"),
-    # doctor calls repair_gitignore_drift (if --fix) + run_project_health_checks;
-    # these are semantically distinct and must run in separate phases.
-    ("diagnostics.py", "doctor"),
 }
 
 

--- a/libs/beacon/tests/unit/test_architecture.py
+++ b/libs/beacon/tests/unit/test_architecture.py
@@ -462,6 +462,9 @@ _TC9B_WAIVERS: set[tuple[str, str]] = {
     ("sync.py", "status"),
     # TODO: wrap discovery + commit + cleanup into a single adopt domain function
     ("adoption.py", "adopt"),
+    # doctor calls repair_gitignore_drift (if --fix) + run_project_health_checks;
+    # these are semantically distinct and must run in separate phases.
+    ("diagnostics.py", "doctor"),
 }
 
 

--- a/libs/beacon/tests/unit/test_doctor_gitignore.py
+++ b/libs/beacon/tests/unit/test_doctor_gitignore.py
@@ -1,0 +1,100 @@
+"""Tests for gitignore-drift check in abc doctor (task 3.1, 4.5).
+
+Covers:
+- Drifted project → DoctorIssue with severity 'error'
+- Healthy project → no gitignore DoctorIssue
+- Tracked-set file ignored → error
+"""
+
+from pathlib import Path
+
+from beacon.core.gitignore import (
+    TIER_A_ENTRIES,
+    TIER_B_OPENCODE_ENTRIES,
+    apply_managed_block,
+)
+from beacon.domains.setup.diagnostics import (
+    run_project_health_checks,
+)
+
+
+def _write_tier_a(tmp_path: Path, entries: list[str] | None = None) -> None:
+    apply_managed_block(tmp_path / ".gitignore", entries or TIER_A_ENTRIES)
+
+
+def _write_tier_b(tmp_path: Path, tool_dir: str, entries: list[str]) -> None:
+    d = tmp_path / tool_dir
+    d.mkdir(exist_ok=True)
+    apply_managed_block(d / ".gitignore", entries)
+
+
+class TestDoctorGitignoreDetection:
+    def test_tc1_drifted_project_returns_error(self, tmp_path):
+        _write_tier_b(tmp_path, ".opencode", TIER_B_OPENCODE_ENTRIES)
+        issues = run_project_health_checks(tmp_path, None, None)
+        gitignore_issues = [i for i in issues if "gitignore" in i.message.lower()]
+        assert len(gitignore_issues) >= 1
+        for i in gitignore_issues:
+            assert i.severity == "error"
+
+    def test_tc2_healthy_project_no_gitignore_issues(self, tmp_path):
+        _write_tier_a(tmp_path)
+        issues = run_project_health_checks(tmp_path, None, None)
+        gitignore_issues = [i for i in issues if "gitignore" in i.message.lower()]
+        assert len(gitignore_issues) == 0
+
+    def test_tc3_tracked_set_ignored_error(self, tmp_path):
+        root = tmp_path / ".gitignore"
+        root.write_text("beacon.yaml\n")
+        _write_tier_a(tmp_path)
+        issues = run_project_health_checks(tmp_path, None, None)
+        tracked_issues = [i for i in issues if "tracked" in i.message.lower()]
+        assert len(tracked_issues) >= 1
+        for i in tracked_issues:
+            assert i.severity == "error"
+
+    def test_tier_a_missing_while_tier_b_present(self, tmp_path):
+        (tmp_path / ".opencode").mkdir()
+        apply_managed_block(
+            tmp_path / ".opencode" / ".gitignore", TIER_B_OPENCODE_ENTRIES
+        )
+        issues = run_project_health_checks(tmp_path, None, None)
+        gitignore_issues = [i for i in issues if "gitignore" in i.message.lower()]
+        tier_a_issues = [i for i in gitignore_issues if "Tier A" in i.message]
+        assert len(tier_a_issues) >= 1
+        assert tier_a_issues[0].severity == "error"
+
+
+class TestDoctorFix:
+    def test_tc1_fix_repairs_drift(self, tmp_path):
+        (tmp_path / ".opencode").mkdir()
+        apply_managed_block(
+            tmp_path / ".opencode" / ".gitignore", TIER_B_OPENCODE_ENTRIES
+        )
+
+        from beacon.core.gitignore import apply_all_gitignores
+
+        apply_all_gitignores(tmp_path)
+
+        drifts_before = len(
+            [
+                i
+                for i in run_project_health_checks(tmp_path, None, None)
+                if "gitignore" in i.message.lower()
+            ]
+        )
+        assert drifts_before == 0, "apply_all_gitignores should fix drift"
+
+    def test_tc2_healthy_no_spurious_fix(self, tmp_path):
+        from beacon.core.gitignore import apply_all_gitignores, diff_gitignores
+
+        apply_all_gitignores(tmp_path)
+        drifts = diff_gitignores(tmp_path)
+        assert len(drifts) == 0
+
+    def test_tc3_fix_then_clean(self, tmp_path):
+        from beacon.core.gitignore import apply_all_gitignores, diff_gitignores
+
+        apply_all_gitignores(tmp_path)
+        drifts = diff_gitignores(tmp_path)
+        assert len(drifts) == 0

--- a/libs/beacon/tests/unit/test_doctor_gitignore.py
+++ b/libs/beacon/tests/unit/test_doctor_gitignore.py
@@ -176,3 +176,43 @@ class TestDoctorFix:
         apply_all_gitignores(tmp_path)
         drifts_first = diff_gitignores(tmp_path)
         assert len(drifts_first) == 0
+
+    # ── FIX F: doctor --fix gated to wired projects ──
+
+    def test_unwired_project_fix_does_not_touch_gitignore(self, tmp_path, monkeypatch):
+        """doctor --fix on unwired project must not create/modify .gitignore."""
+        import beacon.cli.diagnostics
+        from beacon.core.gitignore import MANAGED_BLOCK_BEGIN
+
+        (tmp_path / ".agentic-beacon").mkdir()
+        gitignore = tmp_path / ".gitignore"
+        gitignore.write_text("my-custom-entry/\n")
+        mtime_before = gitignore.stat().st_mtime
+        content_before = gitignore.read_bytes()
+
+        monkeypatch.setattr(
+            beacon.cli.diagnostics, "find_project_root", lambda: tmp_path
+        )
+        beacon.cli.diagnostics.doctor.callback(fix=True)
+
+        assert gitignore.stat().st_mtime == mtime_before
+        assert gitignore.read_bytes() == content_before
+        assert MANAGED_BLOCK_BEGIN not in gitignore.read_text()
+
+    def test_wired_project_fix_repairs_drift(self, tmp_path, monkeypatch):
+        """doctor --fix on wired project with drift repairs .gitignore."""
+        import beacon.cli.diagnostics
+        from beacon.core.gitignore import MANAGED_BLOCK_BEGIN
+
+        _make_wired(tmp_path)
+        gitignore = tmp_path / ".gitignore"
+        gitignore.write_text("user-entry/\n")
+
+        monkeypatch.setattr(
+            beacon.cli.diagnostics, "find_project_root", lambda: tmp_path
+        )
+        beacon.cli.diagnostics.doctor.callback(fix=True)
+
+        content = gitignore.read_text()
+        assert MANAGED_BLOCK_BEGIN in content
+        assert "user-entry/" in content

--- a/libs/beacon/tests/unit/test_doctor_gitignore.py
+++ b/libs/beacon/tests/unit/test_doctor_gitignore.py
@@ -16,6 +16,7 @@ from beacon.core.gitignore import (
     apply_managed_block,
 )
 from beacon.domains.setup.diagnostics import (
+    repair_gitignore_drift,
     run_project_health_checks,
 )
 
@@ -216,3 +217,75 @@ class TestDoctorFix:
         content = gitignore.read_text()
         assert MANAGED_BLOCK_BEGIN in content
         assert "user-entry/" in content
+
+
+# ── FIX H: repair_gitignore_drift (extracted domain op) ──
+
+
+class TestRepairGitignoreDrift:
+    def test_wired_drifted_project_repairs_and_returns_msgs(self, tmp_path):
+        _make_wired(tmp_path)
+        (tmp_path / ".opencode").mkdir()
+        apply_managed_block(
+            tmp_path / ".opencode" / ".gitignore", TIER_B_OPENCODE_ENTRIES
+        )
+        msgs = repair_gitignore_drift(tmp_path)
+        assert len(msgs) >= 1
+        assert "Repaired" in msgs[0]
+        from beacon.core.gitignore import diff_gitignores
+
+        remaining = diff_gitignores(tmp_path)
+        managed = [
+            d
+            for d in remaining
+            if d.kind
+            in {
+                "tier_a_missing",
+                "tier_a_incomplete",
+                "tier_b_missing",
+                "tier_b_incomplete",
+            }
+        ]
+        assert len(managed) == 0, (
+            f"Managed-block drift should be repaired, got: {[d.message for d in managed]}"
+        )
+
+    def test_wired_healthy_returns_empty(self, tmp_path):
+        from beacon.core.gitignore import apply_all_gitignores
+
+        _make_wired(tmp_path)
+        apply_all_gitignores(tmp_path)
+        msgs = repair_gitignore_drift(tmp_path)
+        assert msgs == []
+
+    def test_unwired_returns_empty_no_write(self, tmp_path):
+        msgs = repair_gitignore_drift(tmp_path)
+        assert msgs == []
+        gitignore = tmp_path / ".gitignore"
+        assert not gitignore.exists()
+
+    def test_stale_summary_regression(self, tmp_path):
+        _make_wired(tmp_path)
+        repair_gitignore_drift(tmp_path)
+        issues = run_project_health_checks(tmp_path, None, None)
+        managed_issues = [
+            i
+            for i in issues
+            if "gitignore" in i.message.lower()
+            and ("Tier A" in i.message or "Tier B" in i.message)
+        ]
+        assert len(managed_issues) == 0, (
+            f"After repair, managed-block drift must not appear in health checks: "
+            f"{[i.message for i in managed_issues]}"
+        )
+
+    def test_tracked_set_ignored_not_repaired_by_domain_op(self, tmp_path):
+        _make_wired(tmp_path)
+        _git_init(tmp_path)
+        root = tmp_path / ".gitignore"
+        root.write_text(".agentic-beacon/beacon.yaml\n")
+        from beacon.core.gitignore import apply_all_gitignores
+
+        apply_all_gitignores(tmp_path)
+        msgs = repair_gitignore_drift(tmp_path)
+        assert msgs == [], "tracked_set_ignored alone must not trigger repair"

--- a/libs/beacon/tests/unit/test_doctor_gitignore.py
+++ b/libs/beacon/tests/unit/test_doctor_gitignore.py
@@ -4,8 +4,10 @@ Covers:
 - Drifted project → DoctorIssue with severity 'error'
 - Healthy project → no gitignore DoctorIssue
 - Tracked-set file ignored → error
+- --fix correctly splits managed vs tracked-set drifts
 """
 
+import subprocess
 from pathlib import Path
 
 from beacon.core.gitignore import (
@@ -16,6 +18,22 @@ from beacon.core.gitignore import (
 from beacon.domains.setup.diagnostics import (
     run_project_health_checks,
 )
+
+
+def _git_init(path):
+    subprocess.run(["git", "init", "-q", str(path)], check=False)
+    subprocess.run(
+        ["git", "config", "user.email", "test@test.com"],
+        cwd=path,
+        check=False,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test"],
+        cwd=path,
+        check=False,
+        capture_output=True,
+    )
 
 
 def _write_tier_a(tmp_path: Path, entries: list[str] | None = None) -> None:
@@ -44,6 +62,7 @@ class TestDoctorGitignoreDetection:
         assert len(gitignore_issues) == 0
 
     def test_tc3_tracked_set_ignored_error(self, tmp_path):
+        _git_init(tmp_path)
         root = tmp_path / ".gitignore"
         root.write_text("beacon.yaml\n")
         _write_tier_a(tmp_path)
@@ -98,3 +117,25 @@ class TestDoctorFix:
         apply_all_gitignores(tmp_path)
         drifts = diff_gitignores(tmp_path)
         assert len(drifts) == 0
+
+    def test_tracked_set_ignored_not_repaired(self, tmp_path):
+        """tracked_set_ignored drift must NOT be repaired by apply_all_gitignores."""
+        _git_init(tmp_path)
+        root = tmp_path / ".gitignore"
+        root.write_text(".agentic-beacon/beacon.yaml\n")
+        from beacon.core.gitignore import apply_all_gitignores, diff_gitignores
+
+        apply_all_gitignores(tmp_path)
+        drifts = diff_gitignores(tmp_path)
+        kinds = {d.kind for d in drifts}
+        assert "tracked_set_ignored" in kinds, (
+            "tracked_set_ignored drift must persist after fix"
+        )
+
+    def test_managed_only_fix_is_clean(self, tmp_path):
+        """Managed-block-only drift IS repaired by apply_all_gitignores."""
+        from beacon.core.gitignore import apply_all_gitignores, diff_gitignores
+
+        apply_all_gitignores(tmp_path)
+        drifts_first = diff_gitignores(tmp_path)
+        assert len(drifts_first) == 0

--- a/libs/beacon/tests/unit/test_doctor_gitignore.py
+++ b/libs/beacon/tests/unit/test_doctor_gitignore.py
@@ -46,8 +46,18 @@ def _write_tier_b(tmp_path: Path, tool_dir: str, entries: list[str]) -> None:
     apply_managed_block(d / ".gitignore", entries)
 
 
+def _make_wired(project_root):
+    """Create .agentic-beacon/beacon.yaml so the project appears Beacon-wired."""
+    d = project_root / ".agentic-beacon"
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "beacon.yaml").write_text(
+        "artifacts:\n  contexts: []\n  skills: []\n  agents: []\n"
+    )
+
+
 class TestDoctorGitignoreDetection:
     def test_tc1_drifted_project_returns_error(self, tmp_path):
+        _make_wired(tmp_path)
         _write_tier_b(tmp_path, ".opencode", TIER_B_OPENCODE_ENTRIES)
         issues = run_project_health_checks(tmp_path, None, None)
         gitignore_issues = [i for i in issues if "gitignore" in i.message.lower()]
@@ -62,6 +72,7 @@ class TestDoctorGitignoreDetection:
         assert len(gitignore_issues) == 0
 
     def test_tc3_tracked_set_ignored_error(self, tmp_path):
+        _make_wired(tmp_path)
         _git_init(tmp_path)
         root = tmp_path / ".gitignore"
         root.write_text("beacon.yaml\n")
@@ -73,6 +84,7 @@ class TestDoctorGitignoreDetection:
             assert i.severity == "error"
 
     def test_tier_a_missing_while_tier_b_present(self, tmp_path):
+        _make_wired(tmp_path)
         (tmp_path / ".opencode").mkdir()
         apply_managed_block(
             tmp_path / ".opencode" / ".gitignore", TIER_B_OPENCODE_ENTRIES
@@ -82,6 +94,30 @@ class TestDoctorGitignoreDetection:
         tier_a_issues = [i for i in gitignore_issues if "Tier A" in i.message]
         assert len(tier_a_issues) >= 1
         assert tier_a_issues[0].severity == "error"
+
+    def test_unwired_project_returns_no_drift(self, tmp_path):
+        """No .agentic-beacon/beacon.yaml → _check_gitignore_drift returns [].
+
+        Even if the project's .gitignore lacks a managed block.
+        """
+        issues = run_project_health_checks(tmp_path, None, None)
+        gitignore_issues = [i for i in issues if "gitignore" in i.message.lower()]
+        assert len(gitignore_issues) == 0, (
+            f"Expected no gitignore issues for unwired project, got: {gitignore_issues}"
+        )
+
+    def test_wired_project_still_reports_drift(self, tmp_path):
+        """Wired project with drift still reports gitignore issues."""
+        _make_wired(tmp_path)
+        (tmp_path / ".opencode").mkdir()
+        apply_managed_block(
+            tmp_path / ".opencode" / ".gitignore", TIER_B_OPENCODE_ENTRIES
+        )
+        issues = run_project_health_checks(tmp_path, None, None)
+        gitignore_issues = [i for i in issues if "gitignore" in i.message.lower()]
+        assert len(gitignore_issues) >= 1, (
+            "Expected gitignore drift for wired project with missing Tier A"
+        )
 
 
 class TestDoctorFix:
@@ -120,6 +156,7 @@ class TestDoctorFix:
 
     def test_tracked_set_ignored_not_repaired(self, tmp_path):
         """tracked_set_ignored drift must NOT be repaired by apply_all_gitignores."""
+        _make_wired(tmp_path)
         _git_init(tmp_path)
         root = tmp_path / ".gitignore"
         root.write_text(".agentic-beacon/beacon.yaml\n")

--- a/openspec/changes/ab-94-managed-gitignore/.openspec.yaml
+++ b/openspec/changes/ab-94-managed-gitignore/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-19

--- a/openspec/changes/ab-94-managed-gitignore/design.md
+++ b/openspec/changes/ab-94-managed-gitignore/design.md
@@ -1,0 +1,123 @@
+# Design — Managed-block gitignore engine (AB-94)
+
+## Context
+
+Gitignore ownership is currently spread across three mechanisms with three gating rules, and the `abc adopt` path skips Tier A entirely (it calls `sync_engine.sync_all(...)` directly rather than `run_sync`, so the orchestrator's `GitignoreManager(project_root).ensure_entries()` never runs). The result is drift: Tier B nested `.gitignore`s get written while the Tier A root block does not, leaving the whole `.claude/`/`.opencode/`/`.agentic-beacon/` scaffold un-ignored. `abc doctor --fix` is a stub. This design consolidates all of it into one engine with a marker-delimited, wholesale-regenerated managed block, invoked from every wiring path, plus a doctor check that detects and repairs drift.
+
+The grill resolved five decisions (see "Resolved decisions" below): a single managed BEGIN/END block regenerated wholesale; **all Tier A lines unconditional** (agent dirs folded in, prune retired); **surgical** legacy migration; doctor **error** + **real `--fix`** via the shared writer; and **full unification** — Tier B folded into the same engine.
+
+## Resolved decisions
+
+1. **Ownership model** — a single managed block delimited by `# >>> Agentic Beacon (managed) >>>` … `# <<< Agentic Beacon (managed) <<<`, regenerated wholesale each run, written by one engine called from every wiring path. Chosen over minimal per-line append because only wholesale regeneration lets the entry set evolve and lets existing repos self-heal; it also makes `doctor --fix` trivial (same writer).
+2. **Gating — all Tier A lines unconditional.** The block always lists the full set regardless of tool-dir presence or declared agents. This retires the "only when agents declared" conditioning **and** the `prune_agent_dirs_gitignore_entries` path. Rationale: deterministic, tool-presence-independent output that is trivial to verify; a `.claude/skills/` line in a repo without `.claude/` is harmless. (Note: this intentionally departs from the ticket's "dir-gated" wording, per the grill.)
+3. **Migration — surgical.** On first meeting a legacy loose-line `# Agentic Beacon` region: insert the managed block, dedup exact managed lines, drop the emptied legacy bare header, preserve every non-managed line. Never delete a line we don't own. Idempotent.
+4. **Doctor — error severity + real `--fix`.** A new drift check reports at `error`; `--fix` calls the same engine and populates `fixes_applied` (Beacon's first working `--fix`).
+5. **Scope — full unification.** Tier B nested `.gitignore`s are folded into the same managed-block engine. Their **entry sets are preserved exactly** from today's constants and locked by regression tests (the risk being folding already-working code into the new engine).
+
+## Architecture — where the code lives
+
+Gitignore ownership is now genuinely **cross-domain** (consumed by distribution/sync, adoption/adopt, warehouse/connect, and setup/doctor). Therefore the full policy **and** mechanism live in `core/gitignore.py`, promoted to the single source of truth. This **supersedes** the earlier decision that kept `CLAUDE_DIR_GITIGNORE_ENTRIES` / `OPENCODE_DIR_GITIGNORE_ENTRIES` local to the distribution orchestrator (those constants move into core). `core/` importing nothing from `domains/` is preserved — the engine takes a `project_root: Path` and works purely on the filesystem.
+
+```
+core/gitignore.py  (mechanism + policy — the single source of truth)
+├── managed-block markers (BEGIN/END constants)
+├── TIER_A_ENTRIES            (unconditional root set — 10 lines)
+├── TIER_B_CLAUDE_ENTRIES     (skills/, scheduled_tasks.lock, worktrees/)
+├── TIER_B_OPENCODE_ENTRIES   (skills/, command/, bun.lock, package.json, package-lock.json, node_modules/)
+├── TRACKED_ON_PURPOSE        (beacon.yaml, nested .gitignores, CLAUDE.md, opencode.json, .worktreeinclude)
+├── apply_managed_block(gitignore_path, entries)   # write/regenerate one block + surgical migration
+├── read_managed_block(gitignore_path) -> list[str] | None
+├── apply_all_gitignores(project_root)             # Tier A (root, unconditional) + Tier B (nested, dir-gated by file location)
+└── diff_gitignores(project_root) -> list[GitignoreDrift]   # expected vs actual, for doctor (read-only)
+
+consumers (all call apply_all_gitignores / diff_gitignores):
+├── domains/distribution/orchestrator.py  run_sync   → apply_all_gitignores
+├── domains/adoption/apply.py             accept path → apply_all_gitignores   (FIXES THE BUG)
+├── domains/warehouse/connector.py        connect     → apply_all_gitignores
+└── domains/setup/diagnostics.py          doctor      → diff_gitignores (check) ; cli/diagnostics.py --fix → apply_all_gitignores
+```
+
+Removed: `domains/artifact/agent.py::ensure_agent_dirs_gitignored` and `::prune_agent_dirs_gitignore_entries`; the `CLAUDE_DIR_/OPENCODE_DIR_GITIGNORE_ENTRIES` constants and conditional gitignore blocks in `orchestrator.py`; the conditional `ensure_agent_dirs_gitignored` call in `apply.py`. `GitignoreManager`'s existing `ensure_entries`/`remove_entries`/`verify_beacon_yaml_not_ignored` may be retained for backward-compat callers or refactored into the engine — the tracked-set assertion extends `verify_beacon_yaml_not_ignored` to `TRACKED_ON_PURPOSE`.
+
+## Managed block — exact shape
+
+Root `.gitignore` (Tier A, always all lines):
+
+```
+# >>> Agentic Beacon (managed) >>>
+.agentic-beacon/config.toml
+.agentic-beacon/artifacts/
+.agentic-beacon/warehouse-catalog.md
+.agentic-beacon/pending.yaml
+.claude/skills/
+.claude/commands/
+.claude/agents/
+.opencode/skills/
+.opencode/command/
+.opencode/agents/
+# <<< Agentic Beacon (managed) <<<
+```
+
+Nested `.claude/.gitignore` (Tier B, written only if `.claude/` exists):
+
+```
+# >>> Agentic Beacon (managed) >>>
+skills/
+scheduled_tasks.lock
+worktrees/
+# <<< Agentic Beacon (managed) <<<
+```
+
+Nested `.opencode/.gitignore` (Tier B, written only if `.opencode/` exists):
+
+```
+# >>> Agentic Beacon (managed) >>>
+skills/
+command/
+bun.lock
+package.json
+package-lock.json
+node_modules/
+# <<< Agentic Beacon (managed) <<<
+```
+
+## Algorithms
+
+### `apply_managed_block(path, entries)`
+
+1. Read the file (empty string if absent).
+2. If a managed block (BEGIN/END markers) exists → replace its body with `entries` verbatim; leave everything else byte-identical. Return.
+3. Else (surgical migration): drop any loose line that exactly equals a member of `entries`; if a bare legacy `# Agentic Beacon` header line remains with no owned lines beneath it in its region, drop that header; append the managed block. Preserve all other lines and their order.
+4. Write only if content changed (idempotency). Preserve trailing-newline shape.
+
+### `apply_all_gitignores(project_root)`
+
+- Tier A: `apply_managed_block(project_root/".gitignore", TIER_A_ENTRIES)` — always.
+- Tier B: if `(project_root/".claude").is_dir()` → `apply_managed_block(project_root/".claude/.gitignore", TIER_B_CLAUDE_ENTRIES)`; same for `.opencode/`.
+- Guarded by `if not dry_run` at each call site, matching existing sync semantics.
+
+### `diff_gitignores(project_root)` (doctor, read-only)
+
+Returns drift records for: Tier A block missing/incomplete; a nested Tier B block missing/incomplete while its tool dir exists; any `TRACKED_ON_PURPOSE` file currently git-ignored. Doctor renders each as an `error`. `--fix` = `apply_all_gitignores(project_root)` then record fixes.
+
+## Edge cases
+
+- **No `.gitignore`** → created with just the managed block (Tier A always; Tier B when dir exists).
+- **Managed block present but body stale/reordered** → body regenerated to canonical order; markers preserved.
+- **Legacy header with mixed owned + unknown lines** (this repo: `.claude/scheduled_tasks.lock`, `.agentic-beacon/.legacy-migrated`, `sample-warehouse/`, scattered `.claude/agents/`) → managed lines deduped, unknowns preserved, bare legacy header dropped.
+- **User manually added a managed marker** → treated as the managed block and regenerated (documented; markers are Beacon-owned).
+- **Tracked set safety** → Tier A ignores subpaths only, never whole `.claude/`/`.opencode/`, so `CLAUDE.md`, `opencode.json`, `.worktreeinclude`, `beacon.yaml`, and nested `.gitignore`s are never caught. Asserted by the doctor tracked-set check.
+
+## Testing strategy
+
+- **Engine unit tests**: fresh-file creation; wholesale regen replaces stale body; idempotent re-apply (byte-equal); surgical migration dedups managed + preserves unknowns + drops bare legacy header; migration no-op on 2nd run; unconditional Tier A set present without tool dirs / without declared agents.
+- **Tier B regression lock**: exact `.claude/.gitignore` and `.opencode/.gitignore` entry sets and dir-gating unchanged from prior behavior (guards the fold-into-engine risk).
+- **Path coverage**: adopt-accept writes Tier A (the regression that would have caught the original bug) + nested Tier B; sync writes both tiers; connect routes through the engine.
+- **Doctor**: detects Tier-A-missing-while-Tier-B-present; healthy project → no drift; tracked-set-ignored → error; `--fix` repairs and re-run is clean.
+- **Architecture test** (`tests/unit/test_architecture.py`) still passes — `core/` imports no `domains/`.
+
+## Out of scope
+
+- Changing Tier B **entry contents** (only the writing mechanism changes; contents preserved).
+- Reconciling the pre-existing doc-vs-code drift in the Tier B set beyond preserving current code behavior (possible follow-up).
+- Any warehouse or cross-repo work.

--- a/openspec/changes/ab-94-managed-gitignore/proposal.md
+++ b/openspec/changes/ab-94-managed-gitignore/proposal.md
@@ -1,0 +1,39 @@
+## Why
+
+Beacon owning a wired repo's `.gitignore` is currently a fragmented, drift-prone side effect rather than a guaranteed capability. The evidence (AB-94, found onboarding **agentic-conductor** during HARN-65): `abc adopt`/`abc sync` had emitted the **Tier B** nested `.gitignore` files — which even reference "the root .gitignore (Tier A)" in their own comments — but the **Tier A** block was never written to the root `.gitignore`. The whole `.claude/`, `.opencode/`, `.agentic-beacon/` scaffold showed as untracked and nothing Beacon-owned was actually ignored; a naive `git add -A` would have committed `artifacts/`, symlinks, `node_modules/`, and lockfiles.
+
+Root cause: gitignore ownership is spread across three mechanisms with three different gating rules, and one whole entry point skips Tier A entirely.
+
+- Tier A base entries (`config.toml`, `artifacts/`, `pending.yaml`) are written by `GitignoreManager.ensure_entries()` **only on the `run_sync` path** — `abc adopt` calls `sync_engine.sync_all(...)` directly and never runs it.
+- `warehouse-catalog.md` and the beacon-owned symlink dirs (`.claude/skills|commands/`, `.opencode/skills|command/`) are **never written to the root** at all.
+- Agent dirs (`.claude/agents/`, `.opencode/agents/`) are written by `ensure_agent_dirs_gitignored` **only when agents are declared**, and pruned otherwise.
+- Entries are appended **per-line with no end marker**, so a legacy/partial block can never self-heal, and `abc doctor --fix` is a **no-op stub** (`fixes_applied` is never populated).
+
+This change reframes gitignore ownership from "a bug to patch once" into a first-class Beacon capability: after `abc adopt`/`abc sync`, a wired repo is **guaranteed** to have both gitignore tiers present and correct, and `abc doctor` surfaces (and `--fix` repairs) drift on repos that already exist.
+
+## What Changes
+
+- **One managed-block gitignore engine** in `core/gitignore.py`, promoted to the single cross-domain source of truth for Beacon gitignore ownership. It writes a **marker-delimited managed block** (`# >>> Agentic Beacon (managed) >>>` … `# <<< Agentic Beacon (managed) <<<`) that is **regenerated wholesale** on every run. Both tiers flow through this one engine.
+  - **Tier A** (root `.gitignore`) — every managed line is written **unconditionally** (independent of which tool dirs exist): `.agentic-beacon/{config.toml, artifacts/, warehouse-catalog.md, pending.yaml}` + `.claude/{skills,commands,agents}/` + `.opencode/{skills,command,agents}/`.
+  - **Tier B** (nested `.claude/.gitignore`, `.opencode/.gitignore`) — **folded into the same engine** (full unification). The nested files still materialize only when their tool dir exists (inherent — the file lives inside it); the **entry sets are preserved exactly** from today's `CLAUDE_DIR_GITIGNORE_ENTRIES` / `OPENCODE_DIR_GITIGNORE_ENTRIES` and locked by regression tests.
+- **Single writer, called from every wiring path** — `run_sync`, `abc adopt` (the path that skipped Tier A — the reported bug), and `abc warehouse connect`. All three converge on the same managed-block application, so no path can emit one tier without the other.
+- **Retire the conditional agent-dir logic** — `ensure_agent_dirs_gitignored` / `prune_agent_dirs_gitignore_entries` and the "only when agents declared" gating are removed; agent dirs are just three more unconditional lines in the Tier A block.
+- **Surgical, idempotent migration** — when the engine first meets a legacy loose-line `# Agentic Beacon` region, it inserts the managed block, removes any loose line that exactly matches a managed entry (no double-ignore), drops the now-empty legacy bare header, and **preserves every non-managed line** (`.legacy-migrated`, `sample-warehouse/`, user lines). Re-runs are no-ops.
+- **`abc doctor` gitignore-drift check (severity: error)** — flags a wired repo whose Tier A managed block is missing/incomplete, whose Tier B nested block is missing/incomplete when the tool dir exists (directly catching the reported "Tier B present, Tier A absent" case from both sides), or whose tracked-on-purpose set (`beacon.yaml`, both nested `.gitignore`s, `CLAUDE.md`, `opencode.json`, `.worktreeinclude`) is ignored.
+- **`abc doctor --fix` becomes real** — it calls the same managed-block engine to repair Tier A and Tier B in place and records the repairs in `fixes_applied`. This is Beacon's first working `--fix`.
+
+## Capabilities
+
+### New Capabilities
+- `beacon-gitignore-management`: the managed-block gitignore engine and its ownership contract — the marker-delimited managed block, wholesale regeneration, the two tiers and their (unconditional Tier A / preserved Tier B) entry sets, the surgical migration of legacy loose-line blocks, the single-writer-called-from-every-wiring-path guarantee, the tracked-on-purpose set that must stay visible, and the `abc doctor` drift check + real `--fix`.
+
+### Modified Capabilities
+- `project-agent-wiring`: the "abc setup adds agent directories to .gitignore" requirement is superseded — agent dirs (`.claude/agents/`, `.opencode/agents/`) are now owned unconditionally by the Tier A managed block rather than gated on declared agents, and the `update_agent_gitignores` / prune-on-empty behavior is removed.
+
+## Impact
+
+- **Code**: `core/gitignore.py` (managed-block engine: apply/read/migrate + expected-vs-actual diff; Tier A + Tier B entry-set constants promoted here from the distribution orchestrator); `domains/distribution/orchestrator.py` (call the unified engine; remove `CLAUDE_DIR_GITIGNORE_ENTRIES` / `OPENCODE_DIR_GITIGNORE_ENTRIES` and the conditional agent-dir calls); `domains/adoption/apply.py` (invoke the unified engine on the adopt path — fixes the bug); `domains/warehouse/connector.py` (route through the engine); `domains/artifact/agent.py` (retire `ensure_agent_dirs_gitignored` / `prune_agent_dirs_gitignore_entries`); `domains/setup/diagnostics.py` (gitignore-drift check); `cli/diagnostics.py` (wire real `--fix`).
+- **Behavior**: every beacon-wired repo converges on the same two-tier managed gitignore after any `adopt`/`sync`/`connect`; agent dirs are ignored whether or not agents are currently declared; existing repos with legacy blocks self-heal on next run or via `abc doctor --fix`.
+- **Tests**: unit tests for the engine (wholesale regen idempotency, surgical migration preserving unknowns, unconditional Tier A set, Tier B entry-set regression lock), doctor drift-detection + `--fix` repair, and the adopt-path Tier A coverage that would have caught the original bug.
+- **Docs**: `beacon-ops.md` two-tier gitignore section + `AGENTS.md` reflect the managed-block engine and the unconditional/dir-gating decision.
+- **Scope**: single repo (`agentic-beacon`). No warehouse or cross-repo work. Review-flagged (core `adopt`/`sync`/`connect` path, high blast radius across every wired repo).

--- a/openspec/changes/ab-94-managed-gitignore/specs/beacon-gitignore-management/spec.md
+++ b/openspec/changes/ab-94-managed-gitignore/specs/beacon-gitignore-management/spec.md
@@ -1,0 +1,123 @@
+## ADDED Requirements
+
+### Requirement: Managed-block gitignore engine
+
+Beacon SHALL own its `.gitignore` entries through a single managed block delimited by the exact markers `# >>> Agentic Beacon (managed) >>>` (begin) and `# <<< Agentic Beacon (managed) <<<` (end). On every application the engine SHALL regenerate the block's body **wholesale** from the current entry set — it SHALL NOT append entries line by line. Applying the engine SHALL be idempotent: re-running it against a file that already holds the correct managed block SHALL make no change.
+
+#### Scenario: Block created in a fresh .gitignore
+
+- **GIVEN** a project whose root `.gitignore` has no managed block (or no `.gitignore` at all)
+- **WHEN** the engine applies the Tier A entry set
+- **THEN** the file contains exactly one managed block, delimited by the begin/end markers, listing every Tier A entry
+
+#### Scenario: Wholesale regeneration replaces stale body
+
+- **GIVEN** a managed block whose body is missing one required entry
+- **WHEN** the engine re-applies the current entry set
+- **THEN** the block body is replaced with the full current entry set, the markers are unchanged, and content outside the block is untouched
+
+#### Scenario: Idempotent re-application
+
+- **GIVEN** a `.gitignore` already holding the correct managed block
+- **WHEN** the engine applies the same entry set again
+- **THEN** the file bytes are unchanged
+
+### Requirement: Tier A entry set is unconditional
+
+The Tier A managed block in the project root `.gitignore` SHALL always contain the full entry set regardless of which tool directories exist: `.agentic-beacon/config.toml`, `.agentic-beacon/artifacts/`, `.agentic-beacon/warehouse-catalog.md`, `.agentic-beacon/pending.yaml`, `.claude/skills/`, `.claude/commands/`, `.claude/agents/`, `.opencode/skills/`, `.opencode/command/`, `.opencode/agents/`. Entries SHALL NOT be gated on the presence of `.claude/` or `.opencode/`, nor on whether agents are declared in `beacon.yaml`.
+
+#### Scenario: Full set written even without tool dirs
+
+- **GIVEN** a wired project that has neither `.claude/` nor `.opencode/` and declares no agents
+- **WHEN** the engine applies Tier A
+- **THEN** the managed block still contains all ten entries, including the `.claude/*` and `.opencode/*` symlink-dir lines
+
+#### Scenario: Agent dirs present without declared agents
+
+- **GIVEN** a wired project with an empty `beacon.yaml.artifacts.agents`
+- **WHEN** the engine applies Tier A
+- **THEN** `.claude/agents/` and `.opencode/agents/` are present in the managed block
+
+### Requirement: Tier B nested gitignores flow through the same engine
+
+The nested `.claude/.gitignore` and `.opencode/.gitignore` files SHALL be written as managed blocks by the same engine. A nested file SHALL be written only when its tool directory (`.claude/` or `.opencode/`) exists. The Tier B entry sets SHALL be preserved unchanged from the prior implementation: `.claude/.gitignore` = `skills/`, `scheduled_tasks.lock`, `worktrees/`; `.opencode/.gitignore` = `skills/`, `command/`, `bun.lock`, `package.json`, `package-lock.json`, `node_modules/`.
+
+#### Scenario: Nested block written when tool dir exists
+
+- **GIVEN** a project with a `.claude/` directory
+- **WHEN** the engine applies Tier B
+- **THEN** `.claude/.gitignore` contains a managed block listing exactly `skills/`, `scheduled_tasks.lock`, `worktrees/`
+
+#### Scenario: Nested block skipped when tool dir absent
+
+- **GIVEN** a project with no `.opencode/` directory
+- **WHEN** the engine applies Tier B
+- **THEN** no `.opencode/.gitignore` is created
+
+### Requirement: Surgical migration of legacy loose-line blocks
+
+When the engine first encounters a legacy `# Agentic Beacon` region (an unmanaged header followed by loose entry lines), it SHALL insert the managed block, remove any loose line that exactly matches a managed entry, drop the now-empty legacy bare header, and preserve every non-managed line in place. The engine SHALL NOT delete any line it does not own. Migration SHALL be idempotent.
+
+#### Scenario: Managed lines deduped, unknown lines preserved
+
+- **GIVEN** a root `.gitignore` with a legacy `# Agentic Beacon` header followed by `.agentic-beacon/config.toml`, `.agentic-beacon/artifacts/`, `.agentic-beacon/.legacy-migrated`, and `sample-warehouse/`
+- **WHEN** the engine applies Tier A
+- **THEN** the managed block is present, the two managed lines no longer appear as loose duplicates, the bare legacy `# Agentic Beacon` header is gone, and `.agentic-beacon/.legacy-migrated` and `sample-warehouse/` are still present
+
+#### Scenario: Migration is a no-op on second run
+
+- **GIVEN** a `.gitignore` already migrated to the managed block with preserved unknown lines
+- **WHEN** the engine applies the same entry set again
+- **THEN** the file is unchanged
+
+### Requirement: Every wiring path applies both tiers
+
+`abc sync` (`run_sync`), `abc adopt` (accept), and `abc warehouse connect` SHALL each apply the unified engine so that both tiers are written on every path. No wiring path SHALL emit one tier without the other.
+
+#### Scenario: Adopt writes Tier A (regression for the reported bug)
+
+- **GIVEN** a project being wired for the first time via `abc adopt` where accepted artifacts create `.claude/` and/or `.opencode/`
+- **WHEN** the adopt accept completes
+- **THEN** the root `.gitignore` contains the Tier A managed block AND the nested Tier B blocks exist for each present tool dir
+
+#### Scenario: Sync writes both tiers
+
+- **GIVEN** a wired project
+- **WHEN** `abc sync` runs
+- **THEN** the Tier A managed block and the nested Tier B managed blocks (for present tool dirs) are all present and current
+
+### Requirement: Tracked-on-purpose set stays visible
+
+The engine's entry sets SHALL never cause Beacon's tracked-on-purpose files to be ignored: `.agentic-beacon/beacon.yaml`, the nested `.claude/.gitignore` and `.opencode/.gitignore`, `CLAUDE.md`, `opencode.json`, and `.worktreeinclude`. Because Tier A ignores specific subpaths (never a whole `.claude/` or `.opencode/` directory), these files remain tracked.
+
+#### Scenario: beacon.yaml and configs not ignored
+
+- **GIVEN** a wired project with the full managed blocks applied
+- **WHEN** git evaluates ignore status for `.agentic-beacon/beacon.yaml`, `CLAUDE.md`, `opencode.json`, `.worktreeinclude`, and the nested `.gitignore` files
+- **THEN** none of them are ignored
+
+### Requirement: Doctor detects gitignore drift
+
+`abc doctor` SHALL report a gitignore-drift issue at severity **error** when a wired project's Tier A managed block is missing or incomplete, when a nested Tier B block is missing or incomplete while its tool dir exists, or when any tracked-on-purpose file is ignored. The specific reported case — a Tier B nested block present while the Tier A block is absent — SHALL be detected.
+
+#### Scenario: Tier A missing while Tier B present is flagged
+
+- **GIVEN** a wired project with a nested `.opencode/.gitignore` managed block but no Tier A managed block in the root `.gitignore`
+- **WHEN** `abc doctor` runs
+- **THEN** it reports a gitignore-drift error identifying the missing Tier A block
+
+#### Scenario: Healthy project reports no drift
+
+- **GIVEN** a wired project with correct Tier A and Tier B managed blocks
+- **WHEN** `abc doctor` runs
+- **THEN** no gitignore-drift issue is reported
+
+### Requirement: Doctor --fix repairs the drift
+
+`abc doctor --fix` SHALL repair detected gitignore drift by applying the same managed-block engine to the root and nested `.gitignore` files, and SHALL record each repair in the doctor's applied-fixes summary. A subsequent `abc doctor` run SHALL report no gitignore drift.
+
+#### Scenario: --fix rewrites the managed blocks
+
+- **GIVEN** a wired project flagged with gitignore drift
+- **WHEN** `abc doctor --fix` runs
+- **THEN** the Tier A and Tier B managed blocks are written correctly, the fix is listed in the applied-fixes summary, and a re-run of `abc doctor` reports no drift

--- a/openspec/changes/ab-94-managed-gitignore/specs/project-agent-wiring/spec.md
+++ b/openspec/changes/ab-94-managed-gitignore/specs/project-agent-wiring/spec.md
@@ -1,0 +1,28 @@
+## MODIFIED Requirements
+
+### Requirement: Agent directories are gitignored unconditionally via the managed block
+
+The prior behavior — `abc setup` / `abc sync` / `abc adopt` adding `.claude/agents/` and `.opencode/agents/` to the root `.gitignore` only when agents are declared, via the `update_agent_gitignores` / `ensure_agent_dirs_gitignored` helper, and pruning those entries when agents are removed — is superseded. Agent directories SHALL be owned by the Tier A managed block (see the `beacon-gitignore-management` capability) as unconditional entries. `abc sync`, `abc adopt` accept, and `abc warehouse connect` SHALL each write `.claude/agents/` and `.opencode/agents/` into the managed block regardless of whether any agent is declared in `beacon.yaml.artifacts.agents`. The agent-dir-specific helpers and the prune-on-empty behavior SHALL be removed.
+
+#### Scenario: Agent dirs ignored even with no agents declared
+
+- **GIVEN** a project with `beacon.yaml.artifacts.agents: []`
+- **WHEN** `abc sync` runs
+- **THEN** the root `.gitignore` managed block contains `.claude/agents/` and `.opencode/agents/`
+
+#### Scenario: Fresh project — .gitignore created with agent dirs in the block
+
+- **GIVEN** a project with no `.gitignore`
+- **WHEN** `abc sync` runs (with or without declared agents)
+- **THEN** a `.gitignore` is created whose managed block includes `.claude/agents/` and `.opencode/agents/`
+
+#### Scenario: Agent dirs are not pruned when agents are removed
+
+- **GIVEN** a wired project whose `beacon.yaml.artifacts.agents` is emptied
+- **WHEN** `abc sync` runs
+- **THEN** `.claude/agents/` and `.opencode/agents/` remain in the managed block (they are unconditional, not pruned)
+
+#### Scenario: Idempotent re-run
+
+- **WHEN** `abc sync` runs twice in sequence
+- **THEN** the agent entries appear exactly once, inside the single managed block

--- a/openspec/changes/ab-94-managed-gitignore/tasks.md
+++ b/openspec/changes/ab-94-managed-gitignore/tasks.md
@@ -1,0 +1,289 @@
+# Tasks — Managed-block gitignore engine (AB-94)
+
+<!-- opsx:tdd-header:begin -->
+## TDD WORKFLOW - MANDATORY FOR ALL TASKS
+
+**CRITICAL**: This project follows strict Test-Driven Development (TDD). Before implementing ANY task:
+
+### RED-GREEN-REFACTOR Cycle
+
+1. **RED Phase - Write Failing Tests FIRST**
+   - Read the task's TDD Test Cases (TC1-TCN)
+   - Create test file in `tests/` directory
+   - Write ALL test cases from the task BEFORE any implementation
+   - Run tests - they MUST fail (import errors, missing functions, etc.)
+   - If tests pass without implementation, you wrote the tests wrong!
+
+2. **GREEN Phase - Implement Minimal Code**
+   - Write ONLY enough code to make tests pass
+   - Run tests after each implementation
+   - All tests must pass before marking task complete
+
+3. **REFACTOR Phase - Improve Code Quality**
+   - Clean up implementation
+   - Remove duplication
+   - Improve naming
+   - Tests must still pass after refactoring
+
+### Task Completion Criteria
+
+**A task is NOT complete until:**
+- All TDD test cases are written
+- All tests pass (or are justifiably skipped with documentation)
+- Implementation matches the Expected Output
+- Test results documented in tasks.md
+
+**For skipped tests:**
+- Add `@pytest.mark.skip(reason="...")` with clear justification
+- Document in tasks.md under "Skipped Test Cases" section
+- Explain why feature is deferred and when it will be implemented
+
+### Test Organization
+
+```
+tests/
+├── core/           # Core module tests
+├── <module>/       # Module-specific tests
+└── conftest.py     # Shared fixtures
+```
+
+### Running Tests
+
+```bash
+# Activate venv, install dev deps, run tests
+source .venv/bin/activate
+uv sync --extra dev
+pytest tests/ -v --tb=short
+```
+
+**See Also:**
+- Check project AGENTS.md for unit testing workflow
+- Check knowledge base for TDD lessons and standards
+<!-- opsx:tdd-header:end -->
+
+<!-- opsx:repos-table:begin -->
+## Repositories & Branches
+
+| Repo | Path | Branch | Role |
+|------|------|--------|------|
+| `agentic-beacon` | `~/Code/oss/agentic-beacon` | `openspec/ab-94-managed-gitignore` | Code changes — managed-block gitignore engine in core/gitignore.py, rewiring sync/adopt/connect through it, retiring the conditional agent-dir helpers, doctor drift check + real --fix, and full unit/integration coverage + docs |
+<!-- opsx:repos-table:end -->
+
+
+## 1. Core engine (`core/gitignore.py`)
+
+<!-- opsx:phase-summary:1:begin -->
+**Goal**: Build the single cross-domain managed-block engine: marker-delimited block, wholesale regeneration, surgical migration, the two-tier entry sets, and a read-only drift diff — the source of truth every path and doctor will call.
+**Input**: Existing core/gitignore.py (GitignoreManager with per-line ensure_entries); Tier B constants currently in distribution/orchestrator.py.
+**Output**: core/gitignore.py exposes marker constants, TIER_A_ENTRIES / TIER_B_CLAUDE_ENTRIES / TIER_B_OPENCODE_ENTRIES / TRACKED_ON_PURPOSE, apply_managed_block, read_managed_block, apply_all_gitignores, and diff_gitignores. No imports from domains/.
+**Validation**: pytest tests/unit covering the engine passes; tests/unit/test_architecture.py confirms core imports no domains.
+<!-- opsx:phase-summary:1:end -->
+
+
+- [x] 1.1 Add managed-block markers and entry-set constants: `TIER_A_ENTRIES` (10 unconditional lines), `TIER_B_CLAUDE_ENTRIES`, `TIER_B_OPENCODE_ENTRIES`, `TRACKED_ON_PURPOSE`.
+- [x] 1.2 Implement `apply_managed_block(gitignore_path, entries)`: create/regenerate the marker-delimited block wholesale; idempotent; preserve trailing-newline shape.
+<!-- opsx:tdd:1.2:begin -->
+  - **Input**: pytest tests/unit/test_gitignore.py -k apply_managed_block -v
+  - **Expected Output**: Exit code 0; block written between '# >>> Agentic Beacon (managed) >>>' and '# <<< Agentic Beacon (managed) <<<'; second apply with same entries leaves bytes unchanged.
+  - **Validation**: Fresh-file, stale-body-regen, and idempotent-reapply cases all pass; trailing-newline shape preserved.
+  - **TDD Test Cases (write these first):**
+    - TC1: no .gitignore exists → file created containing exactly one managed block with all supplied entries
+    - TC2: managed block present with correct body → re-apply is byte-identical (idempotent)
+    - TC3: managed block present with a missing/extra/reordered entry → body regenerated to canonical set, markers unchanged, out-of-block content untouched
+    - TC4: file ends without trailing newline → block appended without corrupting the preceding line; newline shape preserved
+    - TC5: entries empty list → block contains only the two markers (no orphan lines)
+<!-- opsx:tdd:1.2:end -->
+- [x] 1.3 Implement surgical migration inside `apply_managed_block`: dedup exact managed lines from a legacy `# Agentic Beacon` region, drop the emptied bare legacy header, preserve all non-managed lines.
+<!-- opsx:tdd:1.3:begin -->
+  - **Input**: pytest tests/unit/test_gitignore.py -k migration -v
+  - **Expected Output**: Legacy loose managed lines removed; bare '# Agentic Beacon' header dropped; non-managed lines (.legacy-migrated, sample-warehouse/, user lines) retained; managed block appended once.
+  - **Validation**: No line the engine does not own is deleted; second run is a no-op.
+  - **TDD Test Cases (write these first):**
+    - TC1: legacy header + managed loose lines + unknown lines → managed lines deduped, unknown lines preserved in place, bare legacy header removed, block appended once
+    - TC2: legacy header whose ALL following lines are managed → header removed, no empty region left behind
+    - TC3: legacy header with a mix incl. scattered .claude/agents/ → agent-dir loose line deduped into the block, other lines preserved
+    - TC4: already-migrated file → second run makes no change (idempotent)
+    - TC5: unknown line equals a managed value only as a substring (not exact) → preserved (exact-match only)
+<!-- opsx:tdd:1.3:end -->
+- [x] 1.4 Implement `read_managed_block(gitignore_path)` and `apply_all_gitignores(project_root)` (Tier A always; Tier B per tool-dir existence).
+<!-- opsx:tdd:1.4:begin -->
+  - **Input**: pytest tests/unit/test_gitignore.py -k apply_all -v
+  - **Expected Output**: Root .gitignore always gets Tier A; .claude/.gitignore written iff .claude/ exists; .opencode/.gitignore written iff .opencode/ exists; read_managed_block returns the parsed entry list or None.
+  - **Validation**: Tier A unconditional; Tier B dir-gated by file location; read round-trips the written block.
+  - **TDD Test Cases (write these first):**
+    - TC1: project with neither tool dir → only root Tier A block written; no nested files created
+    - TC2: project with .claude/ only → root Tier A + .claude/.gitignore; no .opencode/.gitignore
+    - TC3: project with both tool dirs → root + both nested blocks
+    - TC4: read_managed_block on a file with no markers → returns None
+<!-- opsx:tdd:1.4:end -->
+- [x] 1.5 Implement `diff_gitignores(project_root)` returning drift records (Tier A missing/incomplete, Tier B missing/incomplete when dir exists, tracked-on-purpose file ignored); extend the tracked-set assertion to `TRACKED_ON_PURPOSE`.
+<!-- opsx:tdd:1.5:begin -->
+  - **Input**: pytest tests/unit/test_gitignore.py -k diff -v
+  - **Expected Output**: Returns [] for a healthy project; returns drift records identifying the specific tier/file for each defect; flags any TRACKED_ON_PURPOSE path that git would ignore.
+  - **Validation**: Read-only (no writes); the reported 'Tier B present, Tier A absent' case yields a Tier-A drift record.
+  - **TDD Test Cases (write these first):**
+    - TC1: healthy project (both tiers correct) → empty list
+    - TC2: nested .opencode/.gitignore present but root Tier A block absent → drift record naming missing Tier A
+    - TC3: Tier A block present but missing warehouse-catalog.md → incomplete-Tier-A drift record
+    - TC4: .claude/ exists but .claude/.gitignore missing → Tier B drift record
+    - TC5: .gitignore contains a line ignoring beacon.yaml / opencode.json → tracked-set drift record
+    - TC6: diff_gitignores makes no filesystem writes (assert mtime/bytes unchanged)
+<!-- opsx:tdd:1.5:end -->
+
+## 2. Wire every path to the engine
+
+<!-- opsx:phase-summary:2:begin -->
+**Goal**: Route sync, adopt-accept, and warehouse-connect through apply_all_gitignores so no path can emit one tier without the other, and delete the superseded fragmented mechanisms.
+**Input**: Phase 1 engine complete; current call sites in orchestrator.py:462/546/558, adoption/apply.py:294, warehouse/connector.py:47, artifact/agent.py.
+**Output**: All three wiring paths call apply_all_gitignores; CLAUDE_DIR_/OPENCODE_DIR_GITIGNORE_ENTRIES and ensure_agent_dirs_gitignored/prune_agent_dirs_gitignore_entries removed with their callers.
+**Validation**: grep confirms the deleted symbols have no remaining references; path-coverage tests (Phase 4) green.
+<!-- opsx:phase-summary:2:end -->
+
+
+- [x] 2.1 `domains/distribution/orchestrator.py::run_sync` — replace the `ensure_entries()` + conditional agent-dir + per-tool nested-gitignore blocks with a single `apply_all_gitignores(project_root)` call; delete `CLAUDE_DIR_GITIGNORE_ENTRIES` / `OPENCODE_DIR_GITIGNORE_ENTRIES`.
+- [x] 2.2 `domains/adoption/apply.py` — call `apply_all_gitignores(project_root)` on the accept path (fixes the Tier-A-skipped bug); remove the conditional `ensure_agent_dirs_gitignored` call.
+<!-- opsx:tdd:2.2:begin -->
+  - **Input**: pytest tests/unit -k adopt_gitignore -v (or the integration adopt test)
+  - **Expected Output**: After adopt-accept that materializes .claude/ and/or .opencode/, the root .gitignore contains the Tier A managed block AND nested Tier B blocks exist.
+  - **Validation**: This is the regression that would have caught the original agentic-conductor bug — Tier A must be present on the adopt path.
+  - **TDD Test Cases (write these first):**
+    - TC1: adopt-accept on a project with no prior .gitignore → Tier A block present after accept
+    - TC2: adopt-accept that creates .opencode/ → both Tier A and .opencode/.gitignore present (no Tier-B-without-Tier-A drift)
+<!-- opsx:tdd:2.2:end -->
+- [x] 2.3 `domains/warehouse/connector.py` — route `connect` through `apply_all_gitignores`.
+- [x] 2.4 `domains/artifact/agent.py` — remove `ensure_agent_dirs_gitignored` and `prune_agent_dirs_gitignore_entries`; update/remove their callers and imports.
+
+## 3. Doctor check + real `--fix`
+
+<!-- opsx:phase-summary:3:begin -->
+**Goal**: Surface gitignore drift as a doctor error and make --fix actually repair it via the shared engine — Beacon's first working --fix.
+**Input**: Phase 1 diff_gitignores; existing run_project_health_checks + DoctorIssue in setup/diagnostics.py and the --fix stub in cli/diagnostics.py.
+**Output**: abc doctor reports Tier A / Tier B / tracked-set drift at error severity; abc doctor --fix calls apply_all_gitignores and records repairs in fixes_applied.
+**Validation**: Doctor tests (Phase 4.5): drift flagged, healthy clean, --fix repairs, re-run clean.
+<!-- opsx:phase-summary:3:end -->
+
+
+- [x] 3.1 `domains/setup/diagnostics.py` — add a gitignore-drift check (error severity) using `diff_gitignores`; surface Tier A, Tier B, and tracked-set findings via `DoctorIssue`.
+<!-- opsx:tdd:3.1:begin -->
+  - **Input**: pytest tests/unit -k doctor_gitignore -v
+  - **Expected Output**: run_project_health_checks returns DoctorIssue(severity='err', ...) for each drift; none for a healthy project.
+  - **Validation**: Severity is error; messages identify the specific tier/file; the reported Tier-A-missing case is flagged.
+  - **TDD Test Cases (write these first):**
+    - TC1: drifted project → DoctorIssue with severity 'err' and a message naming the missing Tier A block
+    - TC2: healthy project → no gitignore DoctorIssue emitted
+    - TC3: tracked-set file ignored → error-severity DoctorIssue naming the file
+<!-- opsx:tdd:3.1:end -->
+- [x] 3.2 `cli/diagnostics.py` — implement real `--fix`: when drift is found and `--fix` is set, call `apply_all_gitignores` and append to `fixes_applied`.
+<!-- opsx:tdd:3.2:begin -->
+  - **Input**: abc doctor --fix in a drifted scratch project, then abc doctor
+  - **Expected Output**: First run reports drift and prints a fix in the applied-fixes summary; second run reports no gitignore drift.
+  - **Validation**: fixes_applied is non-empty on repair; repaired blocks match the engine output; re-run is clean.
+  - **TDD Test Cases (write these first):**
+    - TC1: drifted project + --fix → blocks repaired, fix recorded in fixes_applied, exit reflects repair
+    - TC2: healthy project + --fix → no fix recorded, no spurious write
+    - TC3: --fix then plain doctor → zero gitignore drift on the second run (idempotent repair)
+<!-- opsx:tdd:3.2:end -->
+
+## 4. Tests
+
+<!-- opsx:phase-summary:4:begin -->
+**Goal**: Lock the engine's behavior, the migration's non-destructiveness, the Tier B fold-in against regression, cross-path coverage (including the adopt bug), and the doctor flow.
+**Input**: Phases 1–3 implemented; pytest with tests/unit and tests/integration split.
+**Output**: New unit + integration tests covering engine, migration, Tier B lock, path coverage, doctor; architecture test still green.
+**Validation**: pytest tests/ green from repo root; BEACON_OFFLINE=1 respected for network-gated integration tests.
+<!-- opsx:phase-summary:4:end -->
+
+
+- [x] 4.1 Engine unit tests: fresh-file, wholesale regen of stale body, idempotent re-apply (byte-equal), unconditional Tier A set (no tool dirs / no declared agents).
+<!-- opsx:tdd:4.1:begin -->
+  - **Input**: pytest tests/unit/test_gitignore.py -v
+  - **Expected Output**: All engine cases pass; Tier A block contains all 10 entries even with no .claude//.opencode/ and empty agents.
+  - **Validation**: Zero failures; unconditional Tier A explicitly asserted.
+<!-- opsx:tdd:4.1:end -->
+- [x] 4.2 Migration unit tests: dedup managed + preserve unknowns + drop bare legacy header; no-op on 2nd run; realistic mixed legacy block.
+<!-- opsx:tdd:4.2:begin -->
+  - **Input**: pytest tests/unit/test_gitignore.py -k migration -v
+  - **Expected Output**: Realistic legacy block (like this repo's) migrates: managed lines deduped, .legacy-migrated / sample-warehouse/ preserved, header dropped; second run byte-identical.
+  - **Validation**: No non-managed line lost; idempotent.
+<!-- opsx:tdd:4.2:end -->
+- [x] 4.3 Tier B regression lock: exact `.claude/.gitignore` / `.opencode/.gitignore` entry sets + dir-gating unchanged.
+<!-- opsx:tdd:4.3:begin -->
+  - **Input**: pytest tests/unit -k tier_b -v
+  - **Expected Output**: .claude/.gitignore == {skills/, scheduled_tasks.lock, worktrees/}; .opencode/.gitignore == {skills/, command/, bun.lock, package.json, package-lock.json, node_modules/}; nested files only when dir exists.
+  - **Validation**: Entry sets match the pre-change constants exactly (guards the fold-into-engine risk).
+<!-- opsx:tdd:4.3:end -->
+- [x] 4.4 Path coverage: adopt-accept writes Tier A + Tier B; sync writes both; connect routes through engine.
+<!-- opsx:tdd:4.4:begin -->
+  - **Input**: pytest tests/ -k 'gitignore and (adopt or sync or connect)' -v
+  - **Expected Output**: Each of the three paths produces the correct Tier A + Tier B blocks; no path emits one tier without the other.
+  - **Validation**: adopt path asserts Tier A present (the original bug); all three paths converge to identical block output.
+<!-- opsx:tdd:4.4:end -->
+- [x] 4.5 Doctor tests: Tier-A-missing-while-Tier-B-present flagged; healthy → clean; tracked-set-ignored → error; `--fix` repairs and re-run is clean.
+<!-- opsx:tdd:4.5:begin -->
+  - **Input**: pytest tests/ -k doctor -v
+  - **Expected Output**: Drift detected at error severity for each defect; healthy project clean; --fix repairs and the re-run is clean.
+  - **Validation**: Covers detection, severity, tracked-set, and the real --fix repair loop.
+<!-- opsx:tdd:4.5:end -->
+- [x] 4.6 `tests/unit/test_architecture.py` still passes (core imports no domains).
+<!-- opsx:tdd:4.6:begin -->
+  - **Input**: pytest tests/unit/test_architecture.py -v
+  - **Expected Output**: Exit code 0 — core/gitignore.py (and the rest of core/) import nothing from domains/ or cli/.
+  - **Validation**: Architecture boundary intact after promoting the policy into core.
+<!-- opsx:tdd:4.6:end -->
+
+## 5. Docs
+
+<!-- opsx:phase-summary:5:begin -->
+**Goal**: Bring the two-tier gitignore documentation in line with the managed-block engine and the unconditional / doctor --fix behavior.
+**Input**: beacon-ops.md two-tier section and AGENTS.md references to the old per-line / conditional agent-dir behavior.
+**Output**: Docs describe the marker-delimited managed block, unconditional Tier A set, and abc doctor --fix.
+**Validation**: Manual read-through; abc warehouse lint clean on edited warehouse docs if applicable.
+<!-- opsx:phase-summary:5:end -->
+
+
+- [ ] 5.1 Update `beacon-ops.md` two-tier gitignore section: managed-block markers, unconditional Tier A, doctor `--fix`.
+- [x] 5.2 Update `AGENTS.md` if it references the old per-line / conditional agent-dir behavior.
+
+## 6. Validate & verify
+
+<!-- opsx:phase-summary:6:begin -->
+**Goal**: Prove the change end-to-end on a real scratch project, not just via unit tests.
+**Input**: All prior phases complete; a scratch project + the built abc CLI.
+**Output**: Verified happy path: adopt/sync produce correct blocks, doctor detects induced drift, --fix repairs it.
+**Validation**: pytest green; documented scratch-project walkthrough succeeds.
+<!-- opsx:phase-summary:6:end -->
+
+
+- [x] 6.1 `pytest` green (unit + integration).
+<!-- opsx:tdd:6.1:begin -->
+  - **Input**: pytest (from repo root); BEACON_OFFLINE=1 pytest -m integration when offline
+  - **Expected Output**: All tests pass; no regressions in existing sync/adopt/connect/doctor suites.
+  - **Validation**: Zero failures, zero errors from repo root.
+<!-- opsx:tdd:6.1:end -->
+- [ ] 6.2 **[OPS]** Happy-path check: `abc adopt` / `abc sync` on a scratch project yields correct Tier A + Tier B blocks; `abc doctor` clean; introduce drift → `abc doctor` errors → `abc doctor --fix` repairs.
+<!-- opsx:tdd:6.2:begin -->
+  - **Input**: abc warehouse init /tmp/ab94-scratch-wh && abc sync in a scratch project; then delete the Tier A block and run abc doctor / abc doctor --fix
+  - **Expected Output**: Correct managed blocks after sync; abc doctor reports an error after the block is deleted; abc doctor --fix restores it and the re-run is clean.
+  - **Validation**: Real CLI walkthrough matches the unit-test expectations end-to-end.
+<!-- opsx:tdd:6.2:end -->
+
+<!-- opsx:metadata:begin -->
+---
+
+## Enhancement Metadata
+
+**Enhanced**: 2026-07-19
+**Methodology**: Spec-Driven Development + TDD
+**Enhancements Applied**:
+- TDD Workflow Header
+- Repositories & Branches table
+- Phase summaries (Goal/Input/Output/Validation)
+- Task-level TDD criteria on 15 task(s)
+- 28 test case(s) across complex tasks
+- 0 task(s) flagged [MANUAL] (blocking pause)
+- 0 task(s) flagged [MANUAL-DEFER] (non-blocking)
+- 1 task(s) flagged [OPS]
+- 0 task(s) routed to Cross-Repo Follow-ups
+
+**Status**: Ready for implementation via `/opsx-apply <name>`.
+<!-- opsx:metadata:end -->

--- a/openspec/changes/ab-94-managed-gitignore/tasks.md
+++ b/openspec/changes/ab-94-managed-gitignore/tasks.md
@@ -1,0 +1,289 @@
+# Tasks — Managed-block gitignore engine (AB-94)
+
+<!-- opsx:tdd-header:begin -->
+## TDD WORKFLOW - MANDATORY FOR ALL TASKS
+
+**CRITICAL**: This project follows strict Test-Driven Development (TDD). Before implementing ANY task:
+
+### RED-GREEN-REFACTOR Cycle
+
+1. **RED Phase - Write Failing Tests FIRST**
+   - Read the task's TDD Test Cases (TC1-TCN)
+   - Create test file in `tests/` directory
+   - Write ALL test cases from the task BEFORE any implementation
+   - Run tests - they MUST fail (import errors, missing functions, etc.)
+   - If tests pass without implementation, you wrote the tests wrong!
+
+2. **GREEN Phase - Implement Minimal Code**
+   - Write ONLY enough code to make tests pass
+   - Run tests after each implementation
+   - All tests must pass before marking task complete
+
+3. **REFACTOR Phase - Improve Code Quality**
+   - Clean up implementation
+   - Remove duplication
+   - Improve naming
+   - Tests must still pass after refactoring
+
+### Task Completion Criteria
+
+**A task is NOT complete until:**
+- All TDD test cases are written
+- All tests pass (or are justifiably skipped with documentation)
+- Implementation matches the Expected Output
+- Test results documented in tasks.md
+
+**For skipped tests:**
+- Add `@pytest.mark.skip(reason="...")` with clear justification
+- Document in tasks.md under "Skipped Test Cases" section
+- Explain why feature is deferred and when it will be implemented
+
+### Test Organization
+
+```
+tests/
+├── core/           # Core module tests
+├── <module>/       # Module-specific tests
+└── conftest.py     # Shared fixtures
+```
+
+### Running Tests
+
+```bash
+# Activate venv, install dev deps, run tests
+source .venv/bin/activate
+uv sync --extra dev
+pytest tests/ -v --tb=short
+```
+
+**See Also:**
+- Check project AGENTS.md for unit testing workflow
+- Check knowledge base for TDD lessons and standards
+<!-- opsx:tdd-header:end -->
+
+<!-- opsx:repos-table:begin -->
+## Repositories & Branches
+
+| Repo | Path | Branch | Role |
+|------|------|--------|------|
+| `agentic-beacon` | `~/Code/oss/agentic-beacon` | `openspec/ab-94-managed-gitignore` | Code changes — managed-block gitignore engine in core/gitignore.py, rewiring sync/adopt/connect through it, retiring the conditional agent-dir helpers, doctor drift check + real --fix, and full unit/integration coverage + docs |
+<!-- opsx:repos-table:end -->
+
+
+## 1. Core engine (`core/gitignore.py`)
+
+<!-- opsx:phase-summary:1:begin -->
+**Goal**: Build the single cross-domain managed-block engine: marker-delimited block, wholesale regeneration, surgical migration, the two-tier entry sets, and a read-only drift diff — the source of truth every path and doctor will call.
+**Input**: Existing core/gitignore.py (GitignoreManager with per-line ensure_entries); Tier B constants currently in distribution/orchestrator.py.
+**Output**: core/gitignore.py exposes marker constants, TIER_A_ENTRIES / TIER_B_CLAUDE_ENTRIES / TIER_B_OPENCODE_ENTRIES / TRACKED_ON_PURPOSE, apply_managed_block, read_managed_block, apply_all_gitignores, and diff_gitignores. No imports from domains/.
+**Validation**: pytest tests/unit covering the engine passes; tests/unit/test_architecture.py confirms core imports no domains.
+<!-- opsx:phase-summary:1:end -->
+
+
+- [ ] 1.1 Add managed-block markers and entry-set constants: `TIER_A_ENTRIES` (10 unconditional lines), `TIER_B_CLAUDE_ENTRIES`, `TIER_B_OPENCODE_ENTRIES`, `TRACKED_ON_PURPOSE`.
+- [ ] 1.2 Implement `apply_managed_block(gitignore_path, entries)`: create/regenerate the marker-delimited block wholesale; idempotent; preserve trailing-newline shape.
+<!-- opsx:tdd:1.2:begin -->
+  - **Input**: pytest tests/unit/test_gitignore.py -k apply_managed_block -v
+  - **Expected Output**: Exit code 0; block written between '# >>> Agentic Beacon (managed) >>>' and '# <<< Agentic Beacon (managed) <<<'; second apply with same entries leaves bytes unchanged.
+  - **Validation**: Fresh-file, stale-body-regen, and idempotent-reapply cases all pass; trailing-newline shape preserved.
+  - **TDD Test Cases (write these first):**
+    - TC1: no .gitignore exists → file created containing exactly one managed block with all supplied entries
+    - TC2: managed block present with correct body → re-apply is byte-identical (idempotent)
+    - TC3: managed block present with a missing/extra/reordered entry → body regenerated to canonical set, markers unchanged, out-of-block content untouched
+    - TC4: file ends without trailing newline → block appended without corrupting the preceding line; newline shape preserved
+    - TC5: entries empty list → block contains only the two markers (no orphan lines)
+<!-- opsx:tdd:1.2:end -->
+- [ ] 1.3 Implement surgical migration inside `apply_managed_block`: dedup exact managed lines from a legacy `# Agentic Beacon` region, drop the emptied bare legacy header, preserve all non-managed lines.
+<!-- opsx:tdd:1.3:begin -->
+  - **Input**: pytest tests/unit/test_gitignore.py -k migration -v
+  - **Expected Output**: Legacy loose managed lines removed; bare '# Agentic Beacon' header dropped; non-managed lines (.legacy-migrated, sample-warehouse/, user lines) retained; managed block appended once.
+  - **Validation**: No line the engine does not own is deleted; second run is a no-op.
+  - **TDD Test Cases (write these first):**
+    - TC1: legacy header + managed loose lines + unknown lines → managed lines deduped, unknown lines preserved in place, bare legacy header removed, block appended once
+    - TC2: legacy header whose ALL following lines are managed → header removed, no empty region left behind
+    - TC3: legacy header with a mix incl. scattered .claude/agents/ → agent-dir loose line deduped into the block, other lines preserved
+    - TC4: already-migrated file → second run makes no change (idempotent)
+    - TC5: unknown line equals a managed value only as a substring (not exact) → preserved (exact-match only)
+<!-- opsx:tdd:1.3:end -->
+- [ ] 1.4 Implement `read_managed_block(gitignore_path)` and `apply_all_gitignores(project_root)` (Tier A always; Tier B per tool-dir existence).
+<!-- opsx:tdd:1.4:begin -->
+  - **Input**: pytest tests/unit/test_gitignore.py -k apply_all -v
+  - **Expected Output**: Root .gitignore always gets Tier A; .claude/.gitignore written iff .claude/ exists; .opencode/.gitignore written iff .opencode/ exists; read_managed_block returns the parsed entry list or None.
+  - **Validation**: Tier A unconditional; Tier B dir-gated by file location; read round-trips the written block.
+  - **TDD Test Cases (write these first):**
+    - TC1: project with neither tool dir → only root Tier A block written; no nested files created
+    - TC2: project with .claude/ only → root Tier A + .claude/.gitignore; no .opencode/.gitignore
+    - TC3: project with both tool dirs → root + both nested blocks
+    - TC4: read_managed_block on a file with no markers → returns None
+<!-- opsx:tdd:1.4:end -->
+- [ ] 1.5 Implement `diff_gitignores(project_root)` returning drift records (Tier A missing/incomplete, Tier B missing/incomplete when dir exists, tracked-on-purpose file ignored); extend the tracked-set assertion to `TRACKED_ON_PURPOSE`.
+<!-- opsx:tdd:1.5:begin -->
+  - **Input**: pytest tests/unit/test_gitignore.py -k diff -v
+  - **Expected Output**: Returns [] for a healthy project; returns drift records identifying the specific tier/file for each defect; flags any TRACKED_ON_PURPOSE path that git would ignore.
+  - **Validation**: Read-only (no writes); the reported 'Tier B present, Tier A absent' case yields a Tier-A drift record.
+  - **TDD Test Cases (write these first):**
+    - TC1: healthy project (both tiers correct) → empty list
+    - TC2: nested .opencode/.gitignore present but root Tier A block absent → drift record naming missing Tier A
+    - TC3: Tier A block present but missing warehouse-catalog.md → incomplete-Tier-A drift record
+    - TC4: .claude/ exists but .claude/.gitignore missing → Tier B drift record
+    - TC5: .gitignore contains a line ignoring beacon.yaml / opencode.json → tracked-set drift record
+    - TC6: diff_gitignores makes no filesystem writes (assert mtime/bytes unchanged)
+<!-- opsx:tdd:1.5:end -->
+
+## 2. Wire every path to the engine
+
+<!-- opsx:phase-summary:2:begin -->
+**Goal**: Route sync, adopt-accept, and warehouse-connect through apply_all_gitignores so no path can emit one tier without the other, and delete the superseded fragmented mechanisms.
+**Input**: Phase 1 engine complete; current call sites in orchestrator.py:462/546/558, adoption/apply.py:294, warehouse/connector.py:47, artifact/agent.py.
+**Output**: All three wiring paths call apply_all_gitignores; CLAUDE_DIR_/OPENCODE_DIR_GITIGNORE_ENTRIES and ensure_agent_dirs_gitignored/prune_agent_dirs_gitignore_entries removed with their callers.
+**Validation**: grep confirms the deleted symbols have no remaining references; path-coverage tests (Phase 4) green.
+<!-- opsx:phase-summary:2:end -->
+
+
+- [ ] 2.1 `domains/distribution/orchestrator.py::run_sync` — replace the `ensure_entries()` + conditional agent-dir + per-tool nested-gitignore blocks with a single `apply_all_gitignores(project_root)` call; delete `CLAUDE_DIR_GITIGNORE_ENTRIES` / `OPENCODE_DIR_GITIGNORE_ENTRIES`.
+- [ ] 2.2 `domains/adoption/apply.py` — call `apply_all_gitignores(project_root)` on the accept path (fixes the Tier-A-skipped bug); remove the conditional `ensure_agent_dirs_gitignored` call.
+<!-- opsx:tdd:2.2:begin -->
+  - **Input**: pytest tests/unit -k adopt_gitignore -v (or the integration adopt test)
+  - **Expected Output**: After adopt-accept that materializes .claude/ and/or .opencode/, the root .gitignore contains the Tier A managed block AND nested Tier B blocks exist.
+  - **Validation**: This is the regression that would have caught the original agentic-conductor bug — Tier A must be present on the adopt path.
+  - **TDD Test Cases (write these first):**
+    - TC1: adopt-accept on a project with no prior .gitignore → Tier A block present after accept
+    - TC2: adopt-accept that creates .opencode/ → both Tier A and .opencode/.gitignore present (no Tier-B-without-Tier-A drift)
+<!-- opsx:tdd:2.2:end -->
+- [ ] 2.3 `domains/warehouse/connector.py` — route `connect` through `apply_all_gitignores`.
+- [ ] 2.4 `domains/artifact/agent.py` — remove `ensure_agent_dirs_gitignored` and `prune_agent_dirs_gitignore_entries`; update/remove their callers and imports.
+
+## 3. Doctor check + real `--fix`
+
+<!-- opsx:phase-summary:3:begin -->
+**Goal**: Surface gitignore drift as a doctor error and make --fix actually repair it via the shared engine — Beacon's first working --fix.
+**Input**: Phase 1 diff_gitignores; existing run_project_health_checks + DoctorIssue in setup/diagnostics.py and the --fix stub in cli/diagnostics.py.
+**Output**: abc doctor reports Tier A / Tier B / tracked-set drift at error severity; abc doctor --fix calls apply_all_gitignores and records repairs in fixes_applied.
+**Validation**: Doctor tests (Phase 4.5): drift flagged, healthy clean, --fix repairs, re-run clean.
+<!-- opsx:phase-summary:3:end -->
+
+
+- [ ] 3.1 `domains/setup/diagnostics.py` — add a gitignore-drift check (error severity) using `diff_gitignores`; surface Tier A, Tier B, and tracked-set findings via `DoctorIssue`.
+<!-- opsx:tdd:3.1:begin -->
+  - **Input**: pytest tests/unit -k doctor_gitignore -v
+  - **Expected Output**: run_project_health_checks returns DoctorIssue(severity='err', ...) for each drift; none for a healthy project.
+  - **Validation**: Severity is error; messages identify the specific tier/file; the reported Tier-A-missing case is flagged.
+  - **TDD Test Cases (write these first):**
+    - TC1: drifted project → DoctorIssue with severity 'err' and a message naming the missing Tier A block
+    - TC2: healthy project → no gitignore DoctorIssue emitted
+    - TC3: tracked-set file ignored → error-severity DoctorIssue naming the file
+<!-- opsx:tdd:3.1:end -->
+- [ ] 3.2 `cli/diagnostics.py` — implement real `--fix`: when drift is found and `--fix` is set, call `apply_all_gitignores` and append to `fixes_applied`.
+<!-- opsx:tdd:3.2:begin -->
+  - **Input**: abc doctor --fix in a drifted scratch project, then abc doctor
+  - **Expected Output**: First run reports drift and prints a fix in the applied-fixes summary; second run reports no gitignore drift.
+  - **Validation**: fixes_applied is non-empty on repair; repaired blocks match the engine output; re-run is clean.
+  - **TDD Test Cases (write these first):**
+    - TC1: drifted project + --fix → blocks repaired, fix recorded in fixes_applied, exit reflects repair
+    - TC2: healthy project + --fix → no fix recorded, no spurious write
+    - TC3: --fix then plain doctor → zero gitignore drift on the second run (idempotent repair)
+<!-- opsx:tdd:3.2:end -->
+
+## 4. Tests
+
+<!-- opsx:phase-summary:4:begin -->
+**Goal**: Lock the engine's behavior, the migration's non-destructiveness, the Tier B fold-in against regression, cross-path coverage (including the adopt bug), and the doctor flow.
+**Input**: Phases 1–3 implemented; pytest with tests/unit and tests/integration split.
+**Output**: New unit + integration tests covering engine, migration, Tier B lock, path coverage, doctor; architecture test still green.
+**Validation**: pytest tests/ green from repo root; BEACON_OFFLINE=1 respected for network-gated integration tests.
+<!-- opsx:phase-summary:4:end -->
+
+
+- [ ] 4.1 Engine unit tests: fresh-file, wholesale regen of stale body, idempotent re-apply (byte-equal), unconditional Tier A set (no tool dirs / no declared agents).
+<!-- opsx:tdd:4.1:begin -->
+  - **Input**: pytest tests/unit/test_gitignore.py -v
+  - **Expected Output**: All engine cases pass; Tier A block contains all 10 entries even with no .claude//.opencode/ and empty agents.
+  - **Validation**: Zero failures; unconditional Tier A explicitly asserted.
+<!-- opsx:tdd:4.1:end -->
+- [ ] 4.2 Migration unit tests: dedup managed + preserve unknowns + drop bare legacy header; no-op on 2nd run; realistic mixed legacy block.
+<!-- opsx:tdd:4.2:begin -->
+  - **Input**: pytest tests/unit/test_gitignore.py -k migration -v
+  - **Expected Output**: Realistic legacy block (like this repo's) migrates: managed lines deduped, .legacy-migrated / sample-warehouse/ preserved, header dropped; second run byte-identical.
+  - **Validation**: No non-managed line lost; idempotent.
+<!-- opsx:tdd:4.2:end -->
+- [ ] 4.3 Tier B regression lock: exact `.claude/.gitignore` / `.opencode/.gitignore` entry sets + dir-gating unchanged.
+<!-- opsx:tdd:4.3:begin -->
+  - **Input**: pytest tests/unit -k tier_b -v
+  - **Expected Output**: .claude/.gitignore == {skills/, scheduled_tasks.lock, worktrees/}; .opencode/.gitignore == {skills/, command/, bun.lock, package.json, package-lock.json, node_modules/}; nested files only when dir exists.
+  - **Validation**: Entry sets match the pre-change constants exactly (guards the fold-into-engine risk).
+<!-- opsx:tdd:4.3:end -->
+- [ ] 4.4 Path coverage: adopt-accept writes Tier A + Tier B; sync writes both; connect routes through engine.
+<!-- opsx:tdd:4.4:begin -->
+  - **Input**: pytest tests/ -k 'gitignore and (adopt or sync or connect)' -v
+  - **Expected Output**: Each of the three paths produces the correct Tier A + Tier B blocks; no path emits one tier without the other.
+  - **Validation**: adopt path asserts Tier A present (the original bug); all three paths converge to identical block output.
+<!-- opsx:tdd:4.4:end -->
+- [ ] 4.5 Doctor tests: Tier-A-missing-while-Tier-B-present flagged; healthy → clean; tracked-set-ignored → error; `--fix` repairs and re-run is clean.
+<!-- opsx:tdd:4.5:begin -->
+  - **Input**: pytest tests/ -k doctor -v
+  - **Expected Output**: Drift detected at error severity for each defect; healthy project clean; --fix repairs and the re-run is clean.
+  - **Validation**: Covers detection, severity, tracked-set, and the real --fix repair loop.
+<!-- opsx:tdd:4.5:end -->
+- [ ] 4.6 `tests/unit/test_architecture.py` still passes (core imports no domains).
+<!-- opsx:tdd:4.6:begin -->
+  - **Input**: pytest tests/unit/test_architecture.py -v
+  - **Expected Output**: Exit code 0 — core/gitignore.py (and the rest of core/) import nothing from domains/ or cli/.
+  - **Validation**: Architecture boundary intact after promoting the policy into core.
+<!-- opsx:tdd:4.6:end -->
+
+## 5. Docs
+
+<!-- opsx:phase-summary:5:begin -->
+**Goal**: Bring the two-tier gitignore documentation in line with the managed-block engine and the unconditional / doctor --fix behavior.
+**Input**: beacon-ops.md two-tier section and AGENTS.md references to the old per-line / conditional agent-dir behavior.
+**Output**: Docs describe the marker-delimited managed block, unconditional Tier A set, and abc doctor --fix.
+**Validation**: Manual read-through; abc warehouse lint clean on edited warehouse docs if applicable.
+<!-- opsx:phase-summary:5:end -->
+
+
+- [ ] 5.1 Update `beacon-ops.md` two-tier gitignore section: managed-block markers, unconditional Tier A, doctor `--fix`.
+- [ ] 5.2 Update `AGENTS.md` if it references the old per-line / conditional agent-dir behavior.
+
+## 6. Validate & verify
+
+<!-- opsx:phase-summary:6:begin -->
+**Goal**: Prove the change end-to-end on a real scratch project, not just via unit tests.
+**Input**: All prior phases complete; a scratch project + the built abc CLI.
+**Output**: Verified happy path: adopt/sync produce correct blocks, doctor detects induced drift, --fix repairs it.
+**Validation**: pytest green; documented scratch-project walkthrough succeeds.
+<!-- opsx:phase-summary:6:end -->
+
+
+- [ ] 6.1 `pytest` green (unit + integration).
+<!-- opsx:tdd:6.1:begin -->
+  - **Input**: pytest (from repo root); BEACON_OFFLINE=1 pytest -m integration when offline
+  - **Expected Output**: All tests pass; no regressions in existing sync/adopt/connect/doctor suites.
+  - **Validation**: Zero failures, zero errors from repo root.
+<!-- opsx:tdd:6.1:end -->
+- [ ] 6.2 **[OPS]** Happy-path check: `abc adopt` / `abc sync` on a scratch project yields correct Tier A + Tier B blocks; `abc doctor` clean; introduce drift → `abc doctor` errors → `abc doctor --fix` repairs.
+<!-- opsx:tdd:6.2:begin -->
+  - **Input**: abc warehouse init /tmp/ab94-scratch-wh && abc sync in a scratch project; then delete the Tier A block and run abc doctor / abc doctor --fix
+  - **Expected Output**: Correct managed blocks after sync; abc doctor reports an error after the block is deleted; abc doctor --fix restores it and the re-run is clean.
+  - **Validation**: Real CLI walkthrough matches the unit-test expectations end-to-end.
+<!-- opsx:tdd:6.2:end -->
+
+<!-- opsx:metadata:begin -->
+---
+
+## Enhancement Metadata
+
+**Enhanced**: 2026-07-19
+**Methodology**: Spec-Driven Development + TDD
+**Enhancements Applied**:
+- TDD Workflow Header
+- Repositories & Branches table
+- Phase summaries (Goal/Input/Output/Validation)
+- Task-level TDD criteria on 15 task(s)
+- 28 test case(s) across complex tasks
+- 0 task(s) flagged [MANUAL] (blocking pause)
+- 0 task(s) flagged [MANUAL-DEFER] (non-blocking)
+- 1 task(s) flagged [OPS]
+- 0 task(s) routed to Cross-Repo Follow-ups
+
+**Status**: Ready for implementation via `/opsx-apply <name>`.
+<!-- opsx:metadata:end -->


### PR DESCRIPTION
## Summary

Reframes Beacon's `.gitignore` ownership from a drift-prone side effect into a first-class, verifiable setup capability. Introduces a **single managed-block engine** in `core/gitignore.py` (marker-delimited `# >>> Agentic Beacon (managed) >>>` … `<<<`, regenerated wholesale) that owns **both tiers** and is called from **every** wiring path, so no path can emit one tier without the other.

- **Tier A** (root `.gitignore`) — 10 unconditional entries (`.agentic-beacon/{config.toml,artifacts/,warehouse-catalog.md,pending.yaml}` + `.claude/{skills,commands,agents}/` + `.opencode/{skills,command,agents}/`).
- **Tier B** (nested `.claude/.gitignore`, `.opencode/.gitignore`) — folded into the same engine; entry sets preserved exactly and regression-locked.
- **Single writer** called from `run_sync`, `abc adopt` (the path that skipped Tier A — the reported agentic-conductor bug), and `abc warehouse connect`.
- **Retires** the conditional agent-dir helpers (`ensure_agent_dirs_gitignored` / `prune_agent_dirs_gitignore_entries`) and the `CLAUDE_DIR_/OPENCODE_DIR_GITIGNORE_ENTRIES` constants — agent dirs are now unconditional Tier A lines.
- **Surgical migration** of legacy loose-line blocks: global exact-match dedup, drop the emptied bare `# Agentic Beacon` header, preserve every non-managed line; idempotent.
- **`abc doctor`** gitignore-drift check (error severity) + **first working `abc doctor --fix`** (repairs via the same engine, records `fixes_applied`).

Closes AB-94.

## Root cause fixed
`abc adopt` called `sync_engine.sync_all(...)` directly and never ran the orchestrator's Tier A `ensure_entries()` — so Tier B nested files emitted while Tier A was skipped. Adopt now routes through `apply_all_gitignores`, applied unconditionally.

## Test plan
- [x] Full suite: **1559 passed, 8 skipped** (verified in supervisor's main venv against worktree src)
- [x] Architecture test green (`core/` imports no `domains/`)
- [x] Supervisor deep-review caught + fixed a migration double-ignore bug on scattered legacy lines (this repo's real `.gitignore` fixture); now proven to dedup each entry to exactly one occurrence, idempotent
- [x] Retired symbols: 0 active references (comment/docstring mentions only)
- [x] CLI smoke: `abc --version`, `abc doctor --help`
- [ ] CI green
- [ ] opencode-review bot clean

## Deferred (non-blocking)
- Task 5.1 — `beacon-ops.md` two-tier section lives in the **warehouse** (delivered via the beacon model), not this repo's diff.
- Task 6.2 — `[OPS]` scratch-project happy-path walkthrough (agent/human-runnable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)