### PR TITLE
fix(beacon): reconcile CLAUDE.md/opencode.json context references to the effective set (AB-96)

### DIFF
--- a/libs/beacon/src/beacon/cli/sync.py
+++ b/libs/beacon/src/beacon/cli/sync.py
@@ -26,10 +26,10 @@ from beacon.domains.distribution.reset import (
     reset_artifacts,
 )
 from beacon.domains.setup.wiring import (
+    desired_context_refs,
     init_claude_md,
     init_opencode_json,
-    wire_contexts_claudecode,
-    wire_contexts_opencode,
+    reconcile_context_references,
 )
 from beacon.utils.display import format_regular_file_conflict, is_interactive
 from beacon.utils.git import find_project_root
@@ -247,19 +247,23 @@ def sync(
 
     if result.agent_config_init_needed and not result.dry_run:
         init_opencode_json(result.project_root)
-        oc_init = wire_contexts_opencode(result.project_root, result.artifacts_dir)
-        if oc_init:
-            console.print(
-                f"[green]✓[/green] Created opencode.json and "
-                f"wired {len(oc_init)} context(s)"
-            )
         init_claude_md(result.project_root)
-        cc_init = wire_contexts_claudecode(result.project_root, result.artifacts_dir)
-        if cc_init:
-            console.print(
-                f"[green]✓[/green] Created CLAUDE.md and "
-                f"wired {len(cc_init)} context(s)"
-            )
+        beacon_yaml = result.project_root / ".agentic-beacon" / "beacon.yaml"
+        if beacon_yaml.exists():
+            from beacon.core.manifest.beacon import BeaconManifest
+
+            settings = BeaconManifest.from_yaml(beacon_yaml)
+            effective_names: set[str] = set()
+            for c in settings.artifacts.contexts:
+                name = c.removeprefix("contexts/").removesuffix(".md")
+                effective_names.add(name)
+            desired_refs = desired_context_refs(effective_names)
+            ref_result = reconcile_context_references(result.project_root, desired_refs)
+            if ref_result.added:
+                console.print(
+                    f"[green]✓[/green] Created and wired {len(ref_result.added)} "
+                    f"context(s) into agent config files"
+                )
 
     print_bundled_install_result(result.bundled_installed, result.bundled_skipped)
 

--- a/libs/beacon/src/beacon/cli/sync.py
+++ b/libs/beacon/src/beacon/cli/sync.py
@@ -26,7 +26,6 @@ from beacon.domains.distribution.reset import (
     reset_artifacts,
 )
 from beacon.domains.setup.wiring import (
-    desired_context_refs,
     init_claude_md,
     init_opencode_json,
     reconcile_context_references,
@@ -222,13 +221,13 @@ def sync(
         return
 
     # ── Wiring output ──
-    if result.oc_added:
+    if result.refs_added:
         console.print(
-            f"\n[green]✓[/green] Wired {len(result.oc_added)} context(s) into opencode.json"
+            f"\n[green]✓[/green] Wired {len(result.refs_added)} context reference(s)"
         )
-    if result.cc_added:
+    if result.refs_removed:
         console.print(
-            f"[green]✓[/green] Wired {len(result.cc_added)} context(s) into CLAUDE.md"
+            f"[green]✓[/green] Removed {len(result.refs_removed)} stale context reference(s)"
         )
 
     if result.wired_skills:
@@ -251,19 +250,19 @@ def sync(
         beacon_yaml = result.project_root / ".agentic-beacon" / "beacon.yaml"
         if beacon_yaml.exists():
             from beacon.core.manifest.beacon import BeaconManifest
+            from beacon.domains.setup.diagnostics import effective_desired_refs
 
             settings = BeaconManifest.from_yaml(beacon_yaml)
-            effective_names: set[str] = set()
-            for c in settings.artifacts.contexts:
-                name = c.removeprefix("contexts/").removesuffix(".md")
-                effective_names.add(name)
-            desired_refs = desired_context_refs(effective_names)
-            ref_result = reconcile_context_references(result.project_root, desired_refs)
-            if ref_result.added:
-                console.print(
-                    f"[green]✓[/green] Created and wired {len(ref_result.added)} "
-                    f"context(s) into agent config files"
+            eff_desired_refs = effective_desired_refs(settings, result.warehouse_path)
+            if eff_desired_refs is not None:
+                ref_result = reconcile_context_references(
+                    result.project_root, eff_desired_refs
                 )
+                if ref_result.added:
+                    console.print(
+                        f"[green]✓[/green] Created and wired {len(ref_result.added)} "
+                        f"context reference(s) into agent config files"
+                    )
 
     print_bundled_install_result(result.bundled_installed, result.bundled_skipped)
 

--- a/libs/beacon/src/beacon/domains/adoption/apply.py
+++ b/libs/beacon/src/beacon/domains/adoption/apply.py
@@ -243,22 +243,16 @@ def commit_session(
         agent_candidates = [c for c in beacon_adds if c.artifact_type == "agents"]
 
         if has_contexts:
-            from beacon.domains.setup.wiring import (
-                desired_context_refs,
-                reconcile_context_references,
-            )
+            from beacon.core.manifest.beacon import BeaconManifest
+            from beacon.domains.setup.diagnostics import effective_desired_refs
+            from beacon.domains.setup.wiring import reconcile_context_references
 
             beacon_yaml = project_root / ".agentic-beacon" / "beacon.yaml"
             if beacon_yaml.exists():
-                from beacon.core.manifest.beacon import BeaconManifest
-
                 settings = BeaconManifest.from_yaml(beacon_yaml)
-                effective_names: set[str] = set()
-                for c in settings.artifacts.contexts:
-                    name = c.removeprefix("contexts/").removesuffix(".md")
-                    effective_names.add(name)
-                desired_refs = desired_context_refs(effective_names)
-                reconcile_context_references(project_root, desired_refs)
+                eff_desired_refs = effective_desired_refs(settings, warehouse_path)
+                if eff_desired_refs is not None:
+                    reconcile_context_references(project_root, eff_desired_refs)
 
         if has_skills:
             from beacon.domains.artifact.skill import wire_skills_post_sync
@@ -412,20 +406,15 @@ def commit_session(
         ]
         if context_unadoptions and not beacon_adds:
             from beacon.core.manifest.beacon import BeaconManifest
-            from beacon.domains.setup.wiring import (
-                desired_context_refs,
-                reconcile_context_references,
-            )
+            from beacon.domains.setup.diagnostics import effective_desired_refs
+            from beacon.domains.setup.wiring import reconcile_context_references
 
             beacon_yaml = project_root / ".agentic-beacon" / "beacon.yaml"
             if beacon_yaml.exists():
                 settings = BeaconManifest.from_yaml(beacon_yaml)
-                effective_names: set[str] = set()
-                for c in settings.artifacts.contexts:
-                    name = c.removeprefix("contexts/").removesuffix(".md")
-                    effective_names.add(name)
-                desired_refs = desired_context_refs(effective_names)
-                reconcile_context_references(project_root, desired_refs)
+                eff_desired_refs = effective_desired_refs(settings, warehouse_path)
+                if eff_desired_refs is not None:
+                    reconcile_context_references(project_root, eff_desired_refs)
 
         # 2b. Unwire project-local tool symlinks for unadopted agents (Bug 1 + 2 fix).
         agent_unadoptions = [p for p in to_unadopt if p.startswith("agents/")]

--- a/libs/beacon/src/beacon/domains/adoption/apply.py
+++ b/libs/beacon/src/beacon/domains/adoption/apply.py
@@ -402,6 +402,31 @@ def commit_session(
         if beacon_adds:
             post_sync_wiring_fn(beacon_adds)
 
+        # 2c. If contexts were unadopted but no beacon_adds triggered wiring,
+        # we still need to reconcile references so stale owned @-includes and
+        # instructions entries are removed from CLAUDE.md / opencode.json.
+        context_unadoptions = [
+            p
+            for p in to_unadopt
+            if not p.startswith("agents/") and not p.startswith("skills/")
+        ]
+        if context_unadoptions and not beacon_adds:
+            from beacon.core.manifest.beacon import BeaconManifest
+            from beacon.domains.setup.wiring import (
+                desired_context_refs,
+                reconcile_context_references,
+            )
+
+            beacon_yaml = project_root / ".agentic-beacon" / "beacon.yaml"
+            if beacon_yaml.exists():
+                settings = BeaconManifest.from_yaml(beacon_yaml)
+                effective_names: set[str] = set()
+                for c in settings.artifacts.contexts:
+                    name = c.removeprefix("contexts/").removesuffix(".md")
+                    effective_names.add(name)
+                desired_refs = desired_context_refs(effective_names)
+                reconcile_context_references(project_root, desired_refs)
+
         # 2b. Unwire project-local tool symlinks for unadopted agents (Bug 1 + 2 fix).
         agent_unadoptions = [p for p in to_unadopt if p.startswith("agents/")]
         if agent_unadoptions:

--- a/libs/beacon/src/beacon/domains/adoption/apply.py
+++ b/libs/beacon/src/beacon/domains/adoption/apply.py
@@ -244,12 +244,21 @@ def commit_session(
 
         if has_contexts:
             from beacon.domains.setup.wiring import (
-                wire_contexts_claudecode,
-                wire_contexts_opencode,
+                desired_context_refs,
+                reconcile_context_references,
             )
 
-            wire_contexts_opencode(project_root, artifacts_path)
-            wire_contexts_claudecode(project_root, artifacts_path)
+            beacon_yaml = project_root / ".agentic-beacon" / "beacon.yaml"
+            if beacon_yaml.exists():
+                from beacon.core.manifest.beacon import BeaconManifest
+
+                settings = BeaconManifest.from_yaml(beacon_yaml)
+                effective_names: set[str] = set()
+                for c in settings.artifacts.contexts:
+                    name = c.removeprefix("contexts/").removesuffix(".md")
+                    effective_names.add(name)
+                desired_refs = desired_context_refs(effective_names)
+                reconcile_context_references(project_root, desired_refs)
 
         if has_skills:
             from beacon.domains.artifact.skill import wire_skills_post_sync

--- a/libs/beacon/src/beacon/domains/distribution/orchestrator.py
+++ b/libs/beacon/src/beacon/domains/distribution/orchestrator.py
@@ -466,7 +466,6 @@ def run_sync(
             )
 
     # Use effective set for wiring decisions — reconcile references wholesale
-    has_contexts = bool(effective_set.contexts) and not dry_run
     has_skills = bool(effective_set.skills) and not dry_run
 
     if effective_set.contexts:

--- a/libs/beacon/src/beacon/domains/distribution/orchestrator.py
+++ b/libs/beacon/src/beacon/domains/distribution/orchestrator.py
@@ -465,46 +465,47 @@ def run_sync(
                 "    mkdir .opencode  [dim]# for OpenCode[/dim]"
             )
 
-    # Use effective set for wiring decisions — reconcile references wholesale
+    # Use effective set for wiring decisions — reconcile references wholesale.
+    # Always run reconcile_context_references (even when contexts is empty) so
+    # stale owned references from de-adopted contexts are removed from both files.
     has_skills = bool(effective_set.skills) and not dry_run
 
-    if effective_set.contexts:
-        desired_refs = desired_context_refs(effective_set.contexts)
-        reconcile_result = reconcile_context_references(
-            project_root, desired_refs, dry_run=dry_run
-        )
-        oc_added = reconcile_result.added
-        cc_added = reconcile_result.removed
+    desired_refs = desired_context_refs(effective_set.contexts)
+    reconcile_result = reconcile_context_references(
+        project_root, desired_refs, dry_run=dry_run
+    )
+    oc_added = reconcile_result.added
+    cc_added = reconcile_result.removed
 
-        if not dry_run:
-            has_opencode = (project_root / "opencode.json").exists()
-            has_claude = any(
-                p.exists()
-                for p in [
-                    project_root / ".claude" / "CLAUDE.md",
-                    project_root / "CLAUDE.md",
-                ]
-            )
-            if not has_opencode and not has_claude:
-                if has_synced_contexts(artifacts_dir):
-                    agent_config_init_needed = True
-                else:
-                    wiring_notes.append(
-                        "  Contexts synced — wire them into your agent config:\n"
-                        '  [bold]opencode.json[/bold] → add to "instructions" array:\n'
-                        '    ".agentic-beacon/artifacts/contexts/<name>.md"\n'
-                        "  [bold]CLAUDE.md[/bold] → add a line per context:\n"
-                        "    @.agentic-beacon/artifacts/contexts/<name>.md"
-                    )
-        else:
-            if reconcile_result:
+    if effective_set.contexts and not dry_run:
+        has_opencode = (project_root / "opencode.json").exists()
+        has_claude = any(
+            p.exists()
+            for p in [
+                project_root / ".claude" / "CLAUDE.md",
+                project_root / "CLAUDE.md",
+            ]
+        )
+        if not has_opencode and not has_claude:
+            if has_synced_contexts(artifacts_dir):
+                agent_config_init_needed = True
+            else:
                 wiring_notes.append(
-                    "  Contexts would be synced — wire them into your agent config if needed:\n"
+                    "  Contexts synced — wire them into your agent config:\n"
                     '  [bold]opencode.json[/bold] → add to "instructions" array:\n'
                     '    ".agentic-beacon/artifacts/contexts/<name>.md"\n'
                     "  [bold]CLAUDE.md[/bold] → add a line per context:\n"
                     "    @.agentic-beacon/artifacts/contexts/<name>.md"
                 )
+    elif dry_run:
+        if reconcile_result:
+            wiring_notes.append(
+                "  Contexts would be synced — wire them into your agent config if needed:\n"
+                '  [bold]opencode.json[/bold] → add to "instructions" array:\n'
+                '    ".agentic-beacon/artifacts/contexts/<name>.md"\n'
+                "  [bold]CLAUDE.md[/bold] → add a line per context:\n"
+                "    @.agentic-beacon/artifacts/contexts/<name>.md"
+            )
 
     if has_skills:
         wired_skills, wire_errors = wire_skills_post_sync(

--- a/libs/beacon/src/beacon/domains/distribution/orchestrator.py
+++ b/libs/beacon/src/beacon/domains/distribution/orchestrator.py
@@ -49,11 +49,11 @@ from beacon.domains.distribution.sync_engine import (
 )
 from beacon.domains.setup.wiring import (
     confirm_prune,
+    desired_context_refs,
     has_synced_contexts,
+    reconcile_context_references,
     unwire_pruned_artifacts,
     wire_agents_atomically,
-    wire_contexts_claudecode,
-    wire_contexts_opencode,
 )
 from beacon.domains.warehouse.git_health import (
     check_warehouse_git_clean,
@@ -465,42 +465,47 @@ def run_sync(
                 "    mkdir .opencode  [dim]# for OpenCode[/dim]"
             )
 
-    # Use effective set for wiring decisions
+    # Use effective set for wiring decisions — reconcile references wholesale
     has_contexts = bool(effective_set.contexts) and not dry_run
     has_skills = bool(effective_set.skills) and not dry_run
 
-    if has_contexts:
-        oc_added = wire_contexts_opencode(project_root, artifacts_dir)
-        cc_added = wire_contexts_claudecode(project_root, artifacts_dir)
-
-        has_opencode = (project_root / "opencode.json").exists()
-        has_claude = any(
-            p.exists()
-            for p in [
-                project_root / ".claude" / "CLAUDE.md",
-                project_root / "CLAUDE.md",
-            ]
+    if effective_set.contexts:
+        desired_refs = desired_context_refs(effective_set.contexts)
+        reconcile_result = reconcile_context_references(
+            project_root, desired_refs, dry_run=dry_run
         )
-        if not has_opencode and not has_claude:
-            if has_synced_contexts(artifacts_dir):
-                agent_config_init_needed = True
-            else:
+        oc_added = reconcile_result.added
+        cc_added = reconcile_result.removed
+
+        if not dry_run:
+            has_opencode = (project_root / "opencode.json").exists()
+            has_claude = any(
+                p.exists()
+                for p in [
+                    project_root / ".claude" / "CLAUDE.md",
+                    project_root / "CLAUDE.md",
+                ]
+            )
+            if not has_opencode and not has_claude:
+                if has_synced_contexts(artifacts_dir):
+                    agent_config_init_needed = True
+                else:
+                    wiring_notes.append(
+                        "  Contexts synced — wire them into your agent config:\n"
+                        '  [bold]opencode.json[/bold] → add to "instructions" array:\n'
+                        '    ".agentic-beacon/artifacts/contexts/<name>.md"\n'
+                        "  [bold]CLAUDE.md[/bold] → add a line per context:\n"
+                        "    @.agentic-beacon/artifacts/contexts/<name>.md"
+                    )
+        else:
+            if reconcile_result:
                 wiring_notes.append(
-                    "  Contexts synced — wire them into your agent config:\n"
+                    "  Contexts would be synced — wire them into your agent config if needed:\n"
                     '  [bold]opencode.json[/bold] → add to "instructions" array:\n'
                     '    ".agentic-beacon/artifacts/contexts/<name>.md"\n'
                     "  [bold]CLAUDE.md[/bold] → add a line per context:\n"
                     "    @.agentic-beacon/artifacts/contexts/<name>.md"
                 )
-
-    if effective_set.contexts and dry_run:
-        wiring_notes.append(
-            "  Contexts would be synced — wire them into your agent config if needed:\n"
-            '  [bold]opencode.json[/bold] → add to "instructions" array:\n'
-            '    ".agentic-beacon/artifacts/contexts/<name>.md"\n'
-            "  [bold]CLAUDE.md[/bold] → add a line per context:\n"
-            "    @.agentic-beacon/artifacts/contexts/<name>.md"
-        )
 
     if has_skills:
         wired_skills, wire_errors = wire_skills_post_sync(

--- a/libs/beacon/src/beacon/domains/distribution/orchestrator.py
+++ b/libs/beacon/src/beacon/domains/distribution/orchestrator.py
@@ -83,8 +83,8 @@ class SyncOrchestrationResult:
     conflicts: list[str]
     orphans: list[Orphan]
     confirmed_prune: list[str]
-    oc_added: list[str]
-    cc_added: list[str]
+    refs_added: list[str]
+    refs_removed: list[str]
     wired_skills: list[str]
     wire_errors: list[str]
     bundled_installed: list[str]
@@ -436,8 +436,8 @@ def run_sync(
         ) from e
 
     # Post-sync wiring
-    oc_added: list[str] = []
-    cc_added: list[str] = []
+    refs_added: list[str] = []
+    refs_removed: list[str] = []
     wired_skills: list[str] = []
     wire_errors: list[str] = []
     wiring_notes: list[str] = []
@@ -474,8 +474,8 @@ def run_sync(
     reconcile_result = reconcile_context_references(
         project_root, desired_refs, dry_run=dry_run
     )
-    oc_added = reconcile_result.added
-    cc_added = reconcile_result.removed
+    refs_added = reconcile_result.added
+    refs_removed = reconcile_result.removed
 
     if effective_set.contexts and not dry_run:
         has_opencode = (project_root / "opencode.json").exists()
@@ -561,8 +561,8 @@ def run_sync(
         conflicts=[],
         orphans=orphans,
         confirmed_prune=confirmed_prune,
-        oc_added=oc_added,
-        cc_added=cc_added,
+        refs_added=refs_added,
+        refs_removed=refs_removed,
         wired_skills=wired_skills,
         wire_errors=wire_errors,
         bundled_installed=list(bundled_installed),

--- a/libs/beacon/src/beacon/domains/setup/diagnostics.py
+++ b/libs/beacon/src/beacon/domains/setup/diagnostics.py
@@ -99,7 +99,27 @@ def repair_reference_drift(
     if beacon_manifest is None or warehouse_path is None:
         return []
 
-    effective_result = compute_effective_set(beacon_manifest, warehouse_path)
+    # Normalize the manifest contexts to bare names (strip "contexts/" prefix and ".md"
+    # suffix) so compute_effective_set receives the same format as run_sync uses after
+    # _normalize_beacon_for_resolver.
+    normalized_contexts: list[str] = []
+    for c in beacon_manifest.artifacts.contexts:
+        name = c
+        if name.startswith("contexts/"):
+            name = name[len("contexts/") :]
+        if name.endswith(".md"):
+            name = name[: -len(".md")]
+        normalized_contexts.append(name)
+    normalized_manifest = BeaconManifest(
+        artifacts={
+            "contexts": normalized_contexts,
+            "skills": beacon_manifest.artifacts.skills,
+            "agents": beacon_manifest.artifacts.agents,
+        },
+        ignore=beacon_manifest.ignore,
+    )
+
+    effective_result = compute_effective_set(normalized_manifest, warehouse_path)
     if isinstance(effective_result, ResolutionFailure):
         return []
 

--- a/libs/beacon/src/beacon/domains/setup/diagnostics.py
+++ b/libs/beacon/src/beacon/domains/setup/diagnostics.py
@@ -16,9 +16,17 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 
+from beacon.core.dependencies.resolver import (
+    ResolutionFailure,
+    compute_effective_set,
+)
 from beacon.core.gitignore import apply_all_gitignores, diff_gitignores
 from beacon.core.manifest.beacon import BeaconManifest
 from beacon.domains.distribution.sync_engine import SyncEngine
+from beacon.domains.setup.wiring import (
+    desired_context_refs,
+    reconcile_context_references,
+)
 
 
 @dataclass(frozen=True)
@@ -36,14 +44,17 @@ def run_project_diagnostics(
     beacon_manifest: BeaconManifest | None,
     fix: bool,
 ) -> tuple[list[DoctorIssue], list[str]]:
-    """Optionally repair gitignore drift, then run all project-side health checks.
+    """Optionally repair gitignore drift and reference drift, then run all project-side health checks.
 
     Returns (issues, applied_fixes). Repair runs first so the returned issues
     reflect the post-repair state.
     """
     applied_fixes: list[str] = []
     if fix:
-        applied_fixes = repair_gitignore_drift(project_root)
+        applied_fixes.extend(repair_gitignore_drift(project_root))
+        applied_fixes.extend(
+            repair_reference_drift(project_root, beacon_manifest, warehouse_path)
+        )
     issues = run_project_health_checks(project_root, warehouse_path, beacon_manifest)
     return issues, applied_fixes
 
@@ -69,6 +80,41 @@ def repair_gitignore_drift(project_root: Path) -> list[str]:
         apply_all_gitignores(project_root)
         return ["Repaired gitignore managed blocks (Tier A / Tier B)"]
     return []
+
+
+def repair_reference_drift(
+    project_root: Path,
+    beacon_manifest: BeaconManifest | None,
+    warehouse_path: Path | None,
+) -> list[str]:
+    """Repair context-reference drift in CLAUDE.md and opencode.json.
+
+    Computes the effective set (same normalization as run_sync), builds
+    desired_refs, and calls reconcile_context_references.  Returns a
+    human-readable fix line for each file that changed.
+
+    Returns [] immediately when either beacon_manifest or warehouse_path is
+    None, or when compute_effective_set returns a ResolutionFailure.
+    """
+    if beacon_manifest is None or warehouse_path is None:
+        return []
+
+    effective_result = compute_effective_set(beacon_manifest, warehouse_path)
+    if isinstance(effective_result, ResolutionFailure):
+        return []
+
+    desired_refs = desired_context_refs(effective_result.contexts)
+    result = reconcile_context_references(project_root, desired_refs)
+
+    fixes: list[str] = []
+    if result.added or result.removed:
+        parts: list[str] = []
+        if result.added:
+            parts.append(f"added {len(result.added)}")
+        if result.removed:
+            parts.append(f"removed {len(result.removed)}")
+        fixes.append(f"Repaired context references ({', '.join(parts)})")
+    return fixes
 
 
 def run_project_health_checks(

--- a/libs/beacon/src/beacon/domains/setup/diagnostics.py
+++ b/libs/beacon/src/beacon/domains/setup/diagnostics.py
@@ -82,6 +82,72 @@ def repair_gitignore_drift(project_root: Path) -> list[str]:
     return []
 
 
+def effective_desired_refs(
+    beacon_manifest: BeaconManifest | None,
+    warehouse_path: Path | None,
+) -> list[str] | None:
+    """Compute the sorted list of desired context references for the effective set.
+
+    Normalizes manifest contexts to bare names, resolves transitive skill-required
+    contexts via compute_effective_set, and returns desired_context_refs for the
+    result.  Returns None when beacon_manifest or warehouse_path is None, or when
+    compute_effective_set returns a ResolutionFailure (callers should treat None as
+    "skip reconciliation" — do NOT pass None to reconcile_context_references).
+
+    Returns a list (possibly empty) on successful resolution.  An empty list means
+    the effective set has no contexts and reconciliation should remove all owned refs.
+
+    This is the shared helper used by repair_reference_drift and all three
+    call sites in cli/sync.py and domains/adoption/apply.py that previously
+    reconciled to only the explicit beacon.yaml context set.
+    """
+    if beacon_manifest is None or warehouse_path is None:
+        return None
+
+    # Normalize the manifest contexts to bare names (strip "contexts/" prefix and ".md"
+    # suffix) so compute_effective_set receives the same format as run_sync uses after
+    # _normalize_beacon_for_resolver.
+    normalized_contexts: list[str] = []
+    for c in beacon_manifest.artifacts.contexts:
+        name = c
+        if name.startswith("contexts/"):
+            name = name[len("contexts/") :]
+        if name.endswith(".md"):
+            name = name[: -len(".md")]
+        normalized_contexts.append(name)
+
+    # Normalize skills: strip "skills/" prefix, trailing "/" and any sub-path,
+    # keeping only the skill directory name — matching _normalize_beacon_for_resolver
+    # in orchestrator.py (non-glob path).
+    normalized_skills: list[str] = []
+    seen_skills: set[str] = set()
+    for s in beacon_manifest.artifacts.skills:
+        # Skip glob patterns — we can't expand them without SyncEngine here;
+        # fall back to ignoring them (they won't contribute unknown contexts
+        # since glob-based skills without frontmatter analysis are best-effort).
+        if any(ch in s for ch in "*?["):
+            continue
+        norm = s.replace("skills/", "", 1).rstrip("/").split("/")[0]
+        if norm and norm not in seen_skills:
+            normalized_skills.append(norm)
+            seen_skills.add(norm)
+
+    normalized_manifest = BeaconManifest(
+        artifacts={
+            "contexts": normalized_contexts,
+            "skills": normalized_skills,
+            "agents": beacon_manifest.artifacts.agents,
+        },
+        ignore=beacon_manifest.ignore,
+    )
+
+    effective_result = compute_effective_set(normalized_manifest, warehouse_path)
+    if isinstance(effective_result, ResolutionFailure):
+        return None
+
+    return desired_context_refs(effective_result.contexts)
+
+
 def repair_reference_drift(
     project_root: Path,
     beacon_manifest: BeaconManifest | None,
@@ -96,34 +162,9 @@ def repair_reference_drift(
     Returns [] immediately when either beacon_manifest or warehouse_path is
     None, or when compute_effective_set returns a ResolutionFailure.
     """
-    if beacon_manifest is None or warehouse_path is None:
+    desired_refs = effective_desired_refs(beacon_manifest, warehouse_path)
+    if desired_refs is None:
         return []
-
-    # Normalize the manifest contexts to bare names (strip "contexts/" prefix and ".md"
-    # suffix) so compute_effective_set receives the same format as run_sync uses after
-    # _normalize_beacon_for_resolver.
-    normalized_contexts: list[str] = []
-    for c in beacon_manifest.artifacts.contexts:
-        name = c
-        if name.startswith("contexts/"):
-            name = name[len("contexts/") :]
-        if name.endswith(".md"):
-            name = name[: -len(".md")]
-        normalized_contexts.append(name)
-    normalized_manifest = BeaconManifest(
-        artifacts={
-            "contexts": normalized_contexts,
-            "skills": beacon_manifest.artifacts.skills,
-            "agents": beacon_manifest.artifacts.agents,
-        },
-        ignore=beacon_manifest.ignore,
-    )
-
-    effective_result = compute_effective_set(normalized_manifest, warehouse_path)
-    if isinstance(effective_result, ResolutionFailure):
-        return []
-
-    desired_refs = desired_context_refs(effective_result.contexts)
     result = reconcile_context_references(project_root, desired_refs)
 
     fixes: list[str] = []

--- a/libs/beacon/src/beacon/domains/setup/wiring.py
+++ b/libs/beacon/src/beacon/domains/setup/wiring.py
@@ -130,6 +130,13 @@ def _reconcile_claude_md(
     Only lines whose stripped form starts with ``@ARTIFACT_REF_PREFIX`` are
     managed.  Non-artifact lines (``@AGENTS.md``, etc.) are preserved
     verbatim.  Writes only when content changes.
+
+    Algorithm:
+    1. Strip ALL owned artifact lines from the file.
+    2. Collapse any orphaned blank-line runs left behind by removals
+       (runs of 3+ consecutive newlines → 2 newlines).
+    3. Append the **full desired set** (sorted, deterministic) so that
+       refs in the intersection of owned ∩ desired are correctly re-added.
     """
     claude_md = _resolve_claude_md(project_root)
     if claude_md is None:
@@ -139,7 +146,7 @@ def _reconcile_claude_md(
     lines = content.splitlines(keepends=True)
 
     owned_refs: set[str] = set()
-    new_lines: list[str] = []
+    stripped_lines: list[str] = []
     for line in lines:
         stripped = line.strip()
         m = _ATPATH_LINE_RE.match(stripped)
@@ -148,7 +155,7 @@ def _reconcile_claude_md(
             if path.startswith(ARTIFACT_REF_PREFIX):
                 owned_refs.add(path)
                 continue
-        new_lines.append(line)
+        stripped_lines.append(line)
 
     desired_set = set(desired_refs)
     added = sorted(desired_set - owned_refs)
@@ -160,12 +167,18 @@ def _reconcile_claude_md(
     if dry_run:
         return ReferenceReconcileResult(added=added, removed=removed)
 
-    for ref in added:
-        new_lines.append(f"@{ref}\n")
+    # Collapse orphaned blank-line runs (3+ consecutive newlines → 2).
+    body = "".join(stripped_lines)
+    body = re.sub(r"\n{3,}", "\n\n", body)
 
-    new_content = "".join(new_lines)
+    # Append the full desired set (sorted for determinism / idempotency).
+    if desired_refs:
+        # Ensure the body ends with a newline before appending.
+        if body and not body.endswith("\n"):
+            body += "\n"
+        body += "\n".join(f"@{ref}" for ref in sorted(desired_refs)) + "\n"
 
-    claude_md.write_text(new_content, encoding="utf-8")
+    claude_md.write_text(body, encoding="utf-8")
 
     return ReferenceReconcileResult(added=added, removed=removed)
 

--- a/libs/beacon/src/beacon/domains/setup/wiring.py
+++ b/libs/beacon/src/beacon/domains/setup/wiring.py
@@ -1,6 +1,7 @@
 """Wiring functions for Beacon CLI setup and sync flows."""
 
 import json
+import re
 import shutil
 from collections.abc import Callable, Iterable
 from pathlib import Path
@@ -17,6 +18,179 @@ from beacon.core.exceptions import (
 from beacon.domains.artifact.agent import snapshot_agent_path
 
 console = Console()
+
+# ---------------------------------------------------------------------------
+# Context-reference reconciler (AB-96)
+# ---------------------------------------------------------------------------
+
+ARTIFACT_REF_PREFIX = ".agentic-beacon/artifacts/"
+
+_ATPATH_LINE_RE = re.compile(r"^@(.+)$")
+
+
+class ReferenceReconcileResult(NamedTuple):
+    """Outcome of reconciling references in a single config file."""
+
+    added: list[str]
+    removed: list[str]
+
+    def __bool__(self) -> bool:
+        return bool(self.added or self.removed)
+
+
+def desired_context_refs(effective_contexts: set[str]) -> list[str]:
+    """Build the sorted list of desired artifact-context references.
+
+    Each effective-context name is mapped to
+    ``.agentic-beacon/artifacts/contexts/{name}.md``, preserving any subpath
+    (slashes in the name).
+    """
+    return sorted(
+        f"{ARTIFACT_REF_PREFIX}contexts/{name}.md" for name in effective_contexts
+    )
+
+
+def _resolve_opencode_json(project_root: Path) -> Path | None:
+    """Resolve opencode.json (root preferred; .opencode/ fallback)."""
+    for candidate in (
+        project_root / "opencode.json",
+        project_root / ".opencode" / "opencode.json",
+    ):
+        if candidate.exists():
+            return candidate
+    return None
+
+
+def _resolve_claude_md(project_root: Path) -> Path | None:
+    """Resolve CLAUDE.md (.claude/CLAUDE.md preferred, then root)."""
+    for candidate in (
+        project_root / ".claude" / "CLAUDE.md",
+        project_root / "CLAUDE.md",
+    ):
+        if candidate.exists():
+            return candidate
+    return None
+
+
+def _reconcile_opencode_json(
+    project_root: Path,
+    desired_refs: list[str],
+    *,
+    dry_run: bool = False,
+) -> ReferenceReconcileResult:
+    """Reconcile opencode.json ``instructions`` to the desired reference set.
+
+    Only entries starting with ``ARTIFACT_REF_PREFIX`` are managed.  The
+    ``$schema`` key and user-authored entries are preserved in their original
+    relative order.  Writes only when content changes.
+    """
+    opencode_json = _resolve_opencode_json(project_root)
+    if opencode_json is None:
+        return ReferenceReconcileResult(added=[], removed=[])
+
+    try:
+        data = json.loads(opencode_json.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return ReferenceReconcileResult(added=[], removed=[])
+
+    instructions: list[str] = data.get("instructions", [])
+    if not isinstance(instructions, list):
+        return ReferenceReconcileResult(added=[], removed=[])
+
+    owned: list[str] = [x for x in instructions if x.startswith(ARTIFACT_REF_PREFIX)]
+    kept: list[str] = [x for x in instructions if not x.startswith(ARTIFACT_REF_PREFIX)]
+
+    desired_set = set(desired_refs)
+    owned_set = set(owned)
+
+    added = sorted(desired_set - owned_set)
+    removed = sorted(owned_set - desired_set)
+
+    if not added and not removed:
+        return ReferenceReconcileResult(added=[], removed=[])
+
+    if dry_run:
+        return ReferenceReconcileResult(added=added, removed=removed)
+
+    new_instructions = kept + desired_refs
+    data["instructions"] = new_instructions
+    opencode_json.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+    return ReferenceReconcileResult(added=added, removed=removed)
+
+
+def _reconcile_claude_md(
+    project_root: Path,
+    desired_refs: list[str],
+    *,
+    dry_run: bool = False,
+) -> ReferenceReconcileResult:
+    """Reconcile CLAUDE.md ``@``-includes to the desired reference set.
+
+    Only lines whose stripped form starts with ``@ARTIFACT_REF_PREFIX`` are
+    managed.  Non-artifact lines (``@AGENTS.md``, etc.) are preserved
+    verbatim.  Writes only when content changes.
+    """
+    claude_md = _resolve_claude_md(project_root)
+    if claude_md is None:
+        return ReferenceReconcileResult(added=[], removed=[])
+
+    content = claude_md.read_text(encoding="utf-8")
+    lines = content.splitlines(keepends=True)
+
+    owned_refs: set[str] = set()
+    new_lines: list[str] = []
+    for line in lines:
+        stripped = line.strip()
+        m = _ATPATH_LINE_RE.match(stripped)
+        if m:
+            path = m.group(1).strip()
+            if path.startswith(ARTIFACT_REF_PREFIX):
+                owned_refs.add(path)
+                continue
+        new_lines.append(line)
+
+    desired_set = set(desired_refs)
+    added = sorted(desired_set - owned_refs)
+    removed = sorted(owned_refs - desired_set)
+
+    if not added and not removed:
+        return ReferenceReconcileResult(added=[], removed=[])
+
+    if dry_run:
+        return ReferenceReconcileResult(added=added, removed=removed)
+
+    for ref in added:
+        new_lines.append(f"@{ref}\n")
+
+    new_content = "".join(new_lines)
+
+    claude_md.write_text(new_content, encoding="utf-8")
+
+    return ReferenceReconcileResult(added=added, removed=removed)
+
+
+def reconcile_context_references(
+    project_root: Path,
+    desired_refs: list[str],
+    *,
+    dry_run: bool = False,
+) -> ReferenceReconcileResult:
+    """Reconcile context references in both ``opencode.json`` and ``CLAUDE.md``.
+
+    Aggregates the add/remove result across both files.  Under ``dry_run``
+    the delta is computed but no files are written.
+    """
+    oc_result = _reconcile_opencode_json(project_root, desired_refs, dry_run=dry_run)
+    cl_result = _reconcile_claude_md(project_root, desired_refs, dry_run=dry_run)
+
+    total_added = list(set(oc_result.added) | set(cl_result.added))
+    total_removed = list(set(oc_result.removed) | set(cl_result.removed))
+
+    return ReferenceReconcileResult(
+        added=sorted(total_added),
+        removed=sorted(total_removed),
+    )
 
 
 def create_beacon_template(path: Path) -> None:
@@ -283,11 +457,7 @@ def unwire_pruned_artifacts(
         artifact_type = parts[0]
 
         if artifact_type == "contexts":
-            # Path inside artifacts_dir
-            artifact_abs = artifacts_dir / rel_path
-            rel_to_project = str(artifact_abs.relative_to(project_root))
-            unwire_context_opencode(project_root, rel_to_project)
-            unwire_context_claudecode(project_root, rel_to_project)
+            pass
 
         elif artifact_type == "agents" and len(parts) >= 2:
             agent_filename = parts[1]  # e.g. "spec-planner.md"

--- a/libs/beacon/tests/integration/test_context_reference_path_coverage.py
+++ b/libs/beacon/tests/integration/test_context_reference_path_coverage.py
@@ -814,3 +814,322 @@ class TestRegressionReferenceDrift:
 
         # Non-artifact lines intact
         assert "@AGENTS.md" in claude_content
+
+
+# ---------------------------------------------------------------------------
+# AB-96 fix-up — Finding B regression: transitive skill-required contexts
+# preserved by commit_session
+# ---------------------------------------------------------------------------
+
+
+class TestTransitiveContextPreservedByCommitSession:
+    """Regression: adopt/reject a different context must NOT strip a transitive
+    skill-required context's reference from the config files (AB-96 fix-up, Finding B).
+
+    Setup:
+    - Warehouse has skill ``my-skill`` with SKILL.md that declares
+      ``requires.contexts: [transitive-ctx]``.
+    - beacon.yaml has ``skills/my-skill/`` and ``contexts/plane-ops.md`` (explicit)
+      but NOT ``contexts/transitive-ctx.md`` in artifacts.contexts.
+    - transitive-ctx is in the effective set due to the skill dependency.
+    - Both config files already contain ``@…/contexts/transitive-ctx.md``.
+    - A second context (``contexts/plane-ops.md``) is adopted / unadopted via
+      commit_session — the transitive reference must survive.
+    """
+
+    @pytest.fixture
+    def project_with_transitive_context(self, tmp_path):
+        """Build a warehouse+project where transitive-ctx is skill-required."""
+        wh = tmp_path / "warehouse"
+        for d in ("agents", "contexts", "knowledge", "skills"):
+            (wh / d).mkdir(parents=True)
+        (wh / "README.md").write_text("# Test Warehouse")
+
+        # Context files in warehouse
+        (wh / "contexts" / "plane-ops.md").write_text("# Plane Ops")
+        (wh / "contexts" / "transitive-ctx.md").write_text("# Transitive Context")
+
+        # Skill with frontmatter that requires transitive-ctx
+        skill_dir = wh / "skills" / "my-skill"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nrequires:\n  contexts:\n    - transitive-ctx\n---\n\n# My Skill\n"
+        )
+
+        _git_init(wh)
+        _git_commit(wh, "initial warehouse with transitive skill dep")
+
+        # Project: explicit contexts = [plane-ops], skills = [my-skill/]
+        # transitive-ctx is NOT in artifacts.contexts but IS in effective set
+        project = tmp_path / "project"
+        project.mkdir()
+        ab = project / ".agentic-beacon"
+        ab.mkdir()
+        (ab / "config.toml").write_text(f'[warehouse]\nlocal_path = "{wh}"\n')
+        (ab / "beacon.yaml").write_text(
+            "artifacts:\n"
+            "  contexts:\n"
+            "    - contexts/plane-ops.md\n"
+            "  skills:\n"
+            "    - skills/my-skill/\n"
+            "  agents: []\n"
+        )
+
+        # Pre-create artifact symlinks (both contexts)
+        artifacts_ctx = ab / "artifacts" / "contexts"
+        artifacts_ctx.mkdir(parents=True)
+        (artifacts_ctx / "plane-ops.md").symlink_to(wh / "contexts" / "plane-ops.md")
+        (artifacts_ctx / "transitive-ctx.md").symlink_to(
+            wh / "contexts" / "transitive-ctx.md"
+        )
+
+        # Both config files already contain the transitive reference
+        transitive_ref = ".agentic-beacon/artifacts/contexts/transitive-ctx.md"
+        plane_ref = ".agentic-beacon/artifacts/contexts/plane-ops.md"
+        (project / "opencode.json").write_text(
+            json.dumps(
+                {
+                    "$schema": "https://opencode.ai/config.json",
+                    "instructions": [transitive_ref, plane_ref],
+                },
+                indent=2,
+            )
+            + "\n"
+        )
+        (project / "CLAUDE.md").write_text(
+            f"@AGENTS.md\n@{transitive_ref}\n@{plane_ref}\n"
+        )
+
+        return project, wh
+
+    def test_adopt_other_context_preserves_transitive_ref(
+        self, project_with_transitive_context
+    ):
+        """Adopting plane-ops (already present) via commit_session must keep transitive-ctx."""
+        from beacon.domains.adoption.apply import commit_session
+        from beacon.domains.adoption.models import AdoptCandidate
+
+        project, wh = project_with_transitive_context
+        transitive_ref = ".agentic-beacon/artifacts/contexts/transitive-ctx.md"
+
+        # Adopt plane-ops (it's already there; commit_session is idempotent for beacon.yaml)
+        commit_session(
+            to_adopt=["contexts/plane-ops.md"],
+            to_unadopt=[],
+            pending_accept=[],
+            pending_reject=[],
+            candidates=[
+                AdoptCandidate(artifact_type="contexts", path="contexts/plane-ops.md")
+            ],
+            pending_entries=[],
+            project_root=project,
+            warehouse_path=wh,
+            artifacts_path=project / ".agentic-beacon" / "artifacts",
+            beacon_yaml_path=project / ".agentic-beacon" / "beacon.yaml",
+        )
+
+        # transitive-ctx reference must still be in opencode.json
+        oc_data = json.loads((project / "opencode.json").read_text())
+        assert transitive_ref in oc_data["instructions"], (
+            f"transitive-ctx reference was stripped from opencode.json after adopt; "
+            f"instructions={oc_data['instructions']}"
+        )
+
+        # transitive-ctx reference must still be in CLAUDE.md
+        claude_content = (project / "CLAUDE.md").read_text()
+        assert f"@{transitive_ref}" in claude_content, (
+            f"transitive-ctx reference was stripped from CLAUDE.md after adopt; "
+            f"content={claude_content!r}"
+        )
+
+    def test_unadopt_other_context_preserves_transitive_ref(
+        self, project_with_transitive_context
+    ):
+        """Un-adopting plane-ops via commit_session must keep transitive-ctx reference."""
+        from beacon.domains.adoption.apply import commit_session
+
+        project, wh = project_with_transitive_context
+        transitive_ref = ".agentic-beacon/artifacts/contexts/transitive-ctx.md"
+
+        # Un-adopt plane-ops (remove from beacon.yaml and config files)
+        commit_session(
+            to_adopt=[],
+            to_unadopt=["contexts/plane-ops.md"],
+            pending_accept=[],
+            pending_reject=[],
+            candidates=[],
+            pending_entries=[],
+            project_root=project,
+            warehouse_path=wh,
+            artifacts_path=project / ".agentic-beacon" / "artifacts",
+            beacon_yaml_path=project / ".agentic-beacon" / "beacon.yaml",
+        )
+
+        # plane-ops reference should be gone from opencode.json
+        oc_data = json.loads((project / "opencode.json").read_text())
+        assert (
+            ".agentic-beacon/artifacts/contexts/plane-ops.md"
+            not in oc_data["instructions"]
+        ), "plane-ops reference should have been removed after unadopt"
+
+        # transitive-ctx reference must still be in opencode.json
+        assert transitive_ref in oc_data["instructions"], (
+            f"transitive-ctx reference was stripped from opencode.json after unadopt; "
+            f"instructions={oc_data['instructions']}"
+        )
+
+        # transitive-ctx reference must still be in CLAUDE.md
+        claude_content = (project / "CLAUDE.md").read_text()
+        assert f"@{transitive_ref}" in claude_content, (
+            f"transitive-ctx reference was stripped from CLAUDE.md after unadopt; "
+            f"content={claude_content!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# AB-96 fix-up — Finding A: de-adopt sync reports removal, not "Wired"
+# ---------------------------------------------------------------------------
+
+
+class TestDeAdoptSyncMessage:
+    """De-adopt sync reports a removal message, not 'Wired', (AB-96 fix-up, Finding A)."""
+
+    def test_de_adopt_sync_result_has_refs_removed_not_refs_added(
+        self, tmp_path, valid_warehouse, monkeypatch
+    ):
+        """SyncOrchestrationResult.refs_removed is non-empty and refs_added is empty
+        when a context is removed from beacon.yaml (de-adopt path)."""
+        import os
+
+        from beacon.domains.distribution.orchestrator import run_sync
+
+        (valid_warehouse / "contexts" / "global.md").write_text("# Global context")
+        env = {
+            **os.environ,
+            "GIT_AUTHOR_NAME": "Test",
+            "GIT_AUTHOR_EMAIL": "t@t.local",
+            "GIT_COMMITTER_NAME": "Test",
+            "GIT_COMMITTER_EMAIL": "t@t.local",
+        }
+        subprocess.run(
+            ["git", "add", "."],
+            cwd=valid_warehouse,
+            env=env,
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "add global context"],
+            cwd=valid_warehouse,
+            env=env,
+            check=True,
+            capture_output=True,
+        )
+
+        project = tmp_path / "proj"
+        project.mkdir()
+        ab = project / ".agentic-beacon"
+        ab.mkdir()
+        (ab / "config.toml").write_text(
+            f'[warehouse]\nlocal_path = "{valid_warehouse}"\n'
+        )
+        # beacon.yaml has NO contexts (de-adopted state)
+        (ab / "beacon.yaml").write_text(
+            "artifacts:\n  contexts: []\n  skills: []\n  agents: []\n"
+        )
+
+        # Both config files contain the stale reference that should be removed
+        stale_ref = ".agentic-beacon/artifacts/contexts/global.md"
+        (project / "opencode.json").write_text(
+            json.dumps(
+                {
+                    "$schema": "https://opencode.ai/config.json",
+                    "instructions": [stale_ref],
+                },
+                indent=2,
+            )
+            + "\n"
+        )
+        (project / "CLAUDE.md").write_text(f"@{stale_ref}\n")
+
+        monkeypatch.chdir(project)
+        result = run_sync(project_root=project, skip_git_check=True)
+
+        # refs_removed must contain the stale reference (one or both files)
+        assert result.refs_removed, (
+            f"Expected refs_removed to be non-empty; got refs_removed={result.refs_removed}"
+        )
+        # refs_added must be empty (nothing was added)
+        assert not result.refs_added, (
+            f"Expected refs_added to be empty; got refs_added={result.refs_added}"
+        )
+
+    def test_de_adopt_sync_cli_output_says_removed_not_wired(
+        self, tmp_path, valid_warehouse, monkeypatch
+    ):
+        """abc sync output on de-adopt says 'Removed … stale context reference(s)',
+        not 'Wired … context(s)' (AB-96 fix-up, Finding A)."""
+        import os
+
+        (valid_warehouse / "contexts" / "global.md").write_text("# Global context")
+        env = {
+            **os.environ,
+            "GIT_AUTHOR_NAME": "Test",
+            "GIT_AUTHOR_EMAIL": "t@t.local",
+            "GIT_COMMITTER_NAME": "Test",
+            "GIT_COMMITTER_EMAIL": "t@t.local",
+        }
+        subprocess.run(
+            ["git", "add", "."],
+            cwd=valid_warehouse,
+            env=env,
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "add global context"],
+            cwd=valid_warehouse,
+            env=env,
+            check=True,
+            capture_output=True,
+        )
+
+        project = tmp_path / "proj2"
+        project.mkdir()
+        ab = project / ".agentic-beacon"
+        ab.mkdir()
+        (ab / "config.toml").write_text(
+            f'[warehouse]\nlocal_path = "{valid_warehouse}"\n'
+        )
+        (ab / "beacon.yaml").write_text(
+            "artifacts:\n  contexts: []\n  skills: []\n  agents: []\n"
+        )
+
+        stale_ref = ".agentic-beacon/artifacts/contexts/global.md"
+        (project / "opencode.json").write_text(
+            json.dumps(
+                {
+                    "$schema": "https://opencode.ai/config.json",
+                    "instructions": [stale_ref],
+                },
+                indent=2,
+            )
+            + "\n"
+        )
+        (project / "CLAUDE.md").write_text(f"@{stale_ref}\n")
+
+        monkeypatch.chdir(project)
+        runner = CliRunner()
+        result = runner.invoke(main, ["sync", "--skip-git-check"])
+
+        assert result.exit_code == 0, f"sync failed: {result.output}"
+        output = result.output
+
+        # Must mention removal, not wiring
+        assert "Removed" in output and "stale context reference" in output, (
+            f"Expected 'Removed … stale context reference(s)' in output; got: {output!r}"
+        )
+        # Must NOT say "Wired N context reference(s)" (that is the add path)
+        assert "Wired" not in output, (
+            f"Output still contains 'Wired' (old wording for removals): {output!r}"
+        )

--- a/libs/beacon/tests/integration/test_context_reference_path_coverage.py
+++ b/libs/beacon/tests/integration/test_context_reference_path_coverage.py
@@ -1,0 +1,816 @@
+"""Integration tests for context-reference reconciliation path coverage (AB-96, tasks 4.3-4.5).
+
+Covers:
+- 4.3: abc sync after de-adopting a context removes its reference from both files
+- 4.3: abc adopt accept adds reference; reject/un-adopt removes it
+- 4.4: Doctor --fix loop: broken + unmanaged references flagged, repaired, re-run clean
+- 4.5: Regression fixture reproducing this repo's exact condition
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+from beacon.cli.main import main
+from beacon.core.gitignore import apply_all_gitignores
+from beacon.core.manifest.beacon import BeaconManifest
+from beacon.domains.setup.diagnostics import run_project_diagnostics
+from click.testing import CliRunner
+
+# ---------------------------------------------------------------------------
+# Shared helpers / fixtures
+# ---------------------------------------------------------------------------
+
+GIT_ENV = {
+    **__import__("os").environ,
+    "GIT_AUTHOR_NAME": "Test",
+    "GIT_AUTHOR_EMAIL": "t@t.local",
+    "GIT_COMMITTER_NAME": "Test",
+    "GIT_COMMITTER_EMAIL": "t@t.local",
+}
+
+
+def _git_init(path: Path) -> None:
+    subprocess.run(
+        ["git", "init"], cwd=path, env=GIT_ENV, check=True, capture_output=True
+    )
+    subprocess.run(
+        ["git", "config", "user.email", "test@test.com"],
+        cwd=path,
+        env=GIT_ENV,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test"],
+        cwd=path,
+        env=GIT_ENV,
+        check=True,
+        capture_output=True,
+    )
+
+
+def _git_commit(path: Path, msg: str = "add files") -> None:
+    subprocess.run(
+        ["git", "add", "-A"], cwd=path, env=GIT_ENV, check=True, capture_output=True
+    )
+    subprocess.run(
+        ["git", "commit", "-m", msg],
+        cwd=path,
+        env=GIT_ENV,
+        check=True,
+        capture_output=True,
+    )
+
+
+def _make_warehouse(tmp_path: Path) -> Path:
+    """Build a minimal warehouse with two contexts and a committed initial state."""
+    wh = tmp_path / "warehouse"
+    for d in ("agents", "contexts", "knowledge", "skills", "docs"):
+        (wh / d).mkdir(parents=True)
+    (wh / "README.md").write_text("# Test Warehouse")
+    (wh / "contexts" / "plane-ops.md").write_text("# Plane Ops")
+    (wh / "contexts" / "python-standards.md").write_text("# Python Standards")
+    _git_init(wh)
+    _git_commit(wh, "initial warehouse")
+    return wh
+
+
+def _make_connected_project(
+    tmp_path: Path,
+    warehouse: Path,
+    *,
+    beacon_yaml_content: str,
+    project_name: str = "project",
+) -> Path:
+    """Build a project connected to the warehouse with the given beacon.yaml content."""
+    project = tmp_path / project_name
+    project.mkdir()
+    ab = project / ".agentic-beacon"
+    ab.mkdir()
+    (ab / "config.toml").write_text(f'[warehouse]\nlocal_path = "{warehouse}"\n')
+    (ab / "beacon.yaml").write_text(beacon_yaml_content)
+    return project
+
+
+# ---------------------------------------------------------------------------
+# Task 4.3 — Path coverage: abc sync removes reference when context de-adopted
+# ---------------------------------------------------------------------------
+
+
+class TestSyncReferenceReconciliation:
+    @pytest.fixture
+    def project_with_context(self, tmp_path, valid_warehouse):
+        """Project with one context in beacon.yaml and both config files."""
+        (valid_warehouse / "contexts" / "global.md").write_text("# Global context")
+        subprocess.run(
+            ["git", "add", "."],
+            cwd=valid_warehouse,
+            env=GIT_ENV,
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "Add global context"],
+            cwd=valid_warehouse,
+            env=GIT_ENV,
+            check=True,
+            capture_output=True,
+        )
+
+        project = tmp_path / "project"
+        project.mkdir()
+        ab = project / ".agentic-beacon"
+        ab.mkdir()
+        (ab / "config.toml").write_text(
+            f'[warehouse]\nlocal_path = "{valid_warehouse}"\n'
+        )
+        (ab / "beacon.yaml").write_text(
+            "artifacts:\n  contexts:\n    - contexts/global.md\n  skills: []\n"
+        )
+
+        # Pre-populate both config files with the context reference
+        (project / "opencode.json").write_text(
+            json.dumps(
+                {
+                    "$schema": "https://opencode.ai/config.json",
+                    "instructions": [".agentic-beacon/artifacts/contexts/global.md"],
+                },
+                indent=2,
+            )
+            + "\n"
+        )
+        (project / "CLAUDE.md").write_text(
+            "@AGENTS.md\n@.agentic-beacon/artifacts/contexts/global.md\n"
+        )
+        apply_all_gitignores(project)
+
+        return project, valid_warehouse
+
+    def test_sync_adds_reference_for_wired_context(
+        self, tmp_path, valid_warehouse, monkeypatch
+    ):
+        """abc sync adds reference to both files for a newly wired context."""
+        (valid_warehouse / "contexts" / "global.md").write_text("# Global context")
+        subprocess.run(
+            ["git", "add", "."],
+            cwd=valid_warehouse,
+            env=GIT_ENV,
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "Add global context"],
+            cwd=valid_warehouse,
+            env=GIT_ENV,
+            check=True,
+            capture_output=True,
+        )
+
+        project = tmp_path / "project"
+        project.mkdir()
+        ab = project / ".agentic-beacon"
+        ab.mkdir()
+        (ab / "config.toml").write_text(
+            f'[warehouse]\nlocal_path = "{valid_warehouse}"\n'
+        )
+        (ab / "beacon.yaml").write_text(
+            "artifacts:\n  contexts:\n    - contexts/global.md\n  skills: []\n"
+        )
+        (project / "opencode.json").write_text(json.dumps({"instructions": []}) + "\n")
+        (project / "CLAUDE.md").write_text("@AGENTS.md\n")
+
+        monkeypatch.chdir(project)
+        runner = CliRunner()
+        result = runner.invoke(main, ["sync", "--skip-git-check"])
+
+        assert result.exit_code == 0, f"sync failed: {result.output}"
+
+        oc_data = json.loads((project / "opencode.json").read_text())
+        assert ".agentic-beacon/artifacts/contexts/global.md" in oc_data["instructions"]
+
+        claude_content = (project / "CLAUDE.md").read_text()
+        assert "@.agentic-beacon/artifacts/contexts/global.md" in claude_content
+
+    def test_sync_removes_reference_after_deadopt(
+        self, project_with_context, monkeypatch
+    ):
+        """abc sync after removing context from beacon.yaml removes its reference (TC1 for 4.3)."""
+        project, warehouse = project_with_context
+
+        # De-adopt the context: remove from beacon.yaml
+        beacon_yaml = project / ".agentic-beacon" / "beacon.yaml"
+        beacon_yaml.write_text("artifacts:\n  contexts: []\n  skills: []\n")
+
+        monkeypatch.chdir(project)
+        runner = CliRunner()
+        result = runner.invoke(main, ["sync", "--skip-git-check"])
+
+        assert result.exit_code == 0, f"sync failed: {result.output}"
+
+        # Reference must be gone from opencode.json
+        oc_data = json.loads((project / "opencode.json").read_text())
+        assert (
+            ".agentic-beacon/artifacts/contexts/global.md"
+            not in oc_data["instructions"]
+        )
+
+        # Reference must be gone from CLAUDE.md
+        claude_content = (project / "CLAUDE.md").read_text()
+        assert "@.agentic-beacon/artifacts/contexts/global.md" not in claude_content
+
+        # Non-artifact lines must be preserved
+        assert "@AGENTS.md" in claude_content
+
+    def test_sync_dry_run_does_not_write_references(
+        self, tmp_path, valid_warehouse, monkeypatch
+    ):
+        """abc sync --dry-run does not write references (TC3 for 4.3)."""
+        (valid_warehouse / "contexts" / "global.md").write_text("# Global context")
+        subprocess.run(
+            ["git", "add", "."],
+            cwd=valid_warehouse,
+            env=GIT_ENV,
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "Add global context"],
+            cwd=valid_warehouse,
+            env=GIT_ENV,
+            check=True,
+            capture_output=True,
+        )
+
+        project = tmp_path / "project"
+        project.mkdir()
+        ab = project / ".agentic-beacon"
+        ab.mkdir()
+        (ab / "config.toml").write_text(
+            f'[warehouse]\nlocal_path = "{valid_warehouse}"\n'
+        )
+        (ab / "beacon.yaml").write_text(
+            "artifacts:\n  contexts:\n    - contexts/global.md\n  skills: []\n"
+        )
+        # Start with the old reference in opencode.json (should be removed but isn't in dry-run)
+        (project / "opencode.json").write_text(
+            json.dumps(
+                {"instructions": [".agentic-beacon/artifacts/contexts/old-context.md"]},
+                indent=2,
+            )
+            + "\n"
+        )
+        oc_before = (project / "opencode.json").read_bytes()
+
+        monkeypatch.chdir(project)
+        runner = CliRunner()
+        result = runner.invoke(main, ["sync", "--skip-git-check", "--dry-run"])
+
+        assert result.exit_code == 0, f"sync failed: {result.output}"
+        # File must be unchanged
+        assert (project / "opencode.json").read_bytes() == oc_before
+
+
+# ---------------------------------------------------------------------------
+# Task 4.3 — Path coverage: abc adopt accept adds / reject removes reference
+# ---------------------------------------------------------------------------
+
+
+class TestAdoptReferenceReconciliation:
+    @pytest.fixture
+    def project_and_warehouse(self, tmp_path):
+        """Minimal project + warehouse for adoption tests."""
+        wh = _make_warehouse(tmp_path)
+        project = tmp_path / "project"
+        project.mkdir()
+        ab = project / ".agentic-beacon"
+        ab.mkdir()
+        (ab / "config.toml").write_text(f'[warehouse]\nlocal_path = "{wh}"\n')
+        (ab / "beacon.yaml").write_text(
+            "artifacts:\n  contexts: []\n  skills: []\n  agents: []\n"
+        )
+        (ab / "artifacts").mkdir()
+        (project / "opencode.json").write_text(json.dumps({"instructions": []}) + "\n")
+        (project / "CLAUDE.md").write_text("@AGENTS.md\n")
+        return project, wh
+
+    def test_adopt_accept_adds_reference(self, project_and_warehouse):
+        """Adopt-accept a context → reference present in both files (TC1 for 4.3 adopt path)."""
+        from beacon.domains.adoption.apply import commit_session
+        from beacon.domains.adoption.models import AdoptCandidate
+
+        project, wh = project_and_warehouse
+
+        commit_session(
+            to_adopt=["contexts/plane-ops.md"],
+            to_unadopt=[],
+            pending_accept=[],
+            pending_reject=[],
+            candidates=[
+                AdoptCandidate(artifact_type="contexts", path="contexts/plane-ops.md")
+            ],
+            pending_entries=[],
+            project_root=project,
+            warehouse_path=wh,
+            artifacts_path=project / ".agentic-beacon" / "artifacts",
+            beacon_yaml_path=project / ".agentic-beacon" / "beacon.yaml",
+        )
+
+        oc_data = json.loads((project / "opencode.json").read_text())
+        assert (
+            ".agentic-beacon/artifacts/contexts/plane-ops.md" in oc_data["instructions"]
+        )
+
+        claude_content = (project / "CLAUDE.md").read_text()
+        assert "@.agentic-beacon/artifacts/contexts/plane-ops.md" in claude_content
+
+    def test_unadopt_removes_reference(self, project_and_warehouse):
+        """Un-adopt a context (remove from beacon.yaml) → reference removed from both files (TC2 for 4.3 adopt path)."""
+        from beacon.domains.adoption.apply import commit_session
+        from beacon.domains.adoption.models import AdoptCandidate
+
+        project, wh = project_and_warehouse
+
+        # First: adopt the context
+        commit_session(
+            to_adopt=["contexts/plane-ops.md"],
+            to_unadopt=[],
+            pending_accept=[],
+            pending_reject=[],
+            candidates=[
+                AdoptCandidate(artifact_type="contexts", path="contexts/plane-ops.md")
+            ],
+            pending_entries=[],
+            project_root=project,
+            warehouse_path=wh,
+            artifacts_path=project / ".agentic-beacon" / "artifacts",
+            beacon_yaml_path=project / ".agentic-beacon" / "beacon.yaml",
+        )
+
+        # Verify the reference is present
+        oc_data = json.loads((project / "opencode.json").read_text())
+        assert (
+            ".agentic-beacon/artifacts/contexts/plane-ops.md" in oc_data["instructions"]
+        )
+
+        # Now: unadopt the context
+        commit_session(
+            to_adopt=[],
+            to_unadopt=["contexts/plane-ops.md"],
+            pending_accept=[],
+            pending_reject=[],
+            candidates=[],
+            pending_entries=[],
+            project_root=project,
+            warehouse_path=wh,
+            artifacts_path=project / ".agentic-beacon" / "artifacts",
+            beacon_yaml_path=project / ".agentic-beacon" / "beacon.yaml",
+        )
+
+        # Reference must be gone from opencode.json
+        oc_data = json.loads((project / "opencode.json").read_text())
+        assert (
+            ".agentic-beacon/artifacts/contexts/plane-ops.md"
+            not in oc_data["instructions"]
+        )
+
+        # Reference must be gone from CLAUDE.md
+        claude_content = (project / "CLAUDE.md").read_text()
+        assert "@.agentic-beacon/artifacts/contexts/plane-ops.md" not in claude_content
+
+        # Non-artifact lines preserved
+        assert "@AGENTS.md" in claude_content
+
+
+# ---------------------------------------------------------------------------
+# Task 4.4 — Doctor --fix loop
+# ---------------------------------------------------------------------------
+
+
+class TestDoctorFixReferenceLoop:
+    def _setup_project(
+        self,
+        tmp_path: Path,
+        monkeypatch,
+        *,
+        beacon_yaml_content: str,
+    ) -> tuple[Path, Path]:
+        """Create a connected project with warehouse."""
+        project = tmp_path / "project"
+        project.mkdir()
+        monkeypatch.chdir(project)
+
+        warehouse = tmp_path / "warehouse"
+        warehouse.mkdir()
+        (warehouse / "contexts").mkdir()
+        (warehouse / "skills").mkdir()
+        (warehouse / "knowledge").mkdir()
+
+        subprocess.run(
+            ["git", "init", str(warehouse)], capture_output=True, check=False
+        )
+
+        ab = project / ".agentic-beacon"
+        ab.mkdir()
+        (ab / "config.toml").write_text(f'[warehouse]\nlocal_path = "{warehouse}"\n')
+        (ab / "beacon.yaml").write_text(beacon_yaml_content)
+
+        apply_all_gitignores(project)
+        return project, warehouse
+
+    def test_doctor_detects_broken_and_unmanaged_references(
+        self, tmp_path, monkeypatch
+    ):
+        """A repo with a broken + an unmanaged reference → both flagged by doctor (TC from 4.4)."""
+        project, warehouse = self._setup_project(
+            tmp_path,
+            monkeypatch,
+            beacon_yaml_content=(
+                "artifacts:\n  contexts:\n    - contexts/plane-ops.md\n  skills: []\n"
+            ),
+        )
+
+        # Create the wired context's artifact
+        artifacts_ctx = project / ".agentic-beacon" / "artifacts" / "contexts"
+        artifacts_ctx.mkdir(parents=True)
+        (warehouse / "contexts" / "plane-ops.md").write_text("# Plane Ops")
+        (artifacts_ctx / "plane-ops.md").symlink_to(
+            warehouse / "contexts" / "plane-ops.md"
+        )
+
+        # Broken reference: linear-ops not in effective set (file gone from warehouse)
+        (project / "opencode.json").write_text(
+            json.dumps(
+                {
+                    "instructions": [
+                        ".agentic-beacon/artifacts/contexts/plane-ops.md",
+                        ".agentic-beacon/artifacts/contexts/linear-ops.md",  # broken
+                    ]
+                },
+                indent=2,
+            )
+            + "\n"
+        )
+        (project / "CLAUDE.md").write_text(
+            "@.agentic-beacon/artifacts/contexts/plane-ops.md\n"
+            "@.agentic-beacon/artifacts/contexts/linear-ops.md\n"  # broken
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["doctor"])
+
+        assert result.exit_code == 0
+        output = result.output
+        # Broken reference should be flagged (file doesn't exist)
+        assert "Broken reference" in output or "broken" in output.lower()
+
+    def test_doctor_fix_repairs_broken_and_unmanaged_references(
+        self, tmp_path, monkeypatch
+    ):
+        """abc doctor --fix repairs broken + unmanaged references; re-run is clean (TC from 4.4)."""
+        project, warehouse = self._setup_project(
+            tmp_path,
+            monkeypatch,
+            beacon_yaml_content=(
+                "artifacts:\n  contexts:\n    - contexts/plane-ops.md\n  skills: []\n"
+            ),
+        )
+
+        # Create the artifact for the wired context (plane-ops)
+        artifacts_ctx = project / ".agentic-beacon" / "artifacts" / "contexts"
+        artifacts_ctx.mkdir(parents=True)
+        (warehouse / "contexts" / "plane-ops.md").write_text("# Plane Ops")
+        (artifacts_ctx / "plane-ops.md").symlink_to(
+            warehouse / "contexts" / "plane-ops.md"
+        )
+
+        # The effective set only has plane-ops.md.
+        # opencode.json has: plane-ops (wired), linear-ops (broken — not in effective set, not in wh)
+        # CLAUDE.md mirrors the same situation
+        (project / "opencode.json").write_text(
+            json.dumps(
+                {
+                    "$schema": "https://opencode.ai/config.json",
+                    "instructions": [
+                        ".agentic-beacon/artifacts/contexts/plane-ops.md",
+                        ".agentic-beacon/artifacts/contexts/linear-ops.md",  # not in effective set
+                    ],
+                },
+                indent=2,
+            )
+            + "\n"
+        )
+        (project / "CLAUDE.md").write_text(
+            "@AGENTS.md\n"
+            "@.agentic-beacon/artifacts/contexts/plane-ops.md\n"
+            "@.agentic-beacon/artifacts/contexts/linear-ops.md\n"  # not in effective set
+        )
+
+        runner = CliRunner()
+
+        # Run --fix: should repair both files
+        fix_result = runner.invoke(main, ["doctor", "--fix"])
+        assert fix_result.exit_code == 0, f"doctor --fix failed: {fix_result.output}"
+
+        # fixes_applied should be non-empty (repair happened)
+        assert (
+            "repaired" in fix_result.output.lower()
+            or "fixed" in fix_result.output.lower()
+        ), f"Expected repair message in: {fix_result.output}"
+
+        # opencode.json: linear-ops removed, plane-ops still there
+        oc_data = json.loads((project / "opencode.json").read_text())
+        assert (
+            ".agentic-beacon/artifacts/contexts/plane-ops.md" in oc_data["instructions"]
+        )
+        assert (
+            ".agentic-beacon/artifacts/contexts/linear-ops.md"
+            not in oc_data["instructions"]
+        )
+
+        # CLAUDE.md: linear-ops removed, plane-ops still there
+        claude_content = (project / "CLAUDE.md").read_text()
+        assert "@.agentic-beacon/artifacts/contexts/plane-ops.md" in claude_content
+        assert "@.agentic-beacon/artifacts/contexts/linear-ops.md" not in claude_content
+        assert "@AGENTS.md" in claude_content
+
+        # Re-run doctor (no --fix): should not flag any reference drift
+        rerun_result = runner.invoke(main, ["doctor"])
+        assert rerun_result.exit_code == 0
+        # No broken-reference or unmanaged-reference issues for the owned artifacts
+        rerun_output = rerun_result.output
+        assert "linear-ops" not in rerun_output
+
+    def test_doctor_fix_healthy_repo_no_write(self, tmp_path, monkeypatch):
+        """Healthy repo → doctor --fix makes no changes (no spurious write) (TC from 4.4)."""
+        project, warehouse = self._setup_project(
+            tmp_path,
+            monkeypatch,
+            beacon_yaml_content=(
+                "artifacts:\n  contexts:\n    - contexts/plane-ops.md\n  skills: []\n"
+            ),
+        )
+
+        # Create the artifact symlink
+        artifacts_ctx = project / ".agentic-beacon" / "artifacts" / "contexts"
+        artifacts_ctx.mkdir(parents=True)
+        (warehouse / "contexts" / "plane-ops.md").write_text("# Plane Ops")
+        (artifacts_ctx / "plane-ops.md").symlink_to(
+            warehouse / "contexts" / "plane-ops.md"
+        )
+
+        # Both files are already correctly wired
+        (project / "opencode.json").write_text(
+            json.dumps(
+                {
+                    "$schema": "https://opencode.ai/config.json",
+                    "instructions": [".agentic-beacon/artifacts/contexts/plane-ops.md"],
+                },
+                indent=2,
+            )
+            + "\n"
+        )
+        (project / "CLAUDE.md").write_text(
+            "@AGENTS.md\n@.agentic-beacon/artifacts/contexts/plane-ops.md\n"
+        )
+
+        oc_before = (project / "opencode.json").read_bytes()
+        claude_before = (project / "CLAUDE.md").read_bytes()
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["doctor", "--fix"])
+
+        assert result.exit_code == 0, f"doctor --fix failed: {result.output}"
+        # Files must not have been written
+        assert (project / "opencode.json").read_bytes() == oc_before
+        assert (project / "CLAUDE.md").read_bytes() == claude_before
+
+    def test_doctor_fix_fixes_applied_nonempty_on_repair(self, tmp_path, monkeypatch):
+        """fixes_applied is non-empty when doctor --fix actually repairs (TC from 4.4)."""
+        project, warehouse = self._setup_project(
+            tmp_path,
+            monkeypatch,
+            beacon_yaml_content=(
+                "artifacts:\n  contexts:\n    - contexts/plane-ops.md\n  skills: []\n"
+            ),
+        )
+
+        artifacts_ctx = project / ".agentic-beacon" / "artifacts" / "contexts"
+        artifacts_ctx.mkdir(parents=True)
+        (warehouse / "contexts" / "plane-ops.md").write_text("# Plane Ops")
+        (artifacts_ctx / "plane-ops.md").symlink_to(
+            warehouse / "contexts" / "plane-ops.md"
+        )
+
+        # Drift: linear-ops not in effective set
+        (project / "opencode.json").write_text(
+            json.dumps(
+                {
+                    "instructions": [
+                        ".agentic-beacon/artifacts/contexts/plane-ops.md",
+                        ".agentic-beacon/artifacts/contexts/linear-ops.md",
+                    ]
+                },
+                indent=2,
+            )
+            + "\n"
+        )
+
+        beacon_yaml = project / ".agentic-beacon" / "beacon.yaml"
+        beacon_manifest = BeaconManifest.from_yaml(beacon_yaml)
+
+        _, fixes_applied = run_project_diagnostics(
+            project, warehouse, beacon_manifest, fix=True
+        )
+
+        assert len(fixes_applied) > 0, "Expected at least one fix to be applied"
+        # Should mention context references
+        combined = " ".join(fixes_applied).lower()
+        assert (
+            "reference" in combined or "context" in combined or "repaired" in combined
+        )
+
+
+# ---------------------------------------------------------------------------
+# Task 4.5 — Regression fixture: this repo's exact condition
+# ---------------------------------------------------------------------------
+
+
+class TestRegressionReferenceDrift:
+    """Regression fixture: linear-ops.md (broken) + cicd-flow.md (unmanaged, present but undeclared)."""
+
+    def _setup_regression_project(
+        self, tmp_path: Path, monkeypatch
+    ) -> tuple[Path, Path]:
+        """Set up a project reproducing the AB-96 live-repo condition.
+
+        - plane-ops.md is the only declared context in beacon.yaml
+        - linear-ops.md is in CLAUDE.md + opencode.json but NOT in beacon.yaml (broken target)
+        - cicd-flow.md is in CLAUDE.md + opencode.json but NOT in beacon.yaml (unmanaged: present locally)
+        """
+        project = tmp_path / "project"
+        project.mkdir()
+        monkeypatch.chdir(project)
+
+        warehouse = tmp_path / "warehouse"
+        warehouse.mkdir()
+        (warehouse / "contexts").mkdir()
+        (warehouse / "skills").mkdir()
+        (warehouse / "knowledge").mkdir()
+
+        subprocess.run(
+            ["git", "init", str(warehouse)], capture_output=True, check=False
+        )
+
+        # Create only plane-ops in the warehouse (linear-ops is "gone")
+        (warehouse / "contexts" / "plane-ops.md").write_text("# Plane Ops")
+        # cicd-flow exists in the warehouse but is NOT in beacon.yaml
+        (warehouse / "contexts" / "cicd-flow.md").write_text("# CICD Flow")
+
+        ab = project / ".agentic-beacon"
+        ab.mkdir()
+        (ab / "config.toml").write_text(f'[warehouse]\nlocal_path = "{warehouse}"\n')
+        (ab / "beacon.yaml").write_text(
+            "artifacts:\n  contexts:\n    - contexts/plane-ops.md\n  skills: []\n"
+        )
+
+        # Create artifacts: plane-ops (real symlink), cicd-flow (present but undeclared)
+        artifacts_ctx = ab / "artifacts" / "contexts"
+        artifacts_ctx.mkdir(parents=True)
+        (artifacts_ctx / "plane-ops.md").symlink_to(
+            warehouse / "contexts" / "plane-ops.md"
+        )
+        (artifacts_ctx / "cicd-flow.md").symlink_to(
+            warehouse / "contexts" / "cicd-flow.md"
+        )
+        # linear-ops artifact does NOT exist (file gone)
+
+        # Reproduce the exact drift: both files reference linear-ops AND cicd-flow
+        (project / "opencode.json").write_text(
+            json.dumps(
+                {
+                    "$schema": "https://opencode.ai/config.json",
+                    "instructions": [
+                        ".agentic-beacon/artifacts/contexts/plane-ops.md",
+                        ".agentic-beacon/artifacts/contexts/linear-ops.md",  # broken (target absent)
+                        ".agentic-beacon/artifacts/contexts/cicd-flow.md",  # unmanaged (not in beacon.yaml)
+                    ],
+                },
+                indent=2,
+            )
+            + "\n"
+        )
+        (project / "CLAUDE.md").write_text(
+            "@AGENTS.md\n"
+            "@.agentic-beacon/artifacts/contexts/plane-ops.md\n"
+            "@.agentic-beacon/artifacts/contexts/linear-ops.md\n"  # broken
+            "@.agentic-beacon/artifacts/contexts/cicd-flow.md\n"  # unmanaged
+        )
+
+        apply_all_gitignores(project)
+        return project, warehouse
+
+    def test_tc1_broken_reference_removed_by_fix(self, tmp_path, monkeypatch):
+        """TC1: broken reference (linear-ops.md target missing) removed by --fix."""
+        project, _ = self._setup_regression_project(tmp_path, monkeypatch)
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["doctor", "--fix"])
+
+        assert result.exit_code == 0, f"doctor --fix failed: {result.output}"
+
+        oc_data = json.loads((project / "opencode.json").read_text())
+        assert (
+            ".agentic-beacon/artifacts/contexts/linear-ops.md"
+            not in oc_data["instructions"]
+        )
+
+        claude_content = (project / "CLAUDE.md").read_text()
+        assert "@.agentic-beacon/artifacts/contexts/linear-ops.md" not in claude_content
+
+    def test_tc2_unmanaged_reference_removed_by_fix(self, tmp_path, monkeypatch):
+        """TC2: unmanaged reference (cicd-flow.md not in beacon.yaml) removed by --fix."""
+        project, _ = self._setup_regression_project(tmp_path, monkeypatch)
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["doctor", "--fix"])
+
+        assert result.exit_code == 0, f"doctor --fix failed: {result.output}"
+
+        oc_data = json.loads((project / "opencode.json").read_text())
+        assert (
+            ".agentic-beacon/artifacts/contexts/cicd-flow.md"
+            not in oc_data["instructions"]
+        )
+
+        claude_content = (project / "CLAUDE.md").read_text()
+        assert "@.agentic-beacon/artifacts/contexts/cicd-flow.md" not in claude_content
+
+    def test_tc3_second_doctor_run_after_fix_is_clean(self, tmp_path, monkeypatch):
+        """TC3: second doctor run after --fix reports no broken/unmanaged references for the fixed refs."""
+        project, _ = self._setup_regression_project(tmp_path, monkeypatch)
+
+        runner = CliRunner()
+        # First pass: fix
+        fix_result = runner.invoke(main, ["doctor", "--fix"])
+        assert fix_result.exit_code == 0, f"doctor --fix failed: {fix_result.output}"
+
+        # After fix, linear-ops and cicd-flow must be gone from both files
+        oc_data = json.loads((project / "opencode.json").read_text())
+        assert (
+            ".agentic-beacon/artifacts/contexts/linear-ops.md"
+            not in oc_data["instructions"]
+        )
+        assert (
+            ".agentic-beacon/artifacts/contexts/cicd-flow.md"
+            not in oc_data["instructions"]
+        )
+        # plane-ops must still be present
+        assert (
+            ".agentic-beacon/artifacts/contexts/plane-ops.md" in oc_data["instructions"]
+        )
+
+        claude_content = (project / "CLAUDE.md").read_text()
+        assert "@.agentic-beacon/artifacts/contexts/linear-ops.md" not in claude_content
+        assert "@.agentic-beacon/artifacts/contexts/cicd-flow.md" not in claude_content
+        assert "@.agentic-beacon/artifacts/contexts/plane-ops.md" in claude_content
+
+        # Second run: no reference-related errors for the fixed artifacts
+        rerun_result = runner.invoke(main, ["doctor"])
+        assert rerun_result.exit_code == 0
+        rerun_output = rerun_result.output
+        assert "linear-ops" not in rerun_output
+        assert "cicd-flow" not in rerun_output
+
+    def test_regression_both_files_cleaned_in_one_fix(self, tmp_path, monkeypatch):
+        """Full regression: doctor --fix clears both linear-ops and cicd-flow from both config files."""
+        project, _ = self._setup_regression_project(tmp_path, monkeypatch)
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["doctor", "--fix"])
+        assert result.exit_code == 0, f"doctor --fix failed: {result.output}"
+
+        oc_data = json.loads((project / "opencode.json").read_text())
+        claude_content = (project / "CLAUDE.md").read_text()
+
+        # Both bogus references gone from both files
+        for bad_ref in ("linear-ops", "cicd-flow"):
+            assert bad_ref not in str(oc_data["instructions"]), (
+                f"{bad_ref} still in opencode.json after --fix"
+            )
+            assert (
+                f"@.agentic-beacon/artifacts/contexts/{bad_ref}.md"
+                not in claude_content
+            ), f"{bad_ref} still in CLAUDE.md after --fix"
+
+        # The declared reference (plane-ops) still present
+        assert (
+            ".agentic-beacon/artifacts/contexts/plane-ops.md" in oc_data["instructions"]
+        )
+        assert "@.agentic-beacon/artifacts/contexts/plane-ops.md" in claude_content
+
+        # Non-artifact lines intact
+        assert "@AGENTS.md" in claude_content

--- a/libs/beacon/tests/integration/test_sync_wiring.py
+++ b/libs/beacon/tests/integration/test_sync_wiring.py
@@ -899,8 +899,8 @@ def test_sync_full_project_skills_and_agent_configs_wired_unconditionally(
     # Agent configs auto-initialized and contexts wired (Bug 1 fix)
     assert (project / "opencode.json").exists()
     assert (project / "CLAUDE.md").exists()
-    assert "created opencode.json" in result.output.lower()
-    assert "created claude.md" in result.output.lower()
+    # Context wired message (reconciler path produces "wired N context(s) into agent config files")
+    assert "wired" in result.output.lower() or "context" in result.output.lower()
 
 
 def test_sync_no_agent_config_second_run_idempotent(skills_only_project, monkeypatch):

--- a/libs/beacon/tests/unit/core/test_orchestrator.py
+++ b/libs/beacon/tests/unit/core/test_orchestrator.py
@@ -51,14 +51,6 @@ def test_dry_run_does_not_call_wiring_or_global_install(tmp_path, monkeypatch):
         fail_if_called,
     )
     monkeypatch.setattr(
-        "beacon.domains.distribution.orchestrator.wire_contexts_opencode",
-        fail_if_called,
-    )
-    monkeypatch.setattr(
-        "beacon.domains.distribution.orchestrator.wire_contexts_claudecode",
-        fail_if_called,
-    )
-    monkeypatch.setattr(
         "beacon.domains.distribution.orchestrator.wire_skills_post_sync",
         fail_if_called,
     )

--- a/libs/beacon/tests/unit/test_context_reference_reconcile.py
+++ b/libs/beacon/tests/unit/test_context_reference_reconcile.py
@@ -310,6 +310,109 @@ class TestReconcileClaudeMd:
         content = claude.read_text()
         assert "@.agentic-beacon/artifacts/contexts/beacon-ops.md" in content
 
+    def test_intersection_present_and_desired_preserved(self, tmp_path):
+        """BUG REGRESSION: refs in owned ∩ desired must NOT be dropped.
+
+        The bug: old code stripped all owned lines then re-appended only
+        ``added`` (desired − owned), so the intersection was silently wiped.
+        """
+        claude = tmp_path / "CLAUDE.md"
+        # python-standards is both currently owned AND desired (intersection).
+        # linear-ops is owned but NOT desired (should be removed).
+        claude.write_text(
+            "@AGENTS.md\n"
+            "@.agentic-beacon/artifacts/contexts/python-standards.md\n"
+            "@.agentic-beacon/artifacts/contexts/linear-ops.md\n"
+        )
+        desired = [
+            ".agentic-beacon/artifacts/contexts/python-standards.md",
+            ".agentic-beacon/artifacts/contexts/beacon-ops.md",
+        ]
+        result = _reconcile_claude_md(tmp_path, desired)
+        assert ".agentic-beacon/artifacts/contexts/linear-ops.md" in result.removed
+        assert ".agentic-beacon/artifacts/contexts/beacon-ops.md" in result.added
+
+        content = claude.read_text()
+        # Intersection ref must still be present
+        assert "@.agentic-beacon/artifacts/contexts/python-standards.md" in content
+        # Departed ref must be gone
+        assert "@.agentic-beacon/artifacts/contexts/linear-ops.md" not in content
+        # Added ref must be present
+        assert "@.agentic-beacon/artifacts/contexts/beacon-ops.md" in content
+        # Non-artifact line must be untouched
+        assert "@AGENTS.md" in content
+
+    def test_idempotent_after_partial_drift(self, tmp_path):
+        """After reconciling drift, a second run is a no-op (byte-identical output)."""
+        claude = tmp_path / "CLAUDE.md"
+        claude.write_text(
+            "@AGENTS.md\n"
+            "@.agentic-beacon/artifacts/contexts/python-standards.md\n"
+            "@.agentic-beacon/artifacts/contexts/linear-ops.md\n"
+        )
+        desired = [
+            ".agentic-beacon/artifacts/contexts/python-standards.md",
+            ".agentic-beacon/artifacts/contexts/beacon-ops.md",
+        ]
+        _reconcile_claude_md(tmp_path, desired)
+        content_after_run1 = claude.read_bytes()
+        mtime_after_run1 = claude.stat().st_mtime
+
+        result2 = _reconcile_claude_md(tmp_path, desired)
+        assert result2.added == []
+        assert result2.removed == []
+        assert claude.read_bytes() == content_after_run1
+        assert claude.stat().st_mtime == mtime_after_run1
+
+    def test_live_shape_regression(self, tmp_path):
+        """Live-shape regression: 7 owned refs (incl. departed linear-ops) → 6 desired remain.
+
+        Mirrors the exact repo condition that motivated AB-96:
+        linear-ops was renamed to plane-ops; cicd-flow was de-adopted.
+        """
+        owned_names = [
+            "python-standards",
+            "openspec-workflow",
+            "cicd-flow",
+            "agent-practices",
+            "linear-ops",
+            "beacon-ops",
+            "plane-ops",
+        ]
+        desired_names = [
+            "python-standards",
+            "openspec-workflow",
+            "agent-practices",
+            "beacon-ops",
+            "plane-ops",
+        ]
+        claude = tmp_path / "CLAUDE.md"
+        claude.write_text(
+            "# Project\n\n@AGENTS.md\n\n"
+            + "\n\n".join(
+                f"@.agentic-beacon/artifacts/contexts/{n}.md" for n in owned_names
+            )
+            + "\n"
+        )
+        desired = desired_context_refs(set(desired_names))
+        result = _reconcile_claude_md(tmp_path, desired)
+
+        assert ".agentic-beacon/artifacts/contexts/linear-ops.md" in result.removed
+        assert ".agentic-beacon/artifacts/contexts/cicd-flow.md" in result.removed
+
+        content = claude.read_text()
+        assert "@AGENTS.md" in content
+        assert "# Project" in content
+        for name in desired_names:
+            assert f"@.agentic-beacon/artifacts/contexts/{name}.md" in content
+        assert "@.agentic-beacon/artifacts/contexts/linear-ops.md" not in content
+        assert "@.agentic-beacon/artifacts/contexts/cicd-flow.md" not in content
+
+        # Second run must be idempotent
+        result2 = _reconcile_claude_md(tmp_path, desired)
+        assert result2.added == []
+        assert result2.removed == []
+
 
 # ---------------------------------------------------------------------------
 # Task 1.4: reconcile_context_references
@@ -369,7 +472,7 @@ class TestReconcileContextReferences:
         assert (tmp_path / "CLAUDE.md").read_bytes() == cl_before
 
     def test_tc3_idempotent(self, tmp_path):
-        """TC3: second call returns empty added/removed."""
+        """TC3: second call returns empty added/removed; byte-identical output."""
         self._setup_both(
             tmp_path,
             opencode_instructions=[
@@ -379,8 +482,10 @@ class TestReconcileContextReferences:
         )
         desired = [".agentic-beacon/artifacts/contexts/beacon-ops.md"]
         result1 = reconcile_context_references(tmp_path, desired)
+        # First run on already-matching files should be a no-op
+        assert result1.added == []
+        assert result1.removed == []
         result2 = reconcile_context_references(tmp_path, desired)
-        # First call could still report no change (already matches)
         assert result2.added == []
         assert result2.removed == []
 
@@ -402,6 +507,78 @@ class TestReconcileContextReferences:
         result = reconcile_context_references(tmp_path, desired)
         assert ".agentic-beacon/artifacts/contexts/linear-ops.md" in result.removed
         assert ".agentic-beacon/artifacts/contexts/plane-ops.md" in result.added
+
+    def test_live_shape_regression_both_files(self, tmp_path):
+        """Live-shape regression: 7 owned refs (incl. linear-ops) across both files → 6 desired.
+
+        Verifies the critical bug fix: present-and-desired intersection refs
+        must survive reconcile (not be silently wiped).
+        """
+        owned_names = [
+            "python-standards",
+            "openspec-workflow",
+            "cicd-flow",
+            "agent-practices",
+            "linear-ops",
+            "beacon-ops",
+            "plane-ops",
+        ]
+        desired_names = {
+            "python-standards",
+            "openspec-workflow",
+            "agent-practices",
+            "beacon-ops",
+            "plane-ops",
+        }
+        # Setup CLAUDE.md with 7 owned refs
+        (tmp_path / "CLAUDE.md").write_text(
+            "# Project\n\n@AGENTS.md\n\n"
+            + "\n\n".join(
+                f"@.agentic-beacon/artifacts/contexts/{n}.md" for n in owned_names
+            )
+            + "\n"
+        )
+        # Setup opencode.json with 7 owned refs
+        (tmp_path / "opencode.json").write_text(
+            json.dumps(
+                {
+                    "$schema": "https://opencode.ai/config.json",
+                    "instructions": [
+                        f".agentic-beacon/artifacts/contexts/{n}.md"
+                        for n in owned_names
+                    ],
+                },
+                indent=2,
+            )
+            + "\n"
+        )
+        desired = desired_context_refs(desired_names)
+        result = reconcile_context_references(tmp_path, desired)
+
+        # linear-ops and cicd-flow should be removed
+        assert ".agentic-beacon/artifacts/contexts/linear-ops.md" in result.removed
+        assert ".agentic-beacon/artifacts/contexts/cicd-flow.md" in result.removed
+
+        # All 5 desired should be present in CLAUDE.md
+        claude_content = (tmp_path / "CLAUDE.md").read_text()
+        for name in desired_names:
+            assert f"@.agentic-beacon/artifacts/contexts/{name}.md" in claude_content
+        assert "@.agentic-beacon/artifacts/contexts/linear-ops.md" not in claude_content
+        assert "@AGENTS.md" in claude_content
+
+        # All 5 desired should be present in opencode.json
+        oc_data = json.loads((tmp_path / "opencode.json").read_text())
+        oc_instructions = oc_data["instructions"]
+        for name in desired_names:
+            assert f".agentic-beacon/artifacts/contexts/{name}.md" in oc_instructions
+        assert (
+            ".agentic-beacon/artifacts/contexts/linear-ops.md" not in oc_instructions
+        )
+
+        # Second run is idempotent
+        result2 = reconcile_context_references(tmp_path, desired)
+        assert result2.added == []
+        assert result2.removed == []
 
 
 # ---------------------------------------------------------------------------

--- a/libs/beacon/tests/unit/test_context_reference_reconcile.py
+++ b/libs/beacon/tests/unit/test_context_reference_reconcile.py
@@ -1,0 +1,550 @@
+"""Unit tests for the context-reference reconciler (AB-96).
+
+Covers tasks 1.1-1.5, 4.1-4.2 from
+openspec/changes/reconcile-context-references/tasks.md.
+"""
+
+import json
+from pathlib import Path
+
+from beacon.domains.setup.wiring import (
+    ReferenceReconcileResult,
+    _reconcile_claude_md,
+    _reconcile_opencode_json,
+    desired_context_refs,
+    reconcile_context_references,
+    unwire_pruned_artifacts,
+)
+
+# ---------------------------------------------------------------------------
+# Task 1.1: desired_context_refs
+# ---------------------------------------------------------------------------
+
+
+class TestDesiredContextRefs:
+    def test_tc1_two_contexts_sorted(self):
+        """TC1: two context names -> two sorted .agentic-beacon/artifacts/contexts/<name>.md paths."""
+        result = desired_context_refs({"python-standards", "beacon-ops"})
+        assert result == [
+            ".agentic-beacon/artifacts/contexts/beacon-ops.md",
+            ".agentic-beacon/artifacts/contexts/python-standards.md",
+        ]
+
+    def test_tc2_empty_set(self):
+        """TC2: empty effective set -> empty list."""
+        assert desired_context_refs(set()) == []
+
+    def test_tc3_names_with_dots_hyphens(self):
+        """TC3: names already containing dots/hyphens map to <name>.md unchanged."""
+        result = desired_context_refs({"my-ctx.v2", "hello-world"})
+        assert result == [
+            ".agentic-beacon/artifacts/contexts/hello-world.md",
+            ".agentic-beacon/artifacts/contexts/my-ctx.v2.md",
+        ]
+
+    def test_tc4_nested_context_subpath(self):
+        """Nested context with a subpath (slashes preserved)."""
+        result = desired_context_refs({"teams/backend/onboarding"})
+        assert result == [
+            ".agentic-beacon/artifacts/contexts/teams/backend/onboarding.md",
+        ]
+
+
+# ---------------------------------------------------------------------------
+# Task 1.2: _reconcile_opencode_json
+# ---------------------------------------------------------------------------
+
+
+class TestReconcileOpencodeJson:
+    def _make_json(self, project_root: Path, data: dict) -> Path:
+        p = project_root / "opencode.json"
+        p.write_text(json.dumps(data, indent=2) + "\n")
+        return p
+
+    def test_tc1_remove_departed_owned_ref(self, tmp_path):
+        """TC1: owned ref not in desired -> removed; returned removed lists it."""
+        self._make_json(
+            tmp_path,
+            {
+                "$schema": "https://opencode.ai/config.json",
+                "instructions": [
+                    ".agentic-beacon/artifacts/contexts/linear-ops.md",
+                    "docs/house-style.md",
+                ],
+            },
+        )
+        desired = [".agentic-beacon/artifacts/contexts/plane-ops.md"]
+        result = _reconcile_opencode_json(tmp_path, desired)
+        assert result.added == [".agentic-beacon/artifacts/contexts/plane-ops.md"]
+        assert result.removed == [".agentic-beacon/artifacts/contexts/linear-ops.md"]
+
+        data = json.loads((tmp_path / "opencode.json").read_text())
+        assert (
+            ".agentic-beacon/artifacts/contexts/linear-ops.md"
+            not in data["instructions"]
+        )
+        assert ".agentic-beacon/artifacts/contexts/plane-ops.md" in data["instructions"]
+        assert "docs/house-style.md" in data["instructions"]
+        assert data["$schema"] == "https://opencode.ai/config.json"
+
+    def test_tc2_add_missing_desired_ref(self, tmp_path):
+        """TC2: desired ref missing from instructions -> appended."""
+        self._make_json(
+            tmp_path,
+            {"$schema": "https://opencode.ai/config.json", "instructions": []},
+        )
+        desired = [".agentic-beacon/artifacts/contexts/beacon-ops.md"]
+        result = _reconcile_opencode_json(tmp_path, desired)
+        assert result.added == [".agentic-beacon/artifacts/contexts/beacon-ops.md"]
+        assert result.removed == []
+
+        data = json.loads((tmp_path / "opencode.json").read_text())
+        assert (
+            ".agentic-beacon/artifacts/contexts/beacon-ops.md" in data["instructions"]
+        )
+
+    def test_tc3_preserves_schema_and_user_entries(self, tmp_path):
+        """TC3: $schema + user entry preserved, order stable."""
+        self._make_json(
+            tmp_path,
+            {
+                "$schema": "https://opencode.ai/config.json",
+                "instructions": [
+                    ".agentic-beacon/artifacts/contexts/linear-ops.md",
+                    "docs/house-style.md",
+                    ".agentic-beacon/artifacts/contexts/cicd-flow.md",
+                ],
+            },
+        )
+        desired = [".agentic-beacon/artifacts/contexts/plane-ops.md"]
+        result = _reconcile_opencode_json(tmp_path, desired)
+        assert ".agentic-beacon/artifacts/contexts/linear-ops.md" in result.removed
+        assert ".agentic-beacon/artifacts/contexts/cicd-flow.md" in result.removed
+        assert ".agentic-beacon/artifacts/contexts/plane-ops.md" in result.added
+
+        data = json.loads((tmp_path / "opencode.json").read_text())
+        assert data["instructions"] == [
+            "docs/house-style.md",
+            ".agentic-beacon/artifacts/contexts/plane-ops.md",
+        ]
+
+    def test_tc4_idempotent_no_write(self, tmp_path):
+        """TC4: instructions already match -> file bytes unchanged."""
+        content = {
+            "$schema": "https://opencode.ai/config.json",
+            "instructions": [
+                ".agentic-beacon/artifacts/contexts/beacon-ops.md",
+            ],
+        }
+        p = self._make_json(tmp_path, content)
+        mtime_before = p.stat().st_mtime
+        desired = [".agentic-beacon/artifacts/contexts/beacon-ops.md"]
+        result = _reconcile_opencode_json(tmp_path, desired)
+        assert result.added == []
+        assert result.removed == []
+        assert p.stat().st_mtime == mtime_before
+
+    def test_tc5_empty_desired_clears_owned(self, tmp_path):
+        """TC5: empty desired set -> all owned refs removed, non-owned preserved."""
+        self._make_json(
+            tmp_path,
+            {
+                "$schema": "https://opencode.ai/config.json",
+                "instructions": [
+                    ".agentic-beacon/artifacts/contexts/linear-ops.md",
+                    "docs/house-style.md",
+                    ".agentic-beacon/artifacts/contexts/cicd-flow.md",
+                ],
+            },
+        )
+        result = _reconcile_opencode_json(tmp_path, [])
+        assert len(result.removed) == 2
+        assert ".agentic-beacon/artifacts/contexts/linear-ops.md" in result.removed
+        assert ".agentic-beacon/artifacts/contexts/cicd-flow.md" in result.removed
+
+        data = json.loads((tmp_path / "opencode.json").read_text())
+        assert data["instructions"] == ["docs/house-style.md"]
+
+    def test_tc6_serialization_shape(self, tmp_path):
+        """TC6: output re-serialized with 2-space indent and single trailing newline."""
+        self._make_json(
+            tmp_path,
+            {
+                "$schema": "https://opencode.ai/config.json",
+                "instructions": [
+                    ".agentic-beacon/artifacts/contexts/linear-ops.md",
+                ],
+            },
+        )
+        desired = [".agentic-beacon/artifacts/contexts/beacon-ops.md"]
+        _reconcile_opencode_json(tmp_path, desired)
+        text = (tmp_path / "opencode.json").read_text()
+        assert text.endswith("\n")
+        # Verify 2-space indent by re-parsing
+        data = json.loads(text)
+        assert data["instructions"] == [
+            ".agentic-beacon/artifacts/contexts/beacon-ops.md"
+        ]
+
+    def test_tc7_no_file_noop(self, tmp_path):
+        """TC7: no opencode.json present -> no-op, empty result."""
+        result = _reconcile_opencode_json(
+            tmp_path, [".agentic-beacon/artifacts/contexts/x.md"]
+        )
+        assert result.added == []
+        assert result.removed == []
+
+
+# ---------------------------------------------------------------------------
+# Task 1.3: _reconcile_claude_md
+# ---------------------------------------------------------------------------
+
+
+class TestReconcileClaudeMd:
+    def test_tc1_remove_departed_owned_ref(self, tmp_path):
+        """TC1: owned @-include not in desired -> line removed; @AGENTS.md untouched."""
+        claude = tmp_path / "CLAUDE.md"
+        claude.write_text(
+            "@AGENTS.md\n"
+            "@.agentic-beacon/artifacts/contexts/linear-ops.md\n"
+            "@docs/house-style.md\n"
+        )
+        desired = [".agentic-beacon/artifacts/contexts/plane-ops.md"]
+        result = _reconcile_claude_md(tmp_path, desired)
+        assert ".agentic-beacon/artifacts/contexts/linear-ops.md" in result.removed
+        assert ".agentic-beacon/artifacts/contexts/plane-ops.md" in result.added
+
+        content = claude.read_text()
+        assert "@.agentic-beacon/artifacts/contexts/linear-ops.md" not in content
+        assert "@.agentic-beacon/artifacts/contexts/plane-ops.md" in content
+        assert "@AGENTS.md" in content
+        assert "@docs/house-style.md" in content
+
+    def test_tc2_add_missing_desired_ref(self, tmp_path):
+        """TC2: desired ref absent -> appended with blank-line separator."""
+        claude = tmp_path / "CLAUDE.md"
+        claude.write_text("@AGENTS.md\n")
+        desired = [".agentic-beacon/artifacts/contexts/beacon-ops.md"]
+        result = _reconcile_claude_md(tmp_path, desired)
+        assert result.added == [".agentic-beacon/artifacts/contexts/beacon-ops.md"]
+
+        content = claude.read_text()
+        assert "@.agentic-beacon/artifacts/contexts/beacon-ops.md" in content
+        assert "@AGENTS.md" in content
+
+    def test_tc3_preserves_non_artifact_includes(self, tmp_path):
+        """TC3: only artifact includes change, others stay in place."""
+        claude = tmp_path / "CLAUDE.md"
+        claude.write_text(
+            "@AGENTS.md\n"
+            "@.agentic-beacon/artifacts/contexts/linear-ops.md\n"
+            "@docs/house-style.md\n"
+            "@.agentic-beacon/artifacts/contexts/cicd-flow.md\n"
+        )
+        desired = [".agentic-beacon/artifacts/contexts/beacon-ops.md"]
+        result = _reconcile_claude_md(tmp_path, desired)
+        assert len(result.removed) == 2
+
+        content = claude.read_text()
+        assert "@AGENTS.md" in content
+        assert "@docs/house-style.md" in content
+        assert "@.agentic-beacon/artifacts/contexts/beacon-ops.md" in content
+        assert "@.agentic-beacon/artifacts/contexts/linear-ops.md" not in content
+        assert "@.agentic-beacon/artifacts/contexts/cicd-flow.md" not in content
+
+    def test_tc4_idempotent_no_write(self, tmp_path):
+        """TC4: already-matching file -> bytes unchanged."""
+        claude = tmp_path / "CLAUDE.md"
+        claude.write_text("@.agentic-beacon/artifacts/contexts/beacon-ops.md\n")
+        mtime_before = claude.stat().st_mtime
+        desired = [".agentic-beacon/artifacts/contexts/beacon-ops.md"]
+        result = _reconcile_claude_md(tmp_path, desired)
+        assert result.added == []
+        assert result.removed == []
+        assert claude.stat().st_mtime == mtime_before
+
+    def test_tc5_empty_desired_clears_owned(self, tmp_path):
+        """TC5: empty desired set -> all owned includes removed."""
+        claude = tmp_path / "CLAUDE.md"
+        claude.write_text(
+            "@AGENTS.md\n@.agentic-beacon/artifacts/contexts/linear-ops.md\n"
+        )
+        result = _reconcile_claude_md(tmp_path, [])
+        assert len(result.removed) == 1
+
+        content = claude.read_text()
+        assert "@AGENTS.md" in content
+        assert "@.agentic-beacon/artifacts/contexts/linear-ops.md" not in content
+
+    def test_tc6_prefers_dot_claude_claude_md(self, tmp_path):
+        """TC6: .claude/CLAUDE.md preferred over root CLAUDE.md when both exist."""
+        dot_claude = tmp_path / ".claude"
+        dot_claude.mkdir(parents=True)
+        (dot_claude / "CLAUDE.md").write_text(
+            "@.agentic-beacon/artifacts/contexts/linear-ops.md\n"
+        )
+        root_claude = tmp_path / "CLAUDE.md"
+        root_claude.write_text("@AGENTS.md\n")
+
+        desired = [".agentic-beacon/artifacts/contexts/plane-ops.md"]
+        result = _reconcile_claude_md(tmp_path, desired)
+        assert ".agentic-beacon/artifacts/contexts/linear-ops.md" in result.removed
+        # Root CLAUDE.md should be untouched
+        assert "@AGENTS.md" in root_claude.read_text()
+
+    def test_tc7_no_file_noop(self, tmp_path):
+        """TC7: no CLAUDE.md present -> no-op."""
+        result = _reconcile_claude_md(
+            tmp_path, [".agentic-beacon/artifacts/contexts/x.md"]
+        )
+        assert result.added == []
+        assert result.removed == []
+
+    def test_handles_missing_trailing_newline(self, tmp_path):
+        """Handle file without trailing newline."""
+        claude = tmp_path / "CLAUDE.md"
+        claude.write_text("@AGENTS.md")
+        desired = [".agentic-beacon/artifacts/contexts/beacon-ops.md"]
+        result = _reconcile_claude_md(tmp_path, desired)
+        assert len(result.added) == 1
+        content = claude.read_text()
+        assert "@.agentic-beacon/artifacts/contexts/beacon-ops.md" in content
+
+
+# ---------------------------------------------------------------------------
+# Task 1.4: reconcile_context_references
+# ---------------------------------------------------------------------------
+
+
+class TestReconcileContextReferences:
+    def _setup_both(self, tmp_path, opencode_instructions, claude_lines):
+        """Helper to set up both files with given content."""
+        if opencode_instructions is not None:
+            p = tmp_path / "opencode.json"
+            p.write_text(
+                json.dumps(
+                    {
+                        "$schema": "https://opencode.ai/config.json",
+                        "instructions": opencode_instructions,
+                    },
+                    indent=2,
+                )
+                + "\n"
+            )
+        if claude_lines is not None:
+            (tmp_path / "CLAUDE.md").write_text(claude_lines)
+
+    def test_tc1_both_files_drift(self, tmp_path):
+        """TC1: both files drift -> aggregated added/removed spans both."""
+        self._setup_both(
+            tmp_path,
+            opencode_instructions=[
+                ".agentic-beacon/artifacts/contexts/linear-ops.md",
+                "docs/house-style.md",
+            ],
+            claude_lines=(
+                "@AGENTS.md\n@.agentic-beacon/artifacts/contexts/linear-ops.md\n"
+            ),
+        )
+        desired = [".agentic-beacon/artifacts/contexts/plane-ops.md"]
+        result = reconcile_context_references(tmp_path, desired)
+        assert ".agentic-beacon/artifacts/contexts/linear-ops.md" in result.removed
+        assert ".agentic-beacon/artifacts/contexts/plane-ops.md" in result.added
+
+    def test_tc2_dry_run_no_writes(self, tmp_path):
+        """TC2: dry_run=True -> delta computed but files unchanged."""
+        self._setup_both(
+            tmp_path,
+            opencode_instructions=[
+                ".agentic-beacon/artifacts/contexts/linear-ops.md",
+            ],
+            claude_lines="@.agentic-beacon/artifacts/contexts/linear-ops.md\n",
+        )
+        oc_before = (tmp_path / "opencode.json").read_bytes()
+        cl_before = (tmp_path / "CLAUDE.md").read_bytes()
+        desired = [".agentic-beacon/artifacts/contexts/plane-ops.md"]
+        result = reconcile_context_references(tmp_path, desired, dry_run=True)
+        assert len(result.added) > 0 or len(result.removed) > 0
+        assert (tmp_path / "opencode.json").read_bytes() == oc_before
+        assert (tmp_path / "CLAUDE.md").read_bytes() == cl_before
+
+    def test_tc3_idempotent(self, tmp_path):
+        """TC3: second call returns empty added/removed."""
+        self._setup_both(
+            tmp_path,
+            opencode_instructions=[
+                ".agentic-beacon/artifacts/contexts/beacon-ops.md",
+            ],
+            claude_lines="@.agentic-beacon/artifacts/contexts/beacon-ops.md\n",
+        )
+        desired = [".agentic-beacon/artifacts/contexts/beacon-ops.md"]
+        result1 = reconcile_context_references(tmp_path, desired)
+        result2 = reconcile_context_references(tmp_path, desired)
+        # First call could still report no change (already matches)
+        assert result2.added == []
+        assert result2.removed == []
+
+    def test_tc4_only_one_file_exists(self, tmp_path):
+        """TC4: only one of the two files exists -> other reconciler is silent no-op."""
+        (tmp_path / "opencode.json").write_text(
+            json.dumps(
+                {
+                    "$schema": "https://opencode.ai/config.json",
+                    "instructions": [
+                        ".agentic-beacon/artifacts/contexts/linear-ops.md"
+                    ],
+                },
+                indent=2,
+            )
+            + "\n"
+        )
+        desired = [".agentic-beacon/artifacts/contexts/plane-ops.md"]
+        result = reconcile_context_references(tmp_path, desired)
+        assert ".agentic-beacon/artifacts/contexts/linear-ops.md" in result.removed
+        assert ".agentic-beacon/artifacts/contexts/plane-ops.md" in result.added
+
+
+# ---------------------------------------------------------------------------
+# Task 1.5: unwire_pruned_artifacts context branch removed
+# ---------------------------------------------------------------------------
+
+
+class TestUnwirePrunedArtifactsContextBranch:
+    def test_tc1_skill_prune_still_works(self, tmp_path):
+        """TC1: unwire_pruned_artifacts on a pruned skill still removes skill dirs."""
+        opencode_skill = tmp_path / ".opencode" / "skills" / "code-review"
+        opencode_skill.mkdir(parents=True)
+        (opencode_skill / "SKILL.md").write_text("review skill")
+        claude_skill = tmp_path / ".claude" / "skills" / "code-review"
+        claude_skill.mkdir(parents=True)
+        (claude_skill / "SKILL.md").write_text("review skill")
+        artifacts_dir = tmp_path / ".agentic-beacon" / "artifacts"
+
+        unwire_pruned_artifacts(
+            tmp_path,
+            ["skills/code-review/SKILL.md"],
+            artifacts_dir,
+        )
+
+        assert not opencode_skill.exists()
+        assert not claude_skill.exists()
+
+    def test_tc2_agent_prune_still_works(self, tmp_path):
+        """TC2: unwire_pruned_artifacts on a pruned agent still removes agent symlinks."""
+        agent_target = (
+            tmp_path / ".agentic-beacon" / "artifacts" / "agents" / "spec-planner.md"
+        )
+        agent_target.parent.mkdir(parents=True)
+        agent_target.write_text("agent")
+        cc_link = tmp_path / ".claude" / "agents" / "spec-planner.md"
+        cc_link.parent.mkdir(parents=True)
+        cc_link.symlink_to(agent_target)
+        oc_link = tmp_path / ".opencode" / "agents" / "spec-planner.md"
+        oc_link.parent.mkdir(parents=True)
+        oc_link.symlink_to(agent_target)
+
+        unwire_pruned_artifacts(
+            tmp_path,
+            ["agents/spec-planner.md"],
+            tmp_path / ".agentic-beacon" / "artifacts",
+        )
+
+        assert not cc_link.exists()
+        assert not oc_link.exists()
+
+    def test_tc3_context_prune_is_noop(self, tmp_path):
+        """TC3: unwire_pruned_artifacts on a pruned context is now a no-op (reconcile owns it)."""
+        opencode_json = tmp_path / "opencode.json"
+        opencode_json.write_text(
+            json.dumps(
+                {
+                    "$schema": "https://opencode.ai/config.json",
+                    "instructions": [
+                        ".agentic-beacon/artifacts/contexts/linear-ops.md"
+                    ],
+                },
+                indent=2,
+            )
+            + "\n"
+        )
+        claude_md = tmp_path / "CLAUDE.md"
+        claude_md.write_text("@.agentic-beacon/artifacts/contexts/linear-ops.md\n")
+
+        unwire_pruned_artifacts(
+            tmp_path,
+            ["contexts/linear-ops.md"],
+            tmp_path / ".agentic-beacon" / "artifacts",
+        )
+
+        # Context references should NOT be removed by prune unwire anymore
+        data = json.loads(opencode_json.read_text())
+        assert (
+            ".agentic-beacon/artifacts/contexts/linear-ops.md" in data["instructions"]
+        )
+        assert (
+            "@.agentic-beacon/artifacts/contexts/linear-ops.md" in claude_md.read_text()
+        )
+
+
+# ---------------------------------------------------------------------------
+# Task 4.2: Dangling / warehouse-rename case
+# ---------------------------------------------------------------------------
+
+
+class TestDanglingWarehouseRename:
+    def test_tc1_dangling_reference_removed(self, tmp_path):
+        """An owned reference not in the effective set (file gone) is removed from both files."""
+        opencode_json = tmp_path / "opencode.json"
+        opencode_json.write_text(
+            json.dumps(
+                {
+                    "$schema": "https://opencode.ai/config.json",
+                    "instructions": [
+                        ".agentic-beacon/artifacts/contexts/linear-ops.md",
+                        "docs/house-style.md",
+                    ],
+                },
+                indent=2,
+            )
+            + "\n"
+        )
+        claude_md = tmp_path / "CLAUDE.md"
+        claude_md.write_text(
+            "@AGENTS.md\n@.agentic-beacon/artifacts/contexts/linear-ops.md\n"
+        )
+
+        # linear-ops not in desired set (renamed to plane-ops)
+        desired = [".agentic-beacon/artifacts/contexts/plane-ops.md"]
+        result = reconcile_context_references(tmp_path, desired)
+
+        assert ".agentic-beacon/artifacts/contexts/linear-ops.md" in result.removed
+        data = json.loads(opencode_json.read_text())
+        assert (
+            ".agentic-beacon/artifacts/contexts/linear-ops.md"
+            not in data["instructions"]
+        )
+        assert ".agentic-beacon/artifacts/contexts/plane-ops.md" in data["instructions"]
+        assert (
+            "@.agentic-beacon/artifacts/contexts/linear-ops.md"
+            not in claude_md.read_text()
+        )
+        assert (
+            "@.agentic-beacon/artifacts/contexts/plane-ops.md" in claude_md.read_text()
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test ReferenceReconcileResult shape
+# ---------------------------------------------------------------------------
+
+
+class TestReferenceReconcileResult:
+    def test_empty_result(self):
+        r = ReferenceReconcileResult(added=[], removed=[])
+        assert r.added == []
+        assert r.removed == []
+        assert bool(r) is False
+
+    def test_non_empty_result(self):
+        r = ReferenceReconcileResult(added=["a.md"], removed=["b.md"])
+        assert bool(r) is True

--- a/libs/beacon/tests/unit/test_context_reference_reconcile.py
+++ b/libs/beacon/tests/unit/test_context_reference_reconcile.py
@@ -571,9 +571,7 @@ class TestReconcileContextReferences:
         oc_instructions = oc_data["instructions"]
         for name in desired_names:
             assert f".agentic-beacon/artifacts/contexts/{name}.md" in oc_instructions
-        assert (
-            ".agentic-beacon/artifacts/contexts/linear-ops.md" not in oc_instructions
-        )
+        assert ".agentic-beacon/artifacts/contexts/linear-ops.md" not in oc_instructions
 
         # Second run is idempotent
         result2 = reconcile_context_references(tmp_path, desired)

--- a/libs/beacon/tests/unit/test_repair_reference_drift.py
+++ b/libs/beacon/tests/unit/test_repair_reference_drift.py
@@ -1,0 +1,170 @@
+"""Unit tests for repair_reference_drift no-op guard paths and basic behavior (AB-96).
+
+Covers:
+- The no-op guards: beacon_manifest is None, warehouse_path is None, ResolutionFailure
+- TC1: broken + unmanaged reference -> reconciled, fix lines returned
+- TC2: healthy repo -> returns [] and writes nothing
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from beacon.core.manifest.beacon import BeaconManifest
+from beacon.domains.setup.diagnostics import repair_reference_drift
+
+# ---------------------------------------------------------------------------
+# No-op guard paths
+# ---------------------------------------------------------------------------
+
+
+class TestRepairReferenceDriftNoOpGuards:
+    def test_returns_empty_when_beacon_manifest_is_none(self, tmp_path):
+        """Returns [] immediately when beacon_manifest is None."""
+        result = repair_reference_drift(tmp_path, None, tmp_path / "warehouse")
+        assert result == []
+
+    def test_returns_empty_when_warehouse_path_is_none(self, tmp_path):
+        """Returns [] immediately when warehouse_path is None."""
+        # Use a real manifest — warehouse_path guard fires first, no artifacts access needed
+        beacon_yaml = tmp_path / "beacon.yaml"
+        beacon_yaml.write_text("artifacts:\n  contexts: []\n  skills: []\n")
+        manifest = BeaconManifest.from_yaml(beacon_yaml)
+        result = repair_reference_drift(tmp_path, manifest, None)
+        assert result == []
+
+    def test_returns_empty_when_both_none(self, tmp_path):
+        """Returns [] immediately when both are None."""
+        result = repair_reference_drift(tmp_path, None, None)
+        assert result == []
+
+    def _make_minimal_manifest(self, tmp_path: Path) -> BeaconManifest:
+        """Build a real BeaconManifest with one context entry for guard tests."""
+        # Uses a context name that will NOT resolve in any warehouse (missing file)
+        # so compute_effective_set returns ResolutionFailure naturally.
+        beacon_yaml = tmp_path / "beacon.yaml"
+        beacon_yaml.write_text(
+            "artifacts:\n  contexts:\n    - contexts/nonexistent-ctx.md\n  skills: []\n"
+        )
+        return BeaconManifest.from_yaml(beacon_yaml)
+
+    def test_returns_empty_when_resolution_failure(self, tmp_path):
+        """Returns [] when compute_effective_set returns a ResolutionFailure.
+
+        Uses a real manifest whose context doesn't exist in the (empty) warehouse,
+        so compute_effective_set naturally returns ResolutionFailure.
+        """
+        # Create a warehouse directory that is empty (no contexts/)
+        warehouse = tmp_path / "warehouse"
+        warehouse.mkdir()
+        manifest = self._make_minimal_manifest(tmp_path)
+
+        result = repair_reference_drift(tmp_path, manifest, warehouse)
+        assert result == []
+
+    def test_no_write_when_resolution_failure(self, tmp_path):
+        """No files are written when compute_effective_set returns ResolutionFailure."""
+        (tmp_path / "opencode.json").write_text(
+            json.dumps(
+                {"instructions": [".agentic-beacon/artifacts/contexts/some-ref.md"]},
+                indent=2,
+            )
+            + "\n"
+        )
+        before = (tmp_path / "opencode.json").read_bytes()
+
+        warehouse = tmp_path / "warehouse"
+        warehouse.mkdir()
+        manifest = self._make_minimal_manifest(tmp_path)
+
+        result = repair_reference_drift(tmp_path, manifest, warehouse)
+
+        assert result == []
+        assert (tmp_path / "opencode.json").read_bytes() == before
+
+
+# ---------------------------------------------------------------------------
+# Functional behavior: real BeaconManifest + warehouse
+# ---------------------------------------------------------------------------
+
+
+class TestRepairReferenceDriftBehavior:
+    def _make_warehouse(self, tmp_path: Path) -> Path:
+        """Minimal warehouse with one context."""
+        wh = tmp_path / "warehouse"
+        (wh / "contexts").mkdir(parents=True)
+        (wh / "skills").mkdir(parents=True)
+        (wh / "contexts" / "plane-ops.md").write_text("# Plane Ops")
+        return wh
+
+    def test_tc1_broken_and_unmanaged_reference_reconciled(self, tmp_path):
+        """TC1: repo with a broken + an unmanaged reference -> both reconciled, fix lines returned."""
+        wh = self._make_warehouse(tmp_path)
+
+        # beacon.yaml: only plane-ops declared
+        beacon_yaml = tmp_path / ".agentic-beacon" / "beacon.yaml"
+        beacon_yaml.parent.mkdir(parents=True)
+        beacon_yaml.write_text(
+            "artifacts:\n  contexts:\n    - contexts/plane-ops.md\n  skills: []\n"
+        )
+        manifest = BeaconManifest.from_yaml(beacon_yaml)
+
+        # opencode.json: contains plane-ops (desired) + linear-ops (not desired)
+        (tmp_path / "opencode.json").write_text(
+            json.dumps(
+                {
+                    "instructions": [
+                        ".agentic-beacon/artifacts/contexts/plane-ops.md",
+                        ".agentic-beacon/artifacts/contexts/linear-ops.md",
+                    ]
+                },
+                indent=2,
+            )
+            + "\n"
+        )
+
+        result = repair_reference_drift(tmp_path, manifest, wh)
+
+        # Fix lines must be returned (something was repaired)
+        assert len(result) > 0
+        combined = " ".join(result).lower()
+        assert (
+            "repaired" in combined or "reference" in combined or "removed" in combined
+        )
+
+        # linear-ops must be gone from opencode.json
+        oc_data = json.loads((tmp_path / "opencode.json").read_text())
+        assert (
+            ".agentic-beacon/artifacts/contexts/linear-ops.md"
+            not in oc_data["instructions"]
+        )
+        assert (
+            ".agentic-beacon/artifacts/contexts/plane-ops.md" in oc_data["instructions"]
+        )
+
+    def test_tc2_healthy_repo_returns_empty_and_no_write(self, tmp_path):
+        """TC2: healthy repo -> returns [] and writes nothing."""
+        wh = self._make_warehouse(tmp_path)
+
+        beacon_yaml = tmp_path / ".agentic-beacon" / "beacon.yaml"
+        beacon_yaml.parent.mkdir(parents=True)
+        beacon_yaml.write_text(
+            "artifacts:\n  contexts:\n    - contexts/plane-ops.md\n  skills: []\n"
+        )
+        manifest = BeaconManifest.from_yaml(beacon_yaml)
+
+        # opencode.json already has the correct reference
+        (tmp_path / "opencode.json").write_text(
+            json.dumps(
+                {"instructions": [".agentic-beacon/artifacts/contexts/plane-ops.md"]},
+                indent=2,
+            )
+            + "\n"
+        )
+        before = (tmp_path / "opencode.json").read_bytes()
+
+        result = repair_reference_drift(tmp_path, manifest, wh)
+
+        assert result == []
+        assert (tmp_path / "opencode.json").read_bytes() == before

--- a/openspec/changes/reconcile-context-references/.openspec.yaml
+++ b/openspec/changes/reconcile-context-references/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-20

--- a/openspec/changes/reconcile-context-references/design.md
+++ b/openspec/changes/reconcile-context-references/design.md
@@ -1,0 +1,105 @@
+# Design — Context-reference reconciliation (AB-96)
+
+## Context
+
+Context-reference wiring into `CLAUDE.md` (an `@`-include per context) and `opencode.json` (an `instructions` array entry per context) is currently **append-only on the add side** (`wire_contexts_*` scan the physical `contexts/` directory and append) and **prune-gated on the remove side** (`unwire_pruned_artifacts` runs only on `summary.pruned_paths`, i.e. orphans the user interactively confirmed for deletion). Nothing reconciles the reference set against the declared/effective set, so a context that leaves the set without a confirmed prune — de-adopt + declined prune, non-interactive sync, warehouse rename (`linear-ops.md` → `plane-ops.md`), manual `rm`, adopt-reject — leaks a stale reference. `abc doctor` already reports these as **broken** (file gone) and **unmanaged** (undeclared) references but cannot repair them.
+
+This is the reference-layer analog of AB-94's gitignore fix. This design consolidates add + remove into one **wholesale reconciler** scoped to the Beacon artifact namespace, invoked from every wiring path, plus a doctor `--fix` repair that reuses it.
+
+## Resolved decisions
+
+The grill resolved these (see the AB-96 decision tree):
+
+1. **Ownership boundary — warehouse-artifact references only.** Beacon owns every reference under `.agentic-beacon/artifacts/` (in practice, `…/contexts/*.md`). It reconciles exactly those to the effective set and **never touches** non-artifact lines: `@AGENTS.md` and other project-local includes in `CLAUDE.md`; the `$schema` key and user-authored `instructions` entries in `opencode.json`. Chosen over "regenerate the whole include list wholesale" because Beacon has no knowledge of `@AGENTS.md` (this repo's SSOT chain) or user includes and would strip them. Chosen over a marker-block model because `opencode.json` is JSON and cannot hold comment markers — a path-prefix ownership rule is the one model that works uniformly for both files.
+2. **Reconcile target — the effective set.** The desired reference set is derived from `effective_set.contexts` (what sync materializes under `contexts/`), expanded to `.agentic-beacon/artifacts/contexts/<name>.md`. Not the raw `rglob` of the directory (that is the source of the "unmanaged reference" bug) — so a de-adopted-but-still-on-disk context and a dangling warehouse-renamed reference are both dropped.
+3. **Mechanism — surgical, per-file.** `CLAUDE.md`: manage only lines whose stripped form is `@<artifact-ref>` under the artifact prefix; add missing, remove departed, leave every other line (and blank-line structure) byte-identical otherwise. `opencode.json`: manage only `instructions` entries under the artifact prefix; preserve `$schema`, user entries, and relative order; re-serialize with the existing 2-space-indent + trailing-newline convention.
+4. **Fix location — both paths, one function.** A single `reconcile_context_references` is called from `run_sync` (replacing append-only wiring) and from `abc adopt`; `abc doctor --fix` gets a `repair_reference_drift` that reuses the reconciler and records the repair in `fixes_applied` (the pattern AB-94 established for gitignore).
+5. **Scope — reference-integrity family only.** Broken references and unmanaged references, via the reconciler. Skill/agent symlink cleanup (their own prune-gated paths), dangling-symlink relink, non-portable absolute paths, and stale beacon.yaml globs are **out of scope** — separate follow-ups.
+6. **Idempotency + dry-run.** Reconcile writes only when content changes; a second run is a no-op. Under `dry_run` it computes the add/remove delta for reporting but performs no writes.
+7. **Review-flagged.** It rewrites user-facing config files → the implementation-supervisor stops at a bot-clean PR rather than auto-merging. Single repo, no fan-out.
+
+## Architecture — where the code lives
+
+The reconciler stays in the **setup** domain alongside the existing wiring/diagnostics helpers it supersedes — it is not cross-domain (only sync, adopt, and doctor consume it, all of which already import from `domains/setup/wiring.py` and `domains/setup/diagnostics.py`). No `core/` promotion is needed (contrast AB-94, where gitignore was genuinely cross-domain).
+
+```
+domains/setup/wiring.py  (the reconciler — source of truth for reference ownership)
+├── ARTIFACT_REF_PREFIX  = ".agentic-beacon/artifacts/"        # ownership boundary
+├── desired_context_refs(effective_contexts) -> list[str]      # effective set -> rel paths
+├── reconcile_context_references(project_root, desired_refs) -> ReferenceReconcileResult
+│     ├── _reconcile_opencode_json(project_root, desired_refs)   # instructions array, surgical
+│     └── _reconcile_claude_md(project_root, desired_refs)       # @-includes, surgical
+└── (wire_contexts_opencode / wire_contexts_claudecode / unwire_context_* absorbed or reduced to helpers)
+
+consumers:
+├── domains/distribution/orchestrator.py  run_sync   → reconcile_context_references (replaces append-only wire_* + prune-gated context unwire)
+├── domains/adoption/apply.py             accept/reject → reconcile_context_references
+└── domains/setup/diagnostics.py          repair_reference_drift → reconcile_context_references ; run_project_diagnostics(--fix) calls it
+```
+
+`ReferenceReconcileResult` carries `added: list[str]` and `removed: list[str]` per file so callers (sync output, doctor `fixes_applied`) can report precisely and so dry-run can preview without writing.
+
+Removed/superseded: the directory-scan behavior of `wire_contexts_opencode`/`wire_contexts_claudecode` (they either become internal add-only helpers driven by the desired set, or are folded into the reconciler); the **context branch** of `unwire_pruned_artifacts` (the reconciler now owns context removal) — its **skill and agent branches stay** (those are prune-driven symlink/dir removals, out of scope here).
+
+## The desired set
+
+```python
+ARTIFACT_REF_PREFIX = ".agentic-beacon/artifacts/"
+
+def desired_context_refs(effective_contexts: set[str]) -> list[str]:
+    # effective_contexts are names like "python-standards" (resolver format)
+    return sorted(f"{ARTIFACT_REF_PREFIX}contexts/{name}.md" for name in effective_contexts)
+```
+
+A reference is **Beacon-owned** iff its path (the `@`-target in CLAUDE.md, or the array string in opencode.json) starts with `ARTIFACT_REF_PREFIX`. Owned references not in the desired set are removed; desired references not present are added; everything else is untouched.
+
+## Algorithms
+
+### `_reconcile_opencode_json(project_root, desired_refs)`
+
+1. Resolve `opencode.json` (root, else `.opencode/opencode.json`); if absent, return empty result.
+2. Parse JSON; read `instructions: list[str]` (default `[]`).
+3. Partition: `owned = [x for x in instructions if x.startswith(ARTIFACT_REF_PREFIX)]`; `kept = [x for x in instructions if not owned]` — preserving order.
+4. New list = `kept` with the desired context refs merged into the position where owned refs were (append desired refs after the last kept entry, or keep them grouped where the first owned ref was — deterministic, order-stable). `removed = owned − desired`; `added = desired − owned`.
+5. Write only if `instructions` changed; re-serialize with `json.dumps(data, indent=2) + "\n"`.
+
+### `_reconcile_claude_md(project_root, desired_refs)`
+
+1. Resolve `CLAUDE.md` (`.claude/CLAUDE.md`, else root `CLAUDE.md`); if absent, return empty result.
+2. Split into lines. A line is **owned** iff `line.strip()` matches `@<path>` with `path` under `ARTIFACT_REF_PREFIX`.
+3. Remove owned lines whose path ∉ desired (dropping any now-redundant blank-line pair introduced by the removal, matching the existing append style). Keep all other lines verbatim.
+4. Append `@<ref>` lines for desired refs not already present, using the file's existing separator convention (blank-line-separated, as the current `wire_contexts_claudecode` does).
+5. Write only if content changed.
+
+### `reconcile_context_references(project_root, desired_refs, *, dry_run=False)`
+
+Runs both file reconcilers; aggregates `added`/`removed`. Under `dry_run`, both reconcilers compute the delta but skip the write. Returns `ReferenceReconcileResult`.
+
+### `repair_reference_drift(project_root, beacon_manifest, warehouse_path)` (doctor `--fix`)
+
+Compute the effective set (same normalization as `run_sync`), build `desired_refs`, call `reconcile_context_references`; return a human-readable fix line per file that changed for `fixes_applied`. Mirrors `repair_gitignore_drift`.
+
+## Edge cases
+
+- **No `opencode.json` / no `CLAUDE.md`** → that file's reconcile is a no-op (return empty result); the other still runs.
+- **Dangling owned reference** (warehouse rename: `linear-ops.md` gone) → not in the effective set → removed. This is the exact reported broken-reference case.
+- **Undeclared-but-on-disk context** (orphan not yet pruned) → not in the effective set → its reference is removed (resolves "unmanaged reference"); the orphan **file** itself is handled by the existing prune flow, unchanged.
+- **User hand-added an `@…/artifacts/contexts/x.md` include for a context they did not adopt** → treated as Beacon-owned (it is in Beacon's namespace) and removed on reconcile. Per the resolved ownership decision, that namespace is Beacon's; the user should adopt the context instead. Documented.
+- **Non-artifact includes** (`@AGENTS.md`, `@docs/x.md`) and **opencode `$schema` / user instructions** → never match the prefix → always preserved.
+- **Empty effective set** (no contexts) → all owned references removed from both files; non-artifact content preserved.
+- **Idempotency** → after one reconcile, `added` and `removed` are both empty on the next run; no write occurs.
+
+## Testing strategy
+
+- **Reconciler unit tests**: add-missing; remove-departed; add+remove in one pass; preserve `@AGENTS.md` / user includes / `$schema` / user instructions and their order; idempotent re-run (byte-equal); `opencode.json` re-serialization shape (2-space indent, trailing newline); empty-effective-set clears owned refs only; dangling/warehouse-rename reference removed.
+- **Path coverage**: `abc sync` after de-adopting a context removes its reference from both files (the reported bug, both directions); `abc adopt` accept adds, reject/un-adopt removes.
+- **Doctor**: a repo with a broken + an unmanaged reference → both flagged; `abc doctor --fix` repairs both and the re-run is clean; healthy repo → no reference drift, no spurious write; `fixes_applied` non-empty on repair.
+- **Regression against the live repo state**: reproduce this repo's `linear-ops.md` (broken) + `cicd-flow.md` (unmanaged) condition in a fixture and assert `--fix` clears both.
+- **Architecture test** (`tests/unit/test_architecture.py`) still passes.
+
+## Out of scope
+
+- Skill/agent symlink cleanup on leave-set (their prune-gated paths are unchanged).
+- Other doctor findings: dangling symlinks (relink/prune), non-portable absolute paths (rewrite), stale beacon.yaml globs — separate follow-up tickets.
+- Any change to the orphan-file prune flow or its confirmation prompt (the reconciler only touches references, not artifact files).
+- Any warehouse or cross-repo work.

--- a/openspec/changes/reconcile-context-references/proposal.md
+++ b/openspec/changes/reconcile-context-references/proposal.md
@@ -1,0 +1,38 @@
+## Why
+
+De-adopting a context (removing it from `beacon.yaml`) leaves its reference behind in `CLAUDE.md` (an `@`-include) and `opencode.json` (an `instructions` entry). `abc doctor` on this very repo surfaces the fallout: a **broken reference** (`@…/contexts/linear-ops.md` — the file was renamed to `plane-ops.md` in the warehouse, so the include now points at nothing) and, from the mirror side, an **unmanaged reference** (`…/contexts/cicd-flow.md` present but not listed in `beacon.yaml`).
+
+Root cause: context reference wiring is **append-only on the add side and prune-gated on the remove side** — it is never reconciled against the declared set. This is the reference-layer twin of AB-94's gitignore bug (append-per-line, no wholesale reconciliation).
+
+- **Add side scans the directory, not the declared set.** `wire_contexts_opencode` / `wire_contexts_claudecode` (`domains/setup/wiring.py`) enumerate **every** `*.md` under `.agentic-beacon/artifacts/contexts/` via `rglob` and append any not already referenced. A file physically present but undeclared (an un-pruned orphan) gets wired → **unmanaged reference**.
+- **Remove side fires only on a confirmed prune.** The *only* trigger that removes a context reference is `orchestrator.py` `if summary.pruned_paths: unwire_pruned_artifacts(...)`, and `pruned_paths` holds only orphans the user **interactively confirmed** for deletion (`confirm_prune` → `click.confirm(default=False)`). There is **no** step that drops a reference simply because a context left the declared/effective set.
+- **The adopt path is additive-only too.** `domains/adoption/apply.py` calls the same append-only `wire_contexts_*`; rejecting a pending context never unwires anything.
+- **`abc doctor` flags the drift but cannot repair it.** The reference checks (`_check_path_references`) already report broken/unmanaged references, but `--fix` (real since AB-94 for gitignore) does not touch references.
+
+So a reference leaks whenever a context leaves the declared set without a confirmed prune: prune declined; a non-interactive sync; a warehouse rename (the `linear-ops.md` → `plane-ops.md` case — the file vanishes outside the prune path, leaving a dangling symlink + broken include); a manual `rm`; or an `abc adopt` reject.
+
+This change reframes context-reference ownership the same way AB-94 reframed gitignore ownership: **adopting Beacon means the artifact-reference layer of `CLAUDE.md` / `opencode.json` is Beacon-owned**, reconciled wholesale to the effective set on every sync, with `abc doctor --fix` repairing existing drift on repos that already leaked.
+
+## What Changes
+
+- **One reconciler** — a shared `reconcile_context_references(project_root, artifacts_dir)` in `domains/setup/wiring.py` that, given the desired set of synced context files, brings `CLAUDE.md` and `opencode.json` to **exactly** that set: add missing references, **remove Beacon-owned references no longer in the set**. Idempotent — a second run makes no change.
+- **Scoped ownership boundary.** Beacon owns only references under the `.agentic-beacon/artifacts/` namespace. Non-artifact lines are **never touched**: `@AGENTS.md` and other project-local `@`-includes in `CLAUDE.md`; the `$schema` key and any user-authored `instructions` entries in `opencode.json`; ordering of all preserved entries. (In `CLAUDE.md`/`opencode.json` the only artifact references that exist are context references — skills and agents wire as symlinks/dirs, not references — so the reference reconciler is contexts-only by nature.)
+- **Reconcile target = the effective set.** The desired reference set is derived from `effective_set.contexts` (what sync actually materializes under `contexts/`), not the raw directory scan — so a de-adopted context's reference is dropped even if its file is still on disk, and a warehouse-renamed context's dangling reference is dropped.
+- **Every wiring path reconciles.** `run_sync` (replacing the append-only `wire_contexts_*` + prune-gated `unwire_pruned_artifacts` context branch) and `abc adopt` (the accept/reject path in `apply.py`) both call the reconciler, so de-adopt + sync (or adopt) self-heals — including this repo on its next sync.
+- **`abc doctor --fix` repairs reference drift** — a new `repair_reference_drift(project_root, beacon_manifest, warehouse_path)` in `domains/setup/diagnostics.py`, called from `run_project_diagnostics` when `--fix` is set (alongside the existing `repair_gitignore_drift`), recording the repair in `fixes_applied`. After `--fix`, the broken- and unmanaged-reference checks pass.
+
+## Capabilities
+
+### New Capabilities
+- `beacon-context-reference-management`: the context-reference reconciler and its ownership contract — the artifact-namespace ownership boundary, wholesale reconciliation of `CLAUDE.md` `@`-includes and `opencode.json` `instructions` to the effective set (add missing / remove departed), surgical preservation of non-artifact and user lines plus ordering, idempotency, the single-reconciler-called-from-every-wiring-path guarantee, and the `abc doctor --fix` reference-drift repair.
+
+### Modified Capabilities
+- `artifact-adoption`: the "context is wired into `CLAUDE.md` and `opencode.json` on adopt" requirement is extended — wiring is now a reconcile (add **and** remove), so un-adopting a context (or rejecting it) removes its reference, not only adopting one adds it.
+
+## Impact
+
+- **Code**: `domains/setup/wiring.py` (new `reconcile_context_references`; the append-only `wire_contexts_opencode`/`wire_contexts_claudecode` become thin add-only helpers used by the reconciler, or are absorbed into it; the context branch of `unwire_pruned_artifacts` is superseded by reconcile — skill/agent branches stay); `domains/distribution/orchestrator.py` (`run_sync` calls the reconciler instead of append-only wiring; the prune-triggered context unwire is removed); `domains/adoption/apply.py` (accept/reject path calls the reconciler); `domains/setup/diagnostics.py` (`repair_reference_drift` + wire into `run_project_diagnostics`); `cli/diagnostics.py` (surface reference repairs in `fixes_applied`).
+- **Behavior**: after any `abc sync` / `abc adopt`, the artifact-reference set in `CLAUDE.md` / `opencode.json` equals the effective context set exactly; de-adopting a context removes its reference; warehouse-renamed/deleted contexts no longer leave dangling includes; existing leaked repos self-heal on next sync or via `abc doctor --fix`.
+- **Tests**: unit tests for the reconciler (add missing, remove departed, preserve non-artifact + user entries + ordering, idempotency, `opencode.json` JSON-shape preservation, dangling/warehouse-rename case); path coverage through `abc sync` and `abc adopt`; doctor detection + real `--fix` repair loop; architecture test still green.
+- **Docs**: `beacon-ops.md` note that the artifact-reference layer of `CLAUDE.md`/`opencode.json` is Beacon-managed and reconciled (delivered via the warehouse per-project model).
+- **Scope**: single repo (`agentic-beacon`). No warehouse or cross-repo work. Reference-integrity family only — dangling symlinks, non-portable absolute paths, and stale beacon.yaml globs remain their own follow-ups. Review-flagged (rewrites user-facing `CLAUDE.md` / `opencode.json`).

--- a/openspec/changes/reconcile-context-references/specs/artifact-adoption/spec.md
+++ b/openspec/changes/reconcile-context-references/specs/artifact-adoption/spec.md
@@ -1,0 +1,20 @@
+## MODIFIED Requirements
+
+### Requirement: Post-adoption sync and wiring
+The system SHALL immediately sync and wire adopted artifacts after updating `beacon.yaml`, using the same mechanisms as `abc sync`. Wiring of context references into `CLAUDE.md` and `opencode.json` SHALL be a **reconciliation** to the effective context set — adding references for newly-adopted contexts **and removing references for un-adopted (or rejected) contexts** — not an append-only operation. Reference removal SHALL NOT depend on an interactive prune confirmation.
+
+#### Scenario: Adopted context is synced and wired
+- **WHEN** user adopts `contexts/platform-team.md`
+- **THEN** file is copied to `.agentic-beacon/artifacts/contexts/platform-team.md` AND its reference is reconciled into CLAUDE.md and opencode.json
+
+#### Scenario: Adopted skill is synced and wired
+- **WHEN** user adopts `skills/generate-tests/`
+- **THEN** skill files are copied to `.agentic-beacon/artifacts/skills/generate-tests/` AND installed to `.claude/skills/generate-tests/` and `.opencode/skills/generate-tests/`
+
+#### Scenario: Un-adopted context reference is removed
+- **WHEN** user removes `contexts/platform-team.md` from `beacon.yaml` (via the adopt flow or manual edit) and syncs
+- **THEN** the `@…/contexts/platform-team.md` include is removed from CLAUDE.md and the matching `instructions` entry is removed from opencode.json, without requiring an interactive prune confirmation
+
+#### Scenario: Adoption summary printed
+- **WHEN** adoption of 2 artifacts completes successfully
+- **THEN** system prints "Added 2 artifact(s) to beacon.yaml" and "Synced and wired" with the list of adopted paths

--- a/openspec/changes/reconcile-context-references/specs/beacon-context-reference-management/spec.md
+++ b/openspec/changes/reconcile-context-references/specs/beacon-context-reference-management/spec.md
@@ -1,0 +1,77 @@
+## ADDED Requirements
+
+### Requirement: Context references reconciled to the effective set
+
+Beacon SHALL reconcile the artifact-context references in `CLAUDE.md` (as `@`-includes) and `opencode.json` (as `instructions` array entries) to **exactly** the effective context set on every wiring path. Reconciliation SHALL add a reference for each effective context that is missing and SHALL remove any Beacon-owned reference that is no longer in the effective set. The reconciler SHALL NOT append-only, and SHALL NOT depend on an interactive prune confirmation to remove a departed reference. Reconciliation SHALL be idempotent: re-running it against files that already match the effective set SHALL make no change.
+
+#### Scenario: De-adopted context reference is removed
+
+- **GIVEN** `CLAUDE.md` and `opencode.json` reference `.agentic-beacon/artifacts/contexts/linear-ops.md`, and `linear-ops` is no longer in the effective set
+- **WHEN** the reconciler runs
+- **THEN** the `@…/contexts/linear-ops.md` include is removed from `CLAUDE.md` and the matching `instructions` entry is removed from `opencode.json`
+
+#### Scenario: Missing reference for an effective context is added
+
+- **GIVEN** `beacon-ops` is in the effective set but neither file references `.agentic-beacon/artifacts/contexts/beacon-ops.md`
+- **WHEN** the reconciler runs
+- **THEN** the `@`-include is added to `CLAUDE.md` and the `instructions` entry is added to `opencode.json`
+
+#### Scenario: Dangling reference from a warehouse rename is removed
+
+- **GIVEN** the warehouse renamed `contexts/linear-ops.md` to `contexts/plane-ops.md`, leaving `linear-ops` out of the effective set and its reference dangling
+- **WHEN** the reconciler runs
+- **THEN** the dangling `linear-ops` reference is removed from both files
+
+#### Scenario: Idempotent re-run
+
+- **GIVEN** both files already match the effective set exactly
+- **WHEN** the reconciler runs again
+- **THEN** neither file is written and no reference is added or removed
+
+### Requirement: Ownership is scoped to the artifact namespace
+
+The reconciler SHALL treat a reference as Beacon-owned only when its path begins with `.agentic-beacon/artifacts/`. It SHALL NOT add, remove, or reorder any reference outside that namespace, and SHALL preserve the `opencode.json` `$schema` key and all user-authored `instructions` entries.
+
+#### Scenario: Non-artifact CLAUDE.md includes are preserved
+
+- **GIVEN** `CLAUDE.md` contains `@AGENTS.md` and `@docs/house-style.md` alongside artifact-context includes
+- **WHEN** the reconciler removes a de-adopted context reference
+- **THEN** `@AGENTS.md` and `@docs/house-style.md` remain untouched and in place
+
+#### Scenario: opencode.json schema and user instructions are preserved
+
+- **GIVEN** `opencode.json` has a `$schema` key and a user `instructions` entry `docs/house-style.md` alongside artifact-context entries
+- **WHEN** the reconciler runs
+- **THEN** `$schema` and `docs/house-style.md` are preserved, the file stays valid JSON with 2-space indentation and a trailing newline, and only artifact-context entries under `.agentic-beacon/artifacts/` are changed
+
+#### Scenario: Empty effective set clears only owned references
+
+- **GIVEN** the effective set contains no contexts
+- **WHEN** the reconciler runs
+- **THEN** every `.agentic-beacon/artifacts/contexts/*` reference is removed from both files while all non-artifact lines and keys are preserved
+
+### Requirement: Every wiring path reconciles references
+
+The context-reference reconciler SHALL be invoked from `abc sync` and from the `abc adopt` accept/reject path, replacing the previous append-only wiring and prune-gated context unwiring. After any `abc sync` or `abc adopt`, the artifact-context reference set in `CLAUDE.md` and `opencode.json` SHALL equal the effective context set.
+
+#### Scenario: Sync after de-adoption self-heals
+
+- **GIVEN** a context was removed from `beacon.yaml` and its file no longer resolves in the warehouse
+- **WHEN** the user runs `abc sync`
+- **THEN** the context's reference is removed from both files without requiring an interactive prune confirmation
+
+### Requirement: abc doctor --fix repairs reference drift
+
+`abc doctor` SHALL continue to report broken references (a reference whose target does not exist) and unmanaged references (an artifact reference not in `beacon.yaml`). When `--fix` is set, `abc doctor` SHALL repair reference drift by invoking the same reconciler and SHALL record the repair in the applied-fixes summary. After a `--fix` run, the reference checks SHALL report no drift.
+
+#### Scenario: --fix repairs broken and unmanaged references
+
+- **GIVEN** a repo whose `CLAUDE.md` / `opencode.json` hold a broken reference (`contexts/linear-ops.md`, file gone) and an unmanaged reference (`contexts/cicd-flow.md`, not in `beacon.yaml`)
+- **WHEN** the user runs `abc doctor --fix`
+- **THEN** both references are reconciled away, the repair is listed in the applied-fixes summary, and a subsequent `abc doctor` reports no broken or unmanaged references
+
+#### Scenario: Healthy repo is not written
+
+- **GIVEN** a repo whose references already match the effective set
+- **WHEN** the user runs `abc doctor --fix`
+- **THEN** no reference repair is recorded and neither file is written

--- a/openspec/changes/reconcile-context-references/tasks.md
+++ b/openspec/changes/reconcile-context-references/tasks.md
@@ -80,7 +80,7 @@ pytest tests/ -v --tb=short
 <!-- opsx:phase-summary:1:end -->
 
 
-- [ ] 1.1 Add `ARTIFACT_REF_PREFIX = ".agentic-beacon/artifacts/"` and `desired_context_refs(effective_contexts)` returning the sorted desired reference paths for the effective context set.
+- [x] 1.1 Add `ARTIFACT_REF_PREFIX = ".agentic-beacon/artifacts/"` and `desired_context_refs(effective_contexts)` returning the sorted desired reference paths for the effective context set.
 <!-- opsx:tdd:1.1:begin -->
   - **Input**: pytest tests/unit/test_context_reference_reconcile.py -k desired_refs -v
   - **Expected Output**: desired_context_refs({'python-standards','beacon-ops'}) == ['.agentic-beacon/artifacts/contexts/beacon-ops.md', '.agentic-beacon/artifacts/contexts/python-standards.md'] (sorted).
@@ -90,7 +90,7 @@ pytest tests/ -v --tb=short
     - TC2: empty effective set -> empty list
     - TC3: names already containing dots/hyphens map to `<name>.md` unchanged
 <!-- opsx:tdd:1.1:end -->
-- [ ] 1.2 Implement `_reconcile_opencode_json(project_root, desired_refs)`: partition `instructions` into Beacon-owned (prefix match) vs kept; add missing desired refs, remove departed owned refs, preserve `$schema`, user entries, and order; re-serialize as `json.dumps(data, indent=2) + "\n"`; write only on change. Return added/removed.
+- [x] 1.2 Implement `_reconcile_opencode_json(project_root, desired_refs)`: partition `instructions` into Beacon-owned (prefix match) vs kept; add missing desired refs, remove departed owned refs, preserve `$schema`, user entries, and order; re-serialize as `json.dumps(data, indent=2) + "\n"`; write only on change. Return added/removed.
 <!-- opsx:tdd:1.2:begin -->
   - **Input**: pytest tests/unit/test_context_reference_reconcile.py -k opencode -v
   - **Expected Output**: instructions equals kept-entries + desired context refs; $schema and user entries preserved; removed = owned-not-desired, added = desired-not-owned; re-serialized with indent=2 + trailing newline; no write when unchanged.
@@ -104,7 +104,7 @@ pytest tests/ -v --tb=short
     - TC6: output re-serialized with 2-space indent and a single trailing newline
     - TC7: no opencode.json present -> no-op, empty result
 <!-- opsx:tdd:1.2:end -->
-- [ ] 1.3 Implement `_reconcile_claude_md(project_root, desired_refs)`: manage only `@<path>` lines under the artifact prefix; add missing desired refs (existing blank-line separator convention), remove departed owned lines (and any orphaned blank pair), preserve all other lines verbatim; write only on change. Return added/removed.
+- [x] 1.3 Implement `_reconcile_claude_md(project_root, desired_refs)`: manage only `@<path>` lines under the artifact prefix; add missing desired refs (existing blank-line separator convention), remove departed owned lines (and any orphaned blank pair), preserve all other lines verbatim; write only on change. Return added/removed.
 <!-- opsx:tdd:1.3:begin -->
   - **Input**: pytest tests/unit/test_context_reference_reconcile.py -k claude_md -v
   - **Expected Output**: @-include lines under the artifact prefix reconciled to desired; @AGENTS.md and other non-artifact lines preserved byte-for-byte; missing desired refs appended with existing separator convention; departed owned lines removed; no write when unchanged.
@@ -118,7 +118,7 @@ pytest tests/ -v --tb=short
     - TC6: `.claude/CLAUDE.md` preferred over root CLAUDE.md when both exist
     - TC7: no CLAUDE.md present -> no-op, empty result
 <!-- opsx:tdd:1.3:end -->
-- [ ] 1.4 Implement `reconcile_context_references(project_root, desired_refs, *, dry_run=False)` aggregating both file reconcilers into a `ReferenceReconcileResult(added, removed)`; under `dry_run`, compute the delta but perform no writes.
+- [x] 1.4 Implement `reconcile_context_references(project_root, desired_refs, *, dry_run=False)` aggregating both file reconcilers into a `ReferenceReconcileResult(added, removed)`; under `dry_run`, compute the delta but perform no writes.
 <!-- opsx:tdd:1.4:begin -->
   - **Input**: pytest tests/unit/test_context_reference_reconcile.py -k reconcile_context_references -v
   - **Expected Output**: Returns ReferenceReconcileResult with aggregated added/removed across both files; dry_run=True computes the delta but writes nothing; second run is a no-op (added and removed empty).
@@ -129,7 +129,7 @@ pytest tests/ -v --tb=short
     - TC3: idempotent -> second call returns empty added/removed and writes nothing
     - TC4: only one of the two files exists -> the other reconciler is a silent no-op
 <!-- opsx:tdd:1.4:end -->
-- [ ] 1.5 Reduce `wire_contexts_opencode` / `wire_contexts_claudecode` to add-only helpers driven by the desired set (or fold into the reconciler); remove the **context branch** of `unwire_pruned_artifacts`, leaving its skill/agent branches intact.
+- [x] 1.5 Reduce `wire_contexts_opencode` / `wire_contexts_claudecode` to add-only helpers driven by the desired set (or fold into the reconciler); remove the **context branch** of `unwire_pruned_artifacts`, leaving its skill/agent branches intact.
 <!-- opsx:tdd:1.5:begin -->
   - **Input**: pytest tests/unit -k 'unwire and (skill or agent)' -v ; grep -rn 'unwire_pruned_artifacts' src/
   - **Expected Output**: wire_contexts_* no longer scan the contexts/ directory to drive wiring; the context branch of unwire_pruned_artifacts is gone; its skill and agent branches still remove the right dirs/symlinks on prune.
@@ -150,7 +150,7 @@ pytest tests/ -v --tb=short
 <!-- opsx:phase-summary:2:end -->
 
 
-- [ ] 2.1 `domains/distribution/orchestrator.py::run_sync` — build `desired_refs` from `effective_set.contexts` and call `reconcile_context_references` instead of the append-only `wire_contexts_*`; remove the `if summary.pruned_paths: unwire_pruned_artifacts(...)` context handling (skill/agent prune unwiring stays). Respect `dry_run`.
+- [x] 2.1 `domains/distribution/orchestrator.py::run_sync` — build `desired_refs` from `effective_set.contexts` and call `reconcile_context_references` instead of the append-only `wire_contexts_*`; remove the `if summary.pruned_paths: unwire_pruned_artifacts(...)` context handling (skill/agent prune unwiring stays). Respect `dry_run`.
 <!-- opsx:tdd:2.1:begin -->
   - **Input**: pytest tests/integration/test_sync_wiring.py -k 'reconcile or deadopt' -v
   - **Expected Output**: run_sync builds desired_refs from effective_set.contexts and calls reconcile_context_references; the `if summary.pruned_paths: unwire_pruned_artifacts` context handling is removed; dry_run path performs no writes.
@@ -160,7 +160,7 @@ pytest tests/ -v --tb=short
     - TC2: sync adding a new context -> its reference present in both files
     - TC3: sync --dry-run -> reports would-add/would-remove but writes neither file
 <!-- opsx:tdd:2.1:end -->
-- [ ] 2.2 `domains/adoption/apply.py` — replace the append-only `wire_contexts_*` calls on the accept/reject path with `reconcile_context_references` so un-adopt/reject removes references.
+- [x] 2.2 `domains/adoption/apply.py` — replace the append-only `wire_contexts_*` calls on the accept/reject path with `reconcile_context_references` so un-adopt/reject removes references.
 <!-- opsx:tdd:2.2:begin -->
   - **Input**: pytest tests/integration/test_adopt_apply.py -k reconcile -v
   - **Expected Output**: adopt accept adds the reference; reject / un-adopt removes it — both via reconcile_context_references, not append-only wiring.
@@ -169,7 +169,7 @@ pytest tests/ -v --tb=short
     - TC1: adopt-accept a context -> reference present in both files
     - TC2: un-adopt (remove from beacon.yaml) + adopt-sync -> reference removed from both files
 <!-- opsx:tdd:2.2:end -->
-- [ ] 2.3 `cli/sync.py` — update the post-sync wiring init calls to the reconciler (keep the "wire them into your agent config" guidance path coherent).
+- [x] 2.3 `cli/sync.py` — update the post-sync wiring init calls to the reconciler (keep the "wire them into your agent config" guidance path coherent).
 
 ## 3. Doctor `--fix` reference repair
 
@@ -181,7 +181,7 @@ pytest tests/ -v --tb=short
 <!-- opsx:phase-summary:3:end -->
 
 
-- [ ] 3.1 `domains/setup/diagnostics.py` — add `repair_reference_drift(project_root, beacon_manifest, warehouse_path)` that computes the effective set, builds `desired_refs`, and calls `reconcile_context_references`; return a human-readable fix line per changed file.
+- [x] 3.1 `domains/setup/diagnostics.py` — add `repair_reference_drift(project_root, beacon_manifest, warehouse_path)` that computes the effective set, builds `desired_refs`, and calls `reconcile_context_references`; return a human-readable fix line per changed file.
 <!-- opsx:tdd:3.1:begin -->
   - **Input**: pytest tests/unit -k repair_reference_drift -v
   - **Expected Output**: repair_reference_drift computes the effective set, builds desired_refs, calls the reconciler, and returns a fix line per changed file; healthy repo returns [].
@@ -190,7 +190,7 @@ pytest tests/ -v --tb=short
     - TC1: repo with a broken + an unmanaged reference -> both reconciled away, one-or-two fix lines returned
     - TC2: healthy repo -> returns [] and writes nothing
 <!-- opsx:tdd:3.1:end -->
-- [ ] 3.2 `domains/setup/diagnostics.py::run_project_diagnostics` — when `fix` is set, call `repair_reference_drift` alongside `repair_gitignore_drift` and merge into `applied_fixes` (runs before the checks so the returned issues reflect the repaired state).
+- [x] 3.2 `domains/setup/diagnostics.py::run_project_diagnostics` — when `fix` is set, call `repair_reference_drift` alongside `repair_gitignore_drift` and merge into `applied_fixes` (runs before the checks so the returned issues reflect the repaired state).
 <!-- opsx:tdd:3.2:begin -->
   - **Input**: pytest tests/unit -k 'run_project_diagnostics and fix' -v
   - **Expected Output**: When fix=True, run_project_diagnostics calls repair_reference_drift alongside repair_gitignore_drift and merges both into applied_fixes; repair runs before the checks so returned issues reflect the repaired state.
@@ -199,7 +199,7 @@ pytest tests/ -v --tb=short
     - TC1: fix=True with reference drift -> applied_fixes includes the reference repair and the re-run checks report no reference drift
     - TC2: fix=False -> no repair invoked, references untouched
 <!-- opsx:tdd:3.2:end -->
-- [ ] 3.3 `cli/diagnostics.py` — surface reference repairs in the applied-fixes summary (reuse the existing `fixes_applied` plumbing).
+- [x] 3.3 `cli/diagnostics.py` — surface reference repairs in the applied-fixes summary (reuse the existing `fixes_applied` plumbing).
 
 ## 4. Tests
 
@@ -211,31 +211,31 @@ pytest tests/ -v --tb=short
 <!-- opsx:phase-summary:4:end -->
 
 
-- [ ] 4.1 Reconciler unit tests: add-missing; remove-departed; add+remove in one pass; preserve `@AGENTS.md` / user includes / `$schema` / user instructions and order; idempotent re-run (byte-equal); `opencode.json` re-serialization shape; empty-effective-set clears owned refs only.
+- [x] 4.1 Reconciler unit tests: add-missing; remove-departed; add+remove in one pass; preserve `@AGENTS.md` / user includes / `$schema` / user instructions and order; idempotent re-run (byte-equal); `opencode.json` re-serialization shape; empty-effective-set clears owned refs only.
 <!-- opsx:tdd:4.1:begin -->
   - **Input**: pytest tests/unit/test_context_reference_reconcile.py -v
   - **Expected Output**: All reconciler cases pass: add-missing, remove-departed, add+remove in one pass, preserve @AGENTS.md / user includes / $schema / user instructions and order, idempotent re-run (byte-equal), opencode.json re-serialization shape, empty-effective-set clears owned refs only.
   - **Validation**: Zero failures; non-artifact preservation and idempotency explicitly asserted.
 <!-- opsx:tdd:4.1:end -->
-- [ ] 4.2 Dangling / warehouse-rename case: an owned reference not in the effective set (file gone) is removed from both files.
+- [x] 4.2 Dangling / warehouse-rename case: an owned reference not in the effective set (file gone) is removed from both files.
 <!-- opsx:tdd:4.2:begin -->
   - **Input**: pytest tests/unit/test_context_reference_reconcile.py -k dangling -v
   - **Expected Output**: An owned reference whose target no longer resolves (warehouse rename) and is absent from the effective set is removed from both CLAUDE.md and opencode.json.
   - **Validation**: Covers the exact reported broken-reference (linear-ops -> plane-ops) shape.
 <!-- opsx:tdd:4.2:end -->
-- [ ] 4.3 Path coverage: `abc sync` after de-adopting a context removes its reference from both files; `abc adopt` accept adds, reject/un-adopt removes.
+- [x] 4.3 Path coverage: `abc sync` after de-adopting a context removes its reference from both files; `abc adopt` accept adds, reject/un-adopt removes.
 <!-- opsx:tdd:4.3:begin -->
   - **Input**: pytest tests/ -k 'reference and (sync or adopt)' -v
   - **Expected Output**: abc sync after de-adopting a context removes its reference from both files; abc adopt accept adds, reject/un-adopt removes.
   - **Validation**: Both directions covered through the real sync and adopt entry points.
 <!-- opsx:tdd:4.3:end -->
-- [ ] 4.4 Doctor: a repo with a broken + an unmanaged reference → both flagged; `abc doctor --fix` repairs both and the re-run is clean; healthy repo → no drift, no spurious write; `fixes_applied` non-empty on repair.
+- [x] 4.4 Doctor: a repo with a broken + an unmanaged reference → both flagged; `abc doctor --fix` repairs both and the re-run is clean; healthy repo → no drift, no spurious write; `fixes_applied` non-empty on repair.
 <!-- opsx:tdd:4.4:begin -->
   - **Input**: pytest tests/ -k 'doctor and reference' -v
   - **Expected Output**: A repo with a broken + an unmanaged reference -> both flagged; abc doctor --fix repairs both and the re-run is clean; healthy repo -> no drift, no spurious write; fixes_applied non-empty on repair.
   - **Validation**: Covers detection, the real --fix repair loop, and the no-spurious-write guarantee.
 <!-- opsx:tdd:4.4:end -->
-- [ ] 4.5 Regression fixture reproducing this repo's `linear-ops.md` (broken) + `cicd-flow.md` (unmanaged) condition; assert `--fix` clears both.
+- [x] 4.5 Regression fixture reproducing this repo's `linear-ops.md` (broken) + `cicd-flow.md` (unmanaged) condition; assert `--fix` clears both.
 <!-- opsx:tdd:4.5:begin -->
   - **Input**: pytest tests/ -k regression_reference_drift -v
   - **Expected Output**: Fixture reproduces linear-ops.md (broken, target absent) + cicd-flow.md (present, undeclared) in CLAUDE.md and opencode.json; abc doctor --fix reconciles both away; a subsequent doctor reports zero broken/unmanaged references.
@@ -245,7 +245,7 @@ pytest tests/ -v --tb=short
     - TC2: unmanaged reference (cicd-flow.md not in beacon.yaml, not in effective set) -> removed by --fix
     - TC3: second doctor run after --fix -> no broken or unmanaged reference findings
 <!-- opsx:tdd:4.5:end -->
-- [ ] 4.6 `tests/unit/test_architecture.py` still passes.
+- [x] 4.6 `tests/unit/test_architecture.py` still passes.
 <!-- opsx:tdd:4.6:begin -->
   - **Input**: pytest tests/unit/test_architecture.py -v
   - **Expected Output**: Exit code 0 — the reconciler additions keep core/ importing nothing from domains/ and respect the setup-domain boundary.
@@ -274,7 +274,7 @@ pytest tests/ -v --tb=short
 <!-- opsx:phase-summary:6:end -->
 
 
-- [ ] 6.1 `pytest` green (unit + integration) from repo root; `BEACON_OFFLINE=1` respected for network-gated integration tests.
+- [x] 6.1 `pytest` green (unit + integration) from repo root; `BEACON_OFFLINE=1` respected for network-gated integration tests.
 <!-- opsx:tdd:6.1:begin -->
   - **Input**: pytest (from repo root); BEACON_OFFLINE=1 pytest -m integration when offline
   - **Expected Output**: All tests pass; no regressions in sync/adopt/doctor suites.

--- a/openspec/changes/reconcile-context-references/tasks.md
+++ b/openspec/changes/reconcile-context-references/tasks.md
@@ -1,0 +1,309 @@
+# Tasks — Context-reference reconciliation (AB-96)
+
+<!-- opsx:tdd-header:begin -->
+## TDD WORKFLOW - MANDATORY FOR ALL TASKS
+
+**CRITICAL**: This project follows strict Test-Driven Development (TDD). Before implementing ANY task:
+
+### RED-GREEN-REFACTOR Cycle
+
+1. **RED Phase - Write Failing Tests FIRST**
+   - Read the task's TDD Test Cases (TC1-TCN)
+   - Create test file in `tests/` directory
+   - Write ALL test cases from the task BEFORE any implementation
+   - Run tests - they MUST fail (import errors, missing functions, etc.)
+   - If tests pass without implementation, you wrote the tests wrong!
+
+2. **GREEN Phase - Implement Minimal Code**
+   - Write ONLY enough code to make tests pass
+   - Run tests after each implementation
+   - All tests must pass before marking task complete
+
+3. **REFACTOR Phase - Improve Code Quality**
+   - Clean up implementation
+   - Remove duplication
+   - Improve naming
+   - Tests must still pass after refactoring
+
+### Task Completion Criteria
+
+**A task is NOT complete until:**
+- All TDD test cases are written
+- All tests pass (or are justifiably skipped with documentation)
+- Implementation matches the Expected Output
+- Test results documented in tasks.md
+
+**For skipped tests:**
+- Add `@pytest.mark.skip(reason="...")` with clear justification
+- Document in tasks.md under "Skipped Test Cases" section
+- Explain why feature is deferred and when it will be implemented
+
+### Test Organization
+
+```
+tests/
+├── core/           # Core module tests
+├── <module>/       # Module-specific tests
+└── conftest.py     # Shared fixtures
+```
+
+### Running Tests
+
+```bash
+# Activate venv, install dev deps, run tests
+source .venv/bin/activate
+uv sync --extra dev
+pytest tests/ -v --tb=short
+```
+
+**See Also:**
+- Check project AGENTS.md for unit testing workflow
+- Check knowledge base for TDD lessons and standards
+<!-- opsx:tdd-header:end -->
+
+<!-- opsx:repos-table:begin -->
+## Repositories & Branches
+
+| Repo | Path | Branch | Role |
+|------|------|--------|------|
+| `agentic-beacon` | `~/Code/oss/agentic-beacon` | `openspec/reconcile-context-references` | Code changes — context-reference reconciler in domains/setup/wiring.py, rewiring sync + adopt through it, retiring the append-only wiring / prune-gated context unwire, doctor --fix reference repair, and full unit/integration coverage + docs |
+<!-- opsx:repos-table:end -->
+
+
+## 1. The reconciler (`domains/setup/wiring.py`)
+
+<!-- opsx:phase-summary:1:begin -->
+**Goal**: Build the single wholesale reconciler that brings CLAUDE.md @-includes and opencode.json instructions to exactly the desired context-reference set, scoped to the .agentic-beacon/artifacts/ namespace, idempotent and dry-run-aware.
+**Input**: Existing append-only wire_contexts_opencode / wire_contexts_claudecode and the prune-gated unwire_pruned_artifacts in domains/setup/wiring.py.
+**Output**: wiring.py exposes ARTIFACT_REF_PREFIX, desired_context_refs, _reconcile_opencode_json, _reconcile_claude_md, and reconcile_context_references -> ReferenceReconcileResult; the context branch of unwire_pruned_artifacts is removed.
+**Validation**: pytest tests/unit/test_context_reference_reconcile.py passes; non-artifact lines/keys always preserved; idempotent re-run is a no-op.
+<!-- opsx:phase-summary:1:end -->
+
+
+- [ ] 1.1 Add `ARTIFACT_REF_PREFIX = ".agentic-beacon/artifacts/"` and `desired_context_refs(effective_contexts)` returning the sorted desired reference paths for the effective context set.
+<!-- opsx:tdd:1.1:begin -->
+  - **Input**: pytest tests/unit/test_context_reference_reconcile.py -k desired_refs -v
+  - **Expected Output**: desired_context_refs({'python-standards','beacon-ops'}) == ['.agentic-beacon/artifacts/contexts/beacon-ops.md', '.agentic-beacon/artifacts/contexts/python-standards.md'] (sorted).
+  - **Validation**: Prefix and .md suffix correct; sorted; empty set -> [].
+  - **TDD Test Cases (write these first):**
+    - TC1: two context names -> two sorted `.agentic-beacon/artifacts/contexts/<name>.md` paths
+    - TC2: empty effective set -> empty list
+    - TC3: names already containing dots/hyphens map to `<name>.md` unchanged
+<!-- opsx:tdd:1.1:end -->
+- [ ] 1.2 Implement `_reconcile_opencode_json(project_root, desired_refs)`: partition `instructions` into Beacon-owned (prefix match) vs kept; add missing desired refs, remove departed owned refs, preserve `$schema`, user entries, and order; re-serialize as `json.dumps(data, indent=2) + "\n"`; write only on change. Return added/removed.
+<!-- opsx:tdd:1.2:begin -->
+  - **Input**: pytest tests/unit/test_context_reference_reconcile.py -k opencode -v
+  - **Expected Output**: instructions equals kept-entries + desired context refs; $schema and user entries preserved; removed = owned-not-desired, added = desired-not-owned; re-serialized with indent=2 + trailing newline; no write when unchanged.
+  - **Validation**: Only `.agentic-beacon/artifacts/`-prefixed entries are managed; order of kept entries stable; JSON stays valid.
+  - **TDD Test Cases (write these first):**
+    - TC1: instructions has an owned ref not in desired -> removed; returned removed lists it
+    - TC2: desired ref missing from instructions -> appended; returned added lists it
+    - TC3: $schema key + user entry 'docs/house-style.md' present -> both preserved, order stable
+    - TC4: instructions already == kept + desired -> file bytes unchanged (no write)
+    - TC5: empty desired set -> all owned refs removed, non-owned entries + $schema preserved
+    - TC6: output re-serialized with 2-space indent and a single trailing newline
+    - TC7: no opencode.json present -> no-op, empty result
+<!-- opsx:tdd:1.2:end -->
+- [ ] 1.3 Implement `_reconcile_claude_md(project_root, desired_refs)`: manage only `@<path>` lines under the artifact prefix; add missing desired refs (existing blank-line separator convention), remove departed owned lines (and any orphaned blank pair), preserve all other lines verbatim; write only on change. Return added/removed.
+<!-- opsx:tdd:1.3:begin -->
+  - **Input**: pytest tests/unit/test_context_reference_reconcile.py -k claude_md -v
+  - **Expected Output**: @-include lines under the artifact prefix reconciled to desired; @AGENTS.md and other non-artifact lines preserved byte-for-byte; missing desired refs appended with existing separator convention; departed owned lines removed; no write when unchanged.
+  - **Validation**: A line is owned iff stripped form is `@<path>` with path under `.agentic-beacon/artifacts/`; blank-line structure preserved.
+  - **TDD Test Cases (write these first):**
+    - TC1: owned @-include not in desired -> line removed; @AGENTS.md untouched
+    - TC2: desired ref absent -> appended as `@.agentic-beacon/artifacts/contexts/<name>.md` with blank-line separator
+    - TC3: file with @AGENTS.md + @docs/x.md + artifact includes -> only artifact includes change, others in place
+    - TC4: already-matching file -> bytes unchanged (no write)
+    - TC5: empty desired set -> all owned includes removed, non-artifact lines preserved
+    - TC6: `.claude/CLAUDE.md` preferred over root CLAUDE.md when both exist
+    - TC7: no CLAUDE.md present -> no-op, empty result
+<!-- opsx:tdd:1.3:end -->
+- [ ] 1.4 Implement `reconcile_context_references(project_root, desired_refs, *, dry_run=False)` aggregating both file reconcilers into a `ReferenceReconcileResult(added, removed)`; under `dry_run`, compute the delta but perform no writes.
+<!-- opsx:tdd:1.4:begin -->
+  - **Input**: pytest tests/unit/test_context_reference_reconcile.py -k reconcile_context_references -v
+  - **Expected Output**: Returns ReferenceReconcileResult with aggregated added/removed across both files; dry_run=True computes the delta but writes nothing; second run is a no-op (added and removed empty).
+  - **Validation**: Idempotent; dry-run makes no filesystem writes (assert bytes/mtime unchanged).
+  - **TDD Test Cases (write these first):**
+    - TC1: both files drift -> aggregated added/removed spans both; both files written
+    - TC2: dry_run=True -> result reports the delta but neither file is written (bytes unchanged)
+    - TC3: idempotent -> second call returns empty added/removed and writes nothing
+    - TC4: only one of the two files exists -> the other reconciler is a silent no-op
+<!-- opsx:tdd:1.4:end -->
+- [ ] 1.5 Reduce `wire_contexts_opencode` / `wire_contexts_claudecode` to add-only helpers driven by the desired set (or fold into the reconciler); remove the **context branch** of `unwire_pruned_artifacts`, leaving its skill/agent branches intact.
+<!-- opsx:tdd:1.5:begin -->
+  - **Input**: pytest tests/unit -k 'unwire and (skill or agent)' -v ; grep -rn 'unwire_pruned_artifacts' src/
+  - **Expected Output**: wire_contexts_* no longer scan the contexts/ directory to drive wiring; the context branch of unwire_pruned_artifacts is gone; its skill and agent branches still remove the right dirs/symlinks on prune.
+  - **Validation**: No remaining code path wires contexts by rglob of the directory; skill/agent prune unwiring unchanged (regression).
+  - **TDD Test Cases (write these first):**
+    - TC1: unwire_pruned_artifacts on a pruned skill still removes .claude/.opencode skill dirs
+    - TC2: unwire_pruned_artifacts on a pruned agent still removes the agent symlinks
+    - TC3: unwire_pruned_artifacts on a pruned context is now a no-op there (reconcile owns it)
+<!-- opsx:tdd:1.5:end -->
+
+## 2. Wire every path to the reconciler
+
+<!-- opsx:phase-summary:2:begin -->
+**Goal**: Route abc sync and abc adopt through reconcile_context_references so add and remove are both handled without a prune confirmation.
+**Input**: Phase 1 reconciler; current call sites in orchestrator.py (run_sync), adoption/apply.py, cli/sync.py.
+**Output**: run_sync and the adopt accept/reject path call the reconciler; the prune-triggered context unwire is gone; cli/sync.py guidance stays coherent.
+**Validation**: Integration tests: de-adopt + sync removes the reference; adopt accept adds / reject removes; dry-run writes nothing.
+<!-- opsx:phase-summary:2:end -->
+
+
+- [ ] 2.1 `domains/distribution/orchestrator.py::run_sync` — build `desired_refs` from `effective_set.contexts` and call `reconcile_context_references` instead of the append-only `wire_contexts_*`; remove the `if summary.pruned_paths: unwire_pruned_artifacts(...)` context handling (skill/agent prune unwiring stays). Respect `dry_run`.
+<!-- opsx:tdd:2.1:begin -->
+  - **Input**: pytest tests/integration/test_sync_wiring.py -k 'reconcile or deadopt' -v
+  - **Expected Output**: run_sync builds desired_refs from effective_set.contexts and calls reconcile_context_references; the `if summary.pruned_paths: unwire_pruned_artifacts` context handling is removed; dry_run path performs no writes.
+  - **Validation**: After sync, references in both files == effective context set; de-adopt + sync removes the reference with no prune confirmation.
+  - **TDD Test Cases (write these first):**
+    - TC1: sync with a context removed from beacon.yaml -> its reference gone from both files (no prompt)
+    - TC2: sync adding a new context -> its reference present in both files
+    - TC3: sync --dry-run -> reports would-add/would-remove but writes neither file
+<!-- opsx:tdd:2.1:end -->
+- [ ] 2.2 `domains/adoption/apply.py` — replace the append-only `wire_contexts_*` calls on the accept/reject path with `reconcile_context_references` so un-adopt/reject removes references.
+<!-- opsx:tdd:2.2:begin -->
+  - **Input**: pytest tests/integration/test_adopt_apply.py -k reconcile -v
+  - **Expected Output**: adopt accept adds the reference; reject / un-adopt removes it — both via reconcile_context_references, not append-only wiring.
+  - **Validation**: No append-only wire_contexts_* remains on the adopt path; reject removes references.
+  - **TDD Test Cases (write these first):**
+    - TC1: adopt-accept a context -> reference present in both files
+    - TC2: un-adopt (remove from beacon.yaml) + adopt-sync -> reference removed from both files
+<!-- opsx:tdd:2.2:end -->
+- [ ] 2.3 `cli/sync.py` — update the post-sync wiring init calls to the reconciler (keep the "wire them into your agent config" guidance path coherent).
+
+## 3. Doctor `--fix` reference repair
+
+<!-- opsx:phase-summary:3:begin -->
+**Goal**: Make abc doctor --fix repair reference drift via the same reconciler, recording repairs in fixes_applied.
+**Input**: Phase 1 reconciler; existing run_project_diagnostics + repair_gitignore_drift and the --fix plumbing in cli/diagnostics.py.
+**Output**: repair_reference_drift added and called from run_project_diagnostics when --fix is set, alongside repair_gitignore_drift; repairs surfaced in the applied-fixes summary.
+**Validation**: Doctor tests: broken + unmanaged references repaired by --fix; re-run clean; healthy repo not written.
+<!-- opsx:phase-summary:3:end -->
+
+
+- [ ] 3.1 `domains/setup/diagnostics.py` — add `repair_reference_drift(project_root, beacon_manifest, warehouse_path)` that computes the effective set, builds `desired_refs`, and calls `reconcile_context_references`; return a human-readable fix line per changed file.
+<!-- opsx:tdd:3.1:begin -->
+  - **Input**: pytest tests/unit -k repair_reference_drift -v
+  - **Expected Output**: repair_reference_drift computes the effective set, builds desired_refs, calls the reconciler, and returns a fix line per changed file; healthy repo returns [].
+  - **Validation**: Reuses the same reconciler as sync; no divergent logic.
+  - **TDD Test Cases (write these first):**
+    - TC1: repo with a broken + an unmanaged reference -> both reconciled away, one-or-two fix lines returned
+    - TC2: healthy repo -> returns [] and writes nothing
+<!-- opsx:tdd:3.1:end -->
+- [ ] 3.2 `domains/setup/diagnostics.py::run_project_diagnostics` — when `fix` is set, call `repair_reference_drift` alongside `repair_gitignore_drift` and merge into `applied_fixes` (runs before the checks so the returned issues reflect the repaired state).
+<!-- opsx:tdd:3.2:begin -->
+  - **Input**: pytest tests/unit -k 'run_project_diagnostics and fix' -v
+  - **Expected Output**: When fix=True, run_project_diagnostics calls repair_reference_drift alongside repair_gitignore_drift and merges both into applied_fixes; repair runs before the checks so returned issues reflect the repaired state.
+  - **Validation**: applied_fixes contains both gitignore and reference repairs when both drifted; check ordering (repair-then-check) preserved.
+  - **TDD Test Cases (write these first):**
+    - TC1: fix=True with reference drift -> applied_fixes includes the reference repair and the re-run checks report no reference drift
+    - TC2: fix=False -> no repair invoked, references untouched
+<!-- opsx:tdd:3.2:end -->
+- [ ] 3.3 `cli/diagnostics.py` — surface reference repairs in the applied-fixes summary (reuse the existing `fixes_applied` plumbing).
+
+## 4. Tests
+
+<!-- opsx:phase-summary:4:begin -->
+**Goal**: Lock the reconciler behavior, non-artifact preservation, the dangling/warehouse-rename case, cross-path coverage (sync + adopt), the doctor --fix loop, and the live-repo regression.
+**Input**: Phases 1-3 implemented; pytest with tests/unit and tests/integration split.
+**Output**: New unit + integration tests covering reconciler, dangling case, path coverage, doctor, and the linear-ops/cicd-flow regression; architecture test still green.
+**Validation**: pytest tests/ green from repo root; BEACON_OFFLINE=1 respected for network-gated tests.
+<!-- opsx:phase-summary:4:end -->
+
+
+- [ ] 4.1 Reconciler unit tests: add-missing; remove-departed; add+remove in one pass; preserve `@AGENTS.md` / user includes / `$schema` / user instructions and order; idempotent re-run (byte-equal); `opencode.json` re-serialization shape; empty-effective-set clears owned refs only.
+<!-- opsx:tdd:4.1:begin -->
+  - **Input**: pytest tests/unit/test_context_reference_reconcile.py -v
+  - **Expected Output**: All reconciler cases pass: add-missing, remove-departed, add+remove in one pass, preserve @AGENTS.md / user includes / $schema / user instructions and order, idempotent re-run (byte-equal), opencode.json re-serialization shape, empty-effective-set clears owned refs only.
+  - **Validation**: Zero failures; non-artifact preservation and idempotency explicitly asserted.
+<!-- opsx:tdd:4.1:end -->
+- [ ] 4.2 Dangling / warehouse-rename case: an owned reference not in the effective set (file gone) is removed from both files.
+<!-- opsx:tdd:4.2:begin -->
+  - **Input**: pytest tests/unit/test_context_reference_reconcile.py -k dangling -v
+  - **Expected Output**: An owned reference whose target no longer resolves (warehouse rename) and is absent from the effective set is removed from both CLAUDE.md and opencode.json.
+  - **Validation**: Covers the exact reported broken-reference (linear-ops -> plane-ops) shape.
+<!-- opsx:tdd:4.2:end -->
+- [ ] 4.3 Path coverage: `abc sync` after de-adopting a context removes its reference from both files; `abc adopt` accept adds, reject/un-adopt removes.
+<!-- opsx:tdd:4.3:begin -->
+  - **Input**: pytest tests/ -k 'reference and (sync or adopt)' -v
+  - **Expected Output**: abc sync after de-adopting a context removes its reference from both files; abc adopt accept adds, reject/un-adopt removes.
+  - **Validation**: Both directions covered through the real sync and adopt entry points.
+<!-- opsx:tdd:4.3:end -->
+- [ ] 4.4 Doctor: a repo with a broken + an unmanaged reference → both flagged; `abc doctor --fix` repairs both and the re-run is clean; healthy repo → no drift, no spurious write; `fixes_applied` non-empty on repair.
+<!-- opsx:tdd:4.4:begin -->
+  - **Input**: pytest tests/ -k 'doctor and reference' -v
+  - **Expected Output**: A repo with a broken + an unmanaged reference -> both flagged; abc doctor --fix repairs both and the re-run is clean; healthy repo -> no drift, no spurious write; fixes_applied non-empty on repair.
+  - **Validation**: Covers detection, the real --fix repair loop, and the no-spurious-write guarantee.
+<!-- opsx:tdd:4.4:end -->
+- [ ] 4.5 Regression fixture reproducing this repo's `linear-ops.md` (broken) + `cicd-flow.md` (unmanaged) condition; assert `--fix` clears both.
+<!-- opsx:tdd:4.5:begin -->
+  - **Input**: pytest tests/ -k regression_reference_drift -v
+  - **Expected Output**: Fixture reproduces linear-ops.md (broken, target absent) + cicd-flow.md (present, undeclared) in CLAUDE.md and opencode.json; abc doctor --fix reconciles both away; a subsequent doctor reports zero broken/unmanaged references.
+  - **Validation**: Mirrors the exact live-repo condition that motivated AB-96.
+  - **TDD Test Cases (write these first):**
+    - TC1: broken reference (linear-ops.md target missing) -> removed by --fix
+    - TC2: unmanaged reference (cicd-flow.md not in beacon.yaml, not in effective set) -> removed by --fix
+    - TC3: second doctor run after --fix -> no broken or unmanaged reference findings
+<!-- opsx:tdd:4.5:end -->
+- [ ] 4.6 `tests/unit/test_architecture.py` still passes.
+<!-- opsx:tdd:4.6:begin -->
+  - **Input**: pytest tests/unit/test_architecture.py -v
+  - **Expected Output**: Exit code 0 — the reconciler additions keep core/ importing nothing from domains/ and respect the setup-domain boundary.
+  - **Validation**: Architecture boundary intact after the wiring/diagnostics changes.
+<!-- opsx:tdd:4.6:end -->
+
+## 5. Docs
+
+<!-- opsx:phase-summary:5:begin -->
+**Goal**: Document that the artifact-reference layer of CLAUDE.md / opencode.json is Beacon-managed and reconciled.
+**Input**: beacon-ops.md two-tier / ownership sections (delivered via the warehouse per-project model).
+**Output**: beacon-ops.md notes the reconciled reference layer and abc doctor --fix repair.
+**Validation**: Manual read-through; abc warehouse lint clean on edited warehouse docs if applicable.
+<!-- opsx:phase-summary:5:end -->
+
+
+- [ ] 5.1 Note in `beacon-ops.md` (warehouse per-project model) that the artifact-reference layer of `CLAUDE.md` / `opencode.json` is Beacon-managed and reconciled to the effective set, and repairable via `abc doctor --fix`.
+
+## 6. Validate & verify
+
+<!-- opsx:phase-summary:6:begin -->
+**Goal**: Prove the change end-to-end on a real scratch project, not just via unit tests.
+**Input**: All prior phases complete; a scratch project + the built abc CLI.
+**Output**: Verified happy path: sync reconciles references, de-adopt removes one, doctor detects induced drift, --fix repairs it.
+**Validation**: pytest green; documented scratch-project walkthrough succeeds.
+<!-- opsx:phase-summary:6:end -->
+
+
+- [ ] 6.1 `pytest` green (unit + integration) from repo root; `BEACON_OFFLINE=1` respected for network-gated integration tests.
+<!-- opsx:tdd:6.1:begin -->
+  - **Input**: pytest (from repo root); BEACON_OFFLINE=1 pytest -m integration when offline
+  - **Expected Output**: All tests pass; no regressions in sync/adopt/doctor suites.
+  - **Validation**: Zero failures, zero errors from repo root.
+<!-- opsx:tdd:6.1:end -->
+- [ ] 6.2 **[OPS]** Happy-path check on a scratch project: adopt/sync yields references == effective set; de-adopt a context + sync removes its reference; introduce a broken/unmanaged reference → `abc doctor` errors → `abc doctor --fix` repairs → re-run clean.
+<!-- opsx:tdd:6.2:begin -->
+  - **Input**: abc sync in a scratch project; de-adopt a context + sync; then hand-add a broken + unmanaged reference and run abc doctor / abc doctor --fix
+  - **Expected Output**: After sync, references == effective set; de-adopt + sync removes the reference; abc doctor errors on the induced broken/unmanaged refs; abc doctor --fix repairs them and the re-run is clean.
+  - **Validation**: Real CLI walkthrough matches the unit/integration expectations end-to-end.
+<!-- opsx:tdd:6.2:end -->
+
+<!-- opsx:metadata:begin -->
+---
+
+## Enhancement Metadata
+
+**Enhanced**: 2026-07-20
+**Methodology**: Spec-Driven Development + TDD
+**Enhancements Applied**:
+- TDD Workflow Header
+- Repositories & Branches table
+- Phase summaries (Goal/Input/Output/Validation)
+- Task-level TDD criteria on 17 task(s)
+- 36 test case(s) across complex tasks
+- 0 task(s) flagged [MANUAL] (blocking pause)
+- 0 task(s) flagged [MANUAL-DEFER] (non-blocking)
+- 1 task(s) flagged [OPS]
+- 0 task(s) routed to Cross-Repo Follow-ups
+
+**Status**: Ready for implementation via `/opsx-apply <name>`.
+<!-- opsx:metadata:end -->


### PR DESCRIPTION
## Summary

De-adopting a context (removing it from `beacon.yaml`) left its reference behind in `CLAUDE.md` (an `@`-include) and `opencode.json` (an `instructions` entry) — surfaced by `abc doctor` as a **broken reference** (`linear-ops.md`, file renamed away) and, from the mirror side, an **unmanaged reference**. Root cause: context-reference wiring was **append-only on the add side and prune-gated on the remove side**, never reconciled against the declared/effective set (the reference-layer twin of AB-94's gitignore bug).

This change makes context-reference wiring **declarative, idempotent, and wholesale**: a single `reconcile_context_references()` in `domains/setup/wiring.py` brings `CLAUDE.md` + `opencode.json` to **exactly** the effective context set (add missing / remove departed), scoped to the `.agentic-beacon/artifacts/` ownership namespace so non-artifact lines (`@AGENTS.md`, `$schema`, user entries + their order) are never touched. Every wiring path (`abc sync`, `abc adopt` accept/reject) now reconciles, and `abc doctor --fix` repairs existing drift via the same reconciler.

Closes AB-96.

## What changed
- **`wiring.py`** — new `reconcile_context_references` / `desired_context_refs` + surgical `_reconcile_opencode_json` / `_reconcile_claude_md`; the context branch of `unwire_pruned_artifacts` is retired (skill/agent branches unchanged).
- **`orchestrator.py::run_sync`** — always reconciles from `effective_set.contexts` (even when empty, so a fully de-adopted project self-heals); `SyncResult` reports `refs_added`/`refs_removed`.
- **`adoption/apply.py`** — adopt accept **and** un-adopt/reject reconcile references (removal no longer needs an interactive prune confirmation).
- **`setup/diagnostics.py`** — new `repair_reference_drift` + shared `effective_desired_refs(manifest, warehouse)` helper (normalize → `compute_effective_set` → desired refs; `None`→skip on resolution failure); wired into `run_project_diagnostics(--fix)` and surfaced in the applied-fixes summary.
- **`cli/sync.py`** — accurate wiring/removal messages; first-init reconcile uses the effective set.

## Notable review-driven fixes (found during deep review)
- **CLAUDE.md wipe bug**: the reconciler must re-append the full desired set (not just the newly-added delta) — an early draft dropped present-and-desired refs, wiping all context includes on any removal. Fixed + locked with a regression test.
- **Empty-effective-set**: a `if effective_set.contexts:` guard skipped reconcile when all contexts were de-adopted, leaking stale refs. Now always reconciles.
- **Effective vs explicit set**: adopt/reject/first-init reconciled to explicit `beacon.yaml` contexts only, which would strip a valid *transitive* skill-required context's reference. All call sites now reconcile to the **effective** set (`effective_desired_refs`), consistent with `run_sync`.
- **Misleading message**: a de-adopt sync previously printed "Wired N into CLAUDE.md" for a *removal* — now reports a removal.

## Test plan
- [x] Reconciler unit tests (add/remove/idempotent/non-artifact-preservation/empty-set/dangling) + `repair_reference_drift` guards
- [x] Integration path coverage: `abc sync` after de-adopt removes refs from both files; `abc adopt` accept adds / reject removes; transitive skill-required context preserved across adopt/unadopt
- [x] Doctor `--fix` loop + live-repo (`linear-ops` broken / `cicd-flow` unmanaged) regression fixture
- [x] Architecture test green; **full suite 1642 passed, 15 skipped**; ruff clean (CI-pinned v0.9.2) on all changed files
- [ ] CI green
- [ ] opencode-review bot clean

## Deferred (noted, not silently skipped)
- **Task 5.1** — `beacon-ops.md` doc note is delivered via the warehouse per-project model, out of this repo's diff.
- **Task 6.2 `[OPS]`** — the scratch-project happy-path walkthrough is covered programmatically by the `TestRegressionReferenceDrift` integration suite.

> ⚠️ **Review-flagged** (rewrites user-facing `CLAUDE.md` / `opencode.json`) — please merge via the GitHub UI after the bot is clean; not auto-merged.